### PR TITLE
[workflow] chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Project-local agent worktrees
+.worktrees/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This file defines how coding agents should work in this repository.
 ### Workflow (Branches + PRs)
 
 - Always branch from the latest `main` when starting a new feature or bug fix.
+- Use project-local worktrees under `.worktrees/` for parallel agent work.
 - Implement work on a new branch, validate changes, then open a PR to `main` for review.
 - Keep commits small and focused; avoid mixing unrelated changes.
 
@@ -27,6 +28,7 @@ This file defines how coding agents should work in this repository.
 
 - If a review-related subagent exists, call it when the code is ready for review.
 - Address review findings as appropriate until no must-fix issues remain.
+- Run local subagent code review before merging any PR; squash merge only after all review comments are resolved.
 
 ### Documentation Updates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file defines how coding agents should work in this repository.
 
 - Always branch from the latest `main` when starting a new feature or bug fix.
 - Use project-local worktrees under `.worktrees/` for parallel agent work.
+  - Example: `git worktree add .worktrees/codex/<topic> -b codex/<topic> origin/main`
 - Implement work on a new branch, validate changes, then open a PR to `main` for review.
 - Keep commits small and focused; avoid mixing unrelated changes.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,7 +67,11 @@ expectations so you can get productive quickly and avoid surprises in CI.
 
 - Keep changesets focused; small commits are welcome.
 - For parallel agent work, branch from the latest `main` and place worktrees
-  under `.worktrees/`.
+  under `.worktrees/`:
+  ```bash
+  git fetch origin
+  git worktree add .worktrees/codex/my-fix -b codex/my-fix origin/main
+  ```
 - Add/adjust tests for new behavior; skip GPU-specific tests in CI by way of markers.
 - Update docs/README when behavior or interfaces change.
 - Run a local code review pass before merging; squash merge only after all

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,8 +66,12 @@ expectations so you can get productive quickly and avoid surprises in CI.
 ## Pull requests
 
 - Keep changesets focused; small commits are welcome.
+- For parallel agent work, branch from the latest `main` and place worktrees
+  under `.worktrees/`.
 - Add/adjust tests for new behavior; skip GPU-specific tests in CI by way of markers.
 - Update docs/README when behavior or interfaces change.
+- Run a local code review pass before merging; squash merge only after all
+  review comments are resolved.
 - Stick to the existing style (Typer CLI, Rich logging) and keep code paths
   simple—avoid over-engineering.
 


### PR DESCRIPTION
## Summary
- Ignore `.worktrees/` so project-local agent worktrees do not pollute git status.
- Document the `.worktrees/` convention in `AGENTS.md` and contributor guidance.
- Document the local review gate before squash merging PRs.

## Test Plan
- `mkdocs build`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance with clearer instructions for parallel work, testing expectations, and documentation updates when behavior changes.
* **Chores**
  * Added a project-local ignore rule for worktree folders.
  * Updated workflow notes to include a final review pass before merging changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->