### PR TITLE
cuda controller ``vram_to_keep`` update & fast exit in ``_run_mat_batch`` function

### DIFF
--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -177,7 +177,7 @@ class CudaGPUController(BaseGPUController):
         tic = time.time()
         for _ in range(self.matmul_iterations):
             torch.relu(matrix)
-            if self._stop_evt.wait(self.interval):
+            if self._stop_evt.is_set():
                 break
         torch.cuda.synchronize()
         toc = time.time()

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -12,6 +12,14 @@ from keep_gpu.utilities.platform_manager import ComputingPlatform
 logger = setup_logger(__name__)
 
 
+_UNITS = {
+    'KB': 1000,  'MB': 1000**2,  'GB': 1000**3,
+    'Kb': 1000 / 8, 'Mb': 1000**2 / 8, 'Gb': 1000**3 / 8,
+    'KIB': 1024, 'MIB': 1024**2, 'GIB': 1024**3,
+    'KIb': 1024 / 8, 'MIb': 1024**2 / 8, 'GIb': 1024**3 / 8,  
+}
+
+
 class CudaGPUController(BaseGPUController):
     """
     Keep a single CUDA GPU busy by repeatedly running lightweight
@@ -38,7 +46,7 @@ class CudaGPUController(BaseGPUController):
         rank: int,
         interval: float = 1.0,
         matmul_iterations: int = 5000,
-        vram_to_keep: int = 0,
+        vram_to_keep: str | int = "1000 MB",
         busy_threshold: int = 10,
     ):
         """
@@ -50,12 +58,19 @@ class CudaGPUController(BaseGPUController):
             Sleep time (seconds) between workload batches.
         matmul_iterations : int, optional
             Number of matmul ops per batch.
-        vram_to_keep : int, optional
-            Reserved free VRAM in MB (currently unused, placeholder for future logic).
+        vram_to_keep : str | int, optional
+            Amount of VRAM to keep busy, e.g. "1000 MB", "20 GB" or 1000 * 1000.
+            This is the total size of the matrix allocated to keep the GPU busy.
         busy_threshold : int, optional
             If current utilisation (%) exceeds this value, the worker will
             insert extra sleeps to avoid hogging the GPU.
         """
+        if type(vram_to_keep) is str:
+            vram_to_keep = self.parse_size(vram_to_keep)
+        elif type(vram_to_keep) is int:
+            vram_to_keep = vram_to_keep
+        else:
+            raise TypeError(f"vram_to_keep must be str or int, got {type(vram_to_keep)}")
         super().__init__(vram_to_keep=vram_to_keep, interval=interval)
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")
@@ -67,9 +82,23 @@ class CudaGPUController(BaseGPUController):
         self._stop_evt: Optional[threading.Event] = None
         self._thread: Optional[threading.Thread] = None
 
+    @staticmethod
+    def parse_size(text: str) -> int:
+        text = text.strip().replace(' ', '').upper()
+        m = re.fullmatch(r'([0-9]*\.?[0-9]+)([A-Z]*)', text)
+        if not m:
+            raise ValueError(f"invalid format: {text}, should be like '1000 MB'")
+        value, unit = m.groups()
+        unit = unit or 'GB'
+        if len(unit) > 1:
+            unit = unit[:-1].upper() + unit[-1]
+        if unit not in _UNITS:
+            raise ValueError(f"unknown unit: {unit}, should be one of {_UNITS.keys()}")
+        return int(float(value) * _UNITS[unit]/8)
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    
     def keep(self) -> None:
         """Launch the background thread that keeps the GPU busy."""
         if self._thread and self._thread.is_alive():
@@ -113,10 +142,20 @@ class CudaGPUController(BaseGPUController):
     def _keep_loop(self) -> None:
         """Internal: run workloads until stop event is set."""
         torch.cuda.set_device(self.rank)
+        while not self._stop_evt.is_set():
+            try:
+                matrix = torch.rand(
+                    self.vram_to_keep, device=self.device, dtype=torch.float32
+                )
+                # print(matrix.shape)
+                break
+            except RuntimeError as e:
+                logger.error("rank %s: failed to allocate matrix: %s", self.rank, e)
+                time.sleep(self.interval)
 
         while not self._stop_evt.is_set():
             try:
-                self._run_mat_batch()
+                self._run_mat_batch(matrix)
                 time.sleep(self.interval)
             except RuntimeError as e:
                 # Handle OOM by clearing cache; then sleep and continue
@@ -131,13 +170,15 @@ class CudaGPUController(BaseGPUController):
     # ------------------------------------------------------------------
     # Workload implementation
     # ------------------------------------------------------------------
-    def _run_mat_batch(self) -> None:
+    @torch.no_grad()
+    def _run_mat_batch(self, matrix: torch.Tensor) -> None:
         """Run a batch of dummy matmuls to keep GPU busy."""
-        matrix = torch.rand(self.vram_to_keep, device=self.device)
 
         tic = time.time()
         for _ in range(self.matmul_iterations):
             torch.relu(matrix)
+            if self._stop_evt.wait(self.interval):
+                break
         torch.cuda.synchronize()
         toc = time.time()
 

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -144,17 +144,6 @@ class CudaGPUController(BaseGPUController):
         torch.cuda.set_device(self.rank)
         while not self._stop_evt.is_set():
             try:
-                matrix = torch.rand(
-                    self.vram_to_keep, device=self.device, dtype=torch.float32
-                )
-                # print(matrix.shape)
-                break
-            except RuntimeError as e:
-                logger.error("rank %s: failed to allocate matrix: %s", self.rank, e)
-                time.sleep(self.interval)
-
-        while not self._stop_evt.is_set():
-            try:
                 self._run_mat_batch()
                 time.sleep(self.interval)
             except RuntimeError as e:
@@ -170,7 +159,6 @@ class CudaGPUController(BaseGPUController):
     # ------------------------------------------------------------------
     # Workload implementation
     # ------------------------------------------------------------------
-    @torch.no_grad()
     def _run_mat_batch(self) -> None:
         """Run a batch of dummy matmuls to keep GPU busy."""
         matrix = torch.rand(self.vram_to_keep, device=self.device)

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -155,7 +155,7 @@ class CudaGPUController(BaseGPUController):
 
         while not self._stop_evt.is_set():
             try:
-                self._run_mat_batch(matrix)
+                self._run_mat_batch()
                 time.sleep(self.interval)
             except RuntimeError as e:
                 # Handle OOM by clearing cache; then sleep and continue
@@ -171,9 +171,9 @@ class CudaGPUController(BaseGPUController):
     # Workload implementation
     # ------------------------------------------------------------------
     @torch.no_grad()
-    def _run_mat_batch(self, matrix: torch.Tensor) -> None:
+    def _run_mat_batch(self) -> None:
         """Run a batch of dummy matmuls to keep GPU busy."""
-
+        matrix = torch.rand(self.vram_to_keep, device=self.device)
         tic = time.time()
         for _ in range(self.matmul_iterations):
             torch.relu(matrix)


### PR DESCRIPTION
``vram_to_keep`` could support string as input: eg. "10GiB"
``_run_mat_batch`` now will stop immediately after the ``_stop_evt`` triggered