### PR TITLE
[session,docs] fix: normalize public keep inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ This file defines how coding agents should work in this repository.
 
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
+- Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
+- Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ http://127.0.0.1:8765/
 Flags that matter:
 
 - Blocking mode knobs:
-  - `--vram` (`1GiB`, `750MB`, or bytes): how much memory to pin.
-  - `--interval` (seconds): sleep between keep-alive bursts.
-  - `--busy-threshold`: skip work when NVML reports higher utilization.
-  - `--gpu-ids`: target a subset; otherwise all visible GPUs are guarded.
+  - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
+  - `--interval` (positive seconds): sleep between keep-alive bursts.
+  - `--busy-threshold`: skip work when telemetry reports higher utilization; `-1` disables utilization backoff.
+  - `--gpu-ids`: target a non-negative subset; otherwise all visible GPUs are guarded.
 - Service mode commands:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
   - `keep-gpu start`: create keep session and return immediately.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -14,8 +14,9 @@ schedulers that the GPU is still busy, without burning a full training workload.
 4. **GPU monitor (NVML/ROCm)** – Wraps `nvidia-ml-py` (the `pynvml` module) for CUDA
    telemetry and optionally `rocm-smi` when installed by way of the `rocm` extra.
    Mac M series does not support direct GPU utilization monitoring.
-5. **Utilities** – `parse_size` turns strings like `1GiB` into bytes, while
-   `setup_logger` wires both console and file logging with optional colors.
+5. **Utilities** – `parse_size` turns strings like `1GiB` or bare byte values into
+   internal float32 tensor element counts, while `setup_logger` wires both console
+   and file logging with optional colors.
 
 ```text
 CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
@@ -28,21 +29,21 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
 1. The CLI (or your Python code) instantiates `GlobalGPUController`.
 2. During `keep()` / `__enter__`, each Cuda worker:
    - Allocates a tensor sized by way of `vram_to_keep`.
-   - Starts a daemon thread that performs `matmul_iterations` fused activations.
+   - Starts a daemon thread that performs intervalled lightweight elementwise batches.
    - Calls `_monitor_utilization` (by way of NVML) to detect real activity.
 3. If utilization exceeds `busy_threshold`, the worker just sleeps for one more
    `interval`. Otherwise it runs a new batch of ops.
 4. When you call `release()` (or exit the context), every worker sets a stop
    event, joins the thread, and clears the CUDA cache.
 
-## Why matmuls?
+## Why lightweight elementwise batches?
 
-Matrix multiplies:
+Elementwise keep-alive batches:
 
 - Allocate continuous VRAM quickly, which is what schedulers monitor.
 - Exercise compute units enough to show non-zero utilization spikes.
-- Are deterministic and easy to tune—adjust `matmul_iterations` to trade power
-  draw for stronger “busy” signals.
+- Are deterministic and easy to tune with interval and iteration settings, trading
+  power draw for stronger “busy” signals.
 
 ## Threading & responsiveness
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,8 @@ keep-gpu --interval 120 --gpu-ids 0 --vram 1GiB
 
 - `--interval` controls the sleep between utilization checks (seconds).
 - `--gpu-ids` limits the job to a subset of visible devices.
-- `--vram` accepts human-readable sizes; KeepGPU allocates one tensor of that size.
+- `--vram` accepts human-readable sizes or bare bytes; KeepGPU allocates one
+  tensor of that size.
 
 Leave the command running while you prepare data or review notebooks. When you are
 ready to hand the GPU back, hit `Ctrl+C`—controllers will release VRAM and exit.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -81,10 +81,10 @@ The dashboard provides:
 
 | Option | Meaning | Default |
 | --- | --- | --- |
-| `--gpu-ids` | Comma-separated GPU IDs. Omit to use all visible devices. | all |
-| `--vram` | Per-GPU memory target (`512MB`, `1GiB`, bytes). | `1GiB` |
-| `--interval` | Seconds between keep-alive cycles. | `300` |
-| `--busy-threshold` / `--util-threshold` | Back off when utilization exceeds this value. | `-1` |
+| `--gpu-ids` | Comma-separated non-negative GPU IDs. Omit to use all visible devices. | all |
+| `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes). | `1GiB` |
+| `--interval` | Positive seconds between keep-alive cycles. | `300` |
+| `--busy-threshold` / `--util-threshold` | Back off when utilization exceeds this value; `-1` disables utilization backoff. | `-1` |
 
 ## Remote sessions
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -18,8 +18,8 @@ train_model()                     # GPU memory is released automatically
 ```
 
 - `rank` matches the CUDA device index (after any `CUDA_VISIBLE_DEVICES` filtering).
-- `interval` is the pause between matmul bursts inside the background thread.
-- `vram_to_keep` accepts ints or human-readable strings (`parse_size` handles it).
+- `interval` is the positive pause between keep-alive bursts inside the background thread.
+- `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size` handles it).
 
 ## Start/stop manually
 

--- a/docs/plans/public-session-contract.md
+++ b/docs/plans/public-session-contract.md
@@ -1,0 +1,27 @@
+# Public Session Contract Fix Plan
+
+## Background
+
+Audit agents found four related public-contract bugs: unitless `--vram` strings are documented as bytes but parse as GB, CLI/MCP defaults can suppress keep-alive compute, zero or negative intervals can create tight loops, and CLI/JSON-RPC accept negative GPU IDs while REST rejects them.
+
+## Goal
+
+Make CLI, Python service, REST, and JSON-RPC use the same humane validation and default policy for session inputs while keeping the change focused.
+
+## Solution
+
+- Keep human-readable VRAM strings such as `512MB` and `1GiB`.
+- Treat digit-only VRAM strings and public integer `vram_to_keep` values as bytes.
+- Convert public bytes to internal float32 element counts once, close to controller setup.
+- Treat negative `busy_threshold` as "utilization backoff disabled" instead of "always back off".
+- Reject non-positive intervals and negative GPU IDs consistently across CLI, direct service calls, REST, and JSON-RPC.
+- Update docs and AGENTS guidance for the clarified public contract.
+
+## Todo
+
+- [x] Add failing tests for VRAM byte parsing, interval validation, GPU ID validation, and busy-threshold semantics.
+- [x] Implement shared validation/parsing helpers without scattering platform branches.
+- [x] Update CLI/MCP/Python controller paths to use the shared contract.
+- [x] Update README, docs, and AGENTS.md with the clarified contract and validation expectation.
+- [x] Run targeted tests, docs build, and pre-commit.
+- [ ] Open PR, run local subagent review, resolve all comments, then squash merge only when clean.

--- a/docs/plans/public-session-contract.md
+++ b/docs/plans/public-session-contract.md
@@ -14,6 +14,7 @@ Make CLI, Python service, REST, and JSON-RPC use the same humane validation and 
 - Treat digit-only VRAM strings and public integer `vram_to_keep` values as bytes.
 - Convert public bytes to internal float32 element counts once, close to controller setup.
 - Treat negative `busy_threshold` as "utilization backoff disabled" instead of "always back off".
+- Preserve subsecond positive intervals for the Python controller API.
 - Reject non-positive intervals and negative GPU IDs consistently across CLI, direct service calls, REST, and JSON-RPC.
 - Update docs and AGENTS guidance for the clarified public contract.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,9 +21,9 @@ These options apply when you run `keep-gpu` without subcommands.
 | Option | Type | Description |
 | --- | --- | --- |
 | `--interval INTEGER` | seconds | Sleep duration between utilization checks and keep-alive batches. |
-| `--gpu-ids TEXT` | comma-separated ints | Subset of GPUs to guard (for example, `0,2`). Omit to use all visible GPUs. |
-| `--vram TEXT` | human size or bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`). |
-| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | Back off when utilization is above this value. |
+| `--gpu-ids TEXT` | comma-separated non-negative ints | Subset of GPUs to guard (for example, `0,2`). Omit to use all visible GPUs. |
+| `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`). |
+| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | Back off when utilization is above this value; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
 
 ## Service mode

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -17,6 +17,7 @@ import typer
 from rich.console import Console
 
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.session_config import validate_interval
 
 DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
@@ -97,11 +98,21 @@ def _parse_gpu_ids(gpu_ids: Optional[str]) -> Optional[List[int]]:
     if not gpu_ids:
         return None
     try:
-        return [int(i.strip()) for i in gpu_ids.split(",")]
+        parsed = [int(i.strip()) for i in gpu_ids.split(",")]
     except ValueError as exc:
         raise typer.BadParameter(
             f"Invalid characters in --gpu-ids '{gpu_ids}'. Use comma-separated integers."
         ) from exc
+    if any(gpu_id < 0 for gpu_id in parsed):
+        raise typer.BadParameter("gpu_ids must contain non-negative integers")
+    return parsed
+
+
+def _validate_cli_interval(interval: int) -> int:
+    try:
+        return validate_interval(interval)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _service_base_url(host: str, port: int) -> str:
@@ -309,6 +320,7 @@ def _run_blocking(
     vram, busy_threshold, legacy_mode = _apply_legacy_threshold(
         vram, legacy_threshold, busy_threshold
     )
+    interval = _validate_cli_interval(interval)
     if legacy_mode == "vram":
         console.print(
             "[yellow]`--threshold` for VRAM is deprecated; use `--vram`.[/yellow]"
@@ -381,6 +393,7 @@ def main(
     if ctx.invoked_subcommand is not None:
         return
     try:
+        interval = _validate_cli_interval(interval)
         _run_blocking(interval, gpu_ids, vram, legacy_threshold, busy_threshold)
     except typer.BadParameter as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
@@ -445,11 +458,13 @@ def start(
     `keep-gpu service-stop` to stop the local service daemon.
     """
     try:
+        interval = _validate_cli_interval(interval)
+        parsed_gpu_ids = _parse_gpu_ids(gpu_ids)
         auto_started = _ensure_service_running(host, port, auto_start=auto_start)
         result = _rpc_call(
             "start_keep",
             {
-                "gpu_ids": _parse_gpu_ids(gpu_ids),
+                "gpu_ids": parsed_gpu_ids,
                 "vram": vram,
                 "interval": interval,
                 "busy_threshold": busy_threshold,

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Union
 import torch
 
 from keep_gpu.utilities.humanized_input import parse_size
+from keep_gpu.utilities.session_config import validate_gpu_ids, validate_interval
 from keep_gpu.utilities.platform_manager import ComputingPlatform, get_platform
 
 
@@ -16,15 +17,9 @@ class GlobalGPUController:
         busy_threshold: int = 10,
     ):
         self.computing_platform = get_platform()
-        self.interval = interval
+        self.interval = validate_interval(interval)
         self.vram_to_keep = vram_to_keep
-        if isinstance(self.vram_to_keep, str):
-            try:
-                self.vram_to_keep = parse_size(self.vram_to_keep)
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid vram_to_keep value: {self.vram_to_keep}. Must be an integer (bytes) or a string like '1GiB', '2MiB' etc."
-                ) from e
+        gpu_ids = validate_gpu_ids(gpu_ids)
         if self.computing_platform == ComputingPlatform.CUDA:
             from keep_gpu.single_gpu_controller.cuda_gpu_controller import (
                 CudaGPUController,
@@ -65,7 +60,7 @@ class GlobalGPUController:
         self.controllers = [
             controller_cls(
                 rank=i,
-                interval=interval,
+                interval=self.interval,
                 vram_to_keep=self.vram_to_keep,
                 busy_threshold=busy_threshold,
             )

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -4,7 +4,11 @@ from typing import List, Optional, Union
 import torch
 
 from keep_gpu.utilities.humanized_input import parse_size
-from keep_gpu.utilities.session_config import validate_gpu_ids, validate_interval
+from keep_gpu.utilities.session_config import (
+    validate_busy_threshold,
+    validate_gpu_ids,
+    validate_interval,
+)
 from keep_gpu.utilities.platform_manager import ComputingPlatform, get_platform
 
 
@@ -18,6 +22,7 @@ class GlobalGPUController:
     ):
         self.computing_platform = get_platform()
         self.interval = validate_interval(interval)
+        self.busy_threshold = validate_busy_threshold(busy_threshold)
         self.vram_to_keep = vram_to_keep
         gpu_ids = validate_gpu_ids(gpu_ids)
         if self.computing_platform == ComputingPlatform.CUDA:
@@ -62,7 +67,7 @@ class GlobalGPUController:
                 rank=i,
                 interval=self.interval,
                 vram_to_keep=self.vram_to_keep,
-                busy_threshold=busy_threshold,
+                busy_threshold=self.busy_threshold,
             )
             for i in self.gpu_ids
         ]

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -36,8 +36,14 @@ from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import unquote, urlparse
 
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.session_config import (
+    validate_busy_threshold,
+    validate_gpu_ids,
+    validate_interval,
+)
 
 logger = setup_logger(__name__)
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -108,6 +114,11 @@ class KeepGPUServer:
         Raises:
             ValueError: If the provided job_id already exists.
         """
+        gpu_ids = validate_gpu_ids(gpu_ids)
+        interval = validate_interval(interval)
+        busy_threshold = validate_busy_threshold(busy_threshold)
+        parse_vram_to_elements(vram)
+
         job_id = job_id or str(uuid.uuid4())
         with self._sessions_lock:
             if job_id in self._sessions:
@@ -368,15 +379,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 }
                 gpu_ids = safe_payload.get("gpu_ids")
                 if gpu_ids is not None:
-                    if not isinstance(gpu_ids, list):
-                        raise ValueError("gpu_ids must be a list of integers")
-                    if len(gpu_ids) > 64:
-                        raise ValueError("gpu_ids has too many items")
-                    if any(
-                        (not isinstance(gpu_id, int) or gpu_id < 0)
-                        for gpu_id in gpu_ids
-                    ):
-                        raise ValueError("gpu_ids must contain non-negative integers")
+                    validate_gpu_ids(gpu_ids)
                     visible_gpus = server_ref.list_gpus().get("gpus", [])
                     if visible_gpus and any(
                         gpu_id >= len(visible_gpus) for gpu_id in gpu_ids

--- a/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
+from keep_gpu.utilities.session_config import validate_interval
 
 
 class BaseGPUController:
@@ -15,7 +16,7 @@ class BaseGPUController:
             interval (float): Time interval (in seconds) between keep-alive cycles.
         """
         self.vram_to_keep = parse_vram_to_elements(vram_to_keep)
-        self.interval = interval
+        self.interval = validate_interval(interval)
 
     def monitor(self):
         """

--- a/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from keep_gpu.utilities.humanized_input import parse_size
+from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 
 
 class BaseGPUController:
@@ -10,17 +10,11 @@ class BaseGPUController:
 
         Args:
             vram_to_keep (int or str): Amount of VRAM to keep busy. Accepts integers
-                (tensor element count) or human strings like "1GiB" (converted to
+                as raw bytes or human strings like "1GiB" (converted to internal
                 element count for float32 tensors).
             interval (float): Time interval (in seconds) between keep-alive cycles.
         """
-        if isinstance(vram_to_keep, str):
-            vram_to_keep = parse_size(vram_to_keep)
-        elif not isinstance(vram_to_keep, int):
-            raise TypeError(
-                f"vram_to_keep must be str or int, got {type(vram_to_keep)}"
-            )
-        self.vram_to_keep = vram_to_keep
+        self.vram_to_keep = parse_vram_to_elements(vram_to_keep)
         self.interval = interval
 
     def monitor(self):

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -9,6 +9,7 @@ from keep_gpu.utilities.gpu_monitor import get_gpu_utilization
 from keep_gpu.utilities.humanized_input import parse_size
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import ComputingPlatform
+from keep_gpu.utilities.session_config import validate_busy_threshold
 
 logger = setup_logger(__name__)
 
@@ -74,7 +75,7 @@ class CudaGPUController(BaseGPUController):
         if relu_iterations <= 0:
             raise ValueError("relu_iterations must be positive")
         self.relu_iterations = relu_iterations
-        self.busy_threshold = busy_threshold
+        self.busy_threshold = validate_busy_threshold(busy_threshold)
         self.platform = ComputingPlatform.CUDA
 
         self._stop_evt: Optional[threading.Event] = None

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -182,7 +182,7 @@ class CudaGPUController(BaseGPUController):
         while not stop_evt.is_set():
             try:
                 gpu_utilization = self._monitor_utilization(self.rank)
-                if gpu_utilization > self.busy_threshold:
+                if not self._should_run_batch(gpu_utilization, self.busy_threshold):
                     logger.debug(
                         "rank %s: GPU busy (%d%%), sleeping longer",
                         self.rank,
@@ -237,3 +237,8 @@ class CudaGPUController(BaseGPUController):
         """
         utilization = get_gpu_utilization(rank)
         return utilization if utilization is not None else 0
+
+    @staticmethod
+    def _should_run_batch(gpu_utilization: int, busy_threshold: int) -> bool:
+        """Return whether keep-alive compute should run for this utilization."""
+        return busy_threshold < 0 or gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -8,6 +8,7 @@ import torch
 from keep_gpu.single_gpu_controller.base_gpu_controller import BaseGPUController
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import ComputingPlatform
+from keep_gpu.utilities.session_config import validate_busy_threshold
 
 logger = setup_logger(__name__)
 
@@ -32,7 +33,7 @@ class MacMGPUController(BaseGPUController):
 
         self.rank = rank
         self.device = torch.device("mps")
-        self.busy_threshold = busy_threshold
+        self.busy_threshold = validate_busy_threshold(busy_threshold)
         self.iterations = iterations
         self.platform = ComputingPlatform.MACM
 

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -6,6 +6,7 @@ import torch
 
 from keep_gpu.single_gpu_controller.base_gpu_controller import BaseGPUController
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.session_config import validate_busy_threshold
 
 logger = setup_logger(__name__)
 
@@ -29,7 +30,7 @@ class RocmGPUController(BaseGPUController):
         super().__init__(vram_to_keep=vram_to_keep, interval=interval)
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")
-        self.busy_threshold = busy_threshold
+        self.busy_threshold = validate_busy_threshold(busy_threshold)
         self.iterations = iterations
         self.max_allocation_retries = max_allocation_retries
         self._stop_evt: Optional[threading.Event] = None

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -173,7 +173,11 @@ class RocmGPUController(BaseGPUController):
         while not stop_evt.is_set():
             try:
                 util = self._query_utilization()
-                if util is not None and util > self.busy_threshold:
+                if (
+                    util is not None
+                    and self.busy_threshold >= 0
+                    and util > self.busy_threshold
+                ):
                     logger.debug("rank %s: GPU busy (%d%%), sleeping", self.rank, util)
                 else:
                     self._run_batch(tensor)

--- a/src/keep_gpu/utilities/humanized_input.py
+++ b/src/keep_gpu/utilities/humanized_input.py
@@ -1,4 +1,5 @@
 import re
+from typing import Union
 
 _UNITS = {
     "KB": 1000,
@@ -16,24 +17,41 @@ _UNITS = {
 }
 
 
+def _bytes_to_float32_elements(byte_count: float) -> int:
+    elements = int(byte_count / 4)
+    if elements <= 0:
+        raise ValueError("memory size must be at least 4 bytes")
+    return elements
+
+
 def parse_size(text: str) -> int:
     """
     Parse human-readable memory strings into float32 element counts.
 
     The return value is the number of float32 elements needed to occupy the
-    requested memory size. When no unit is provided, the default unit is GB.
-    Supported units are the keys in `_UNITS`.
+    requested memory size. When no unit is provided, the value is interpreted
+    as raw bytes. Supported units are the keys in `_UNITS`.
     """
     text = text.strip().replace(" ", "")
     m = re.fullmatch(r"([0-9]*\.?[0-9]+)([A-Za-z]*)", text)
     if not m:
         raise ValueError(f"invalid format: {text}, should be like '1000 MB'")
     value, unit = m.groups()
-    unit = unit or "GB"
+    if not unit:
+        return _bytes_to_float32_elements(float(value))
     if len(unit) > 1:
         # Treat all-lowercase units as byte units ("gb" -> "GB", "gib" -> "GIB")
         # while preserving explicit mixed-case bit forms ("Gb", "GIb").
         unit = unit.upper() if unit.islower() else unit[:-1].upper() + unit[-1]
     if unit not in _UNITS:
         raise ValueError(f"unknown unit: {unit}, should be one of {_UNITS.keys()}")
-    return int(float(value) * _UNITS[unit] / 4)  # float32 takes 4 bytes
+    return _bytes_to_float32_elements(float(value) * _UNITS[unit])
+
+
+def parse_vram_to_elements(value: Union[int, str]) -> int:
+    """Normalize public VRAM input to internal float32 element count."""
+    if isinstance(value, str):
+        return parse_size(value)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return _bytes_to_float32_elements(float(value))
+    raise TypeError(f"vram_to_keep must be str or int bytes, got {type(value)}")

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -1,8 +1,12 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 
 def _is_plain_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_plain_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
@@ -18,9 +22,9 @@ def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
     return list(gpu_ids)
 
 
-def validate_interval(interval: Any) -> int:
+def validate_interval(interval: Any) -> Union[int, float]:
     """Validate public interval input in seconds."""
-    if not _is_plain_int(interval) or interval <= 0:
+    if not _is_plain_number(interval) or interval <= 0:
         raise ValueError("interval must be positive")
     return interval
 

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -1,0 +1,32 @@
+from typing import Any, List, Optional
+
+
+def _is_plain_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
+    """Validate public GPU id input and return a normalized list."""
+    if gpu_ids is None:
+        return None
+    if not isinstance(gpu_ids, list):
+        raise ValueError("gpu_ids must be a list of integers")
+    if len(gpu_ids) > 64:
+        raise ValueError("gpu_ids has too many items")
+    if any(not _is_plain_int(gpu_id) or gpu_id < 0 for gpu_id in gpu_ids):
+        raise ValueError("gpu_ids must contain non-negative integers")
+    return list(gpu_ids)
+
+
+def validate_interval(interval: Any) -> int:
+    """Validate public interval input in seconds."""
+    if not _is_plain_int(interval) or interval <= 0:
+        raise ValueError("interval must be positive")
+    return interval
+
+
+def validate_busy_threshold(busy_threshold: Any) -> int:
+    """Validate utilization threshold; -1 disables utilization backoff."""
+    if not _is_plain_int(busy_threshold) or busy_threshold < -1:
+        raise ValueError("busy_threshold must be an integer >= -1")
+    return busy_threshold

--- a/tests/cuda_controller/test_2_32pow_elements.py
+++ b/tests/cuda_controller/test_2_32pow_elements.py
@@ -22,7 +22,7 @@ def test_large_vram_allocation():
         rank=0,
         interval=0.5,
         relu_iterations=100,
-        vram_to_keep=vram_elements,
+        vram_to_keep=required_bytes,
         busy_threshold=10,
     )
 

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -16,6 +16,11 @@ def test_non_negative_busy_threshold_backs_off_above_limit_without_gpu():
     assert CudaGPUController._should_run_batch(11, 10) is False
 
 
+def test_cuda_controller_rejects_busy_threshold_below_minus_one_without_gpu():
+    with pytest.raises(ValueError, match="busy_threshold must be an integer >= -1"):
+        CudaGPUController(rank=0, vram_to_keep="4MB", busy_threshold=-2)
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="Only run CUDA tests when CUDA is available",

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -6,6 +6,16 @@ import torch
 from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
 
 
+def test_negative_busy_threshold_disables_backoff_without_gpu():
+    assert CudaGPUController._should_run_batch(0, -1) is True
+    assert CudaGPUController._should_run_batch(100, -1) is True
+
+
+def test_non_negative_busy_threshold_backs_off_above_limit_without_gpu():
+    assert CudaGPUController._should_run_batch(10, 10) is True
+    assert CudaGPUController._should_run_batch(11, 10) is False
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="Only run CUDA tests when CUDA is available",

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -2,6 +2,33 @@ import time
 import pytest
 import torch
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.utilities import platform_manager as pm
+
+
+def test_global_controller_accepts_fractional_interval(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+
+    class DummyController:
+        def __init__(self, *, rank, interval, vram_to_keep, busy_threshold):
+            self.rank = rank
+            self.interval = interval
+            self.vram_to_keep = vram_to_keep
+            self.busy_threshold = busy_threshold
+
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module, "CudaGPUController", DummyController)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    controller = GlobalGPUController(
+        gpu_ids=[0],
+        interval=0.05,
+        vram_to_keep="8MB",
+        busy_threshold=10,
+    )
+
+    assert controller.interval == 0.05
+    assert controller.controllers[0].interval == 0.05
 
 
 @pytest.mark.skipif(

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -1,0 +1,11 @@
+import pytest
+
+from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.utilities import platform_manager as pm
+
+
+def test_global_controller_rejects_busy_threshold_below_minus_one(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CPU)
+
+    with pytest.raises(ValueError, match="busy_threshold must be an integer >= -1"):
+        GlobalGPUController(busy_threshold=-2)

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -217,3 +217,36 @@ def test_http_post_rejects_unknown_fields():
         httpd.server_close()
         server.shutdown()
         thread.join(timeout=2)
+
+
+def test_http_post_rejects_non_positive_interval():
+    server = make_server()
+
+    class _Server(TCPServer):
+        allow_reuse_address = True
+
+    httpd = _Server(("127.0.0.1", 0), _JSONRPCHandler)
+    httpd.keepgpu_server = server  # type: ignore[attr-defined]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+
+    try:
+        status_code, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "gpu_ids": [0],
+                "vram": "64MB",
+                "interval": 0,
+                "busy_threshold": 5,
+            },
+        )
+        assert status_code == 400
+        assert "interval must be positive" in payload["error"]["message"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -44,6 +44,33 @@ def test_start_status_stop_cycle():
     assert server.status(job_id)["active"] is False
 
 
+def test_start_rejects_negative_gpu_id():
+    server = make_server()
+
+    try:
+        server.start_keep(gpu_ids=[0, -1])
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "gpu_ids must contain non-negative integers" in str(exc)
+
+    assert server.status()["active_jobs"] == []
+
+
+def test_jsonrpc_rejects_non_positive_interval():
+    server = make_server()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"gpu_ids": [0], "interval": 0},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert "interval must be positive" in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
 def test_stop_all():
     server = make_server()
     job_a = server.start_keep()["job_id"]

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -50,6 +50,44 @@ def test_start_command_uses_rpc(monkeypatch):
     assert port == cli.DEFAULT_SERVICE_PORT
 
 
+def test_start_command_rejects_negative_gpu_ids(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be started")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("RPC should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["start", "--gpu-ids", "0,-1"])
+
+    assert result.exit_code == 1
+    assert "non-negative integers" in result.output
+
+
+def test_start_command_rejects_non_positive_interval(monkeypatch):
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("RPC should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["start", "--interval", "0"])
+
+    assert result.exit_code == 1
+    assert "interval must be positive" in result.output
+
+
 def test_stop_requires_job_id_or_all():
     result = runner.invoke(cli.app, ["stop"])
     assert result.exit_code == 1
@@ -70,6 +108,21 @@ def test_blocking_mode_remains_default(monkeypatch):
 
     assert result.exit_code == 0
     assert called["args"] == (120, "0", "1GiB", None, -1)
+
+
+def test_blocking_mode_rejects_non_positive_interval(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_run_blocking",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("blocking runner should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["--interval", "0"])
+
+    assert result.exit_code == 1
+    assert "interval must be positive" in result.output
 
 
 def test_start_prints_dashboard_and_stop_hints(monkeypatch):

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -1,4 +1,11 @@
+import pytest
+
 from keep_gpu import cli
+
+
+def test_parse_gpu_ids_rejects_negative_values():
+    with pytest.raises(Exception, match="non-negative integers"):
+        cli._parse_gpu_ids("0,-1")
 
 
 def test_apply_legacy_threshold_none():

--- a/tests/utilities/test_humanized_input.py
+++ b/tests/utilities/test_humanized_input.py
@@ -1,0 +1,14 @@
+from keep_gpu.utilities.humanized_input import parse_size, parse_vram_to_elements
+
+
+def test_parse_size_digit_only_string_means_bytes():
+    assert parse_size("1073741824") == 268_435_456
+
+
+def test_parse_size_human_units_still_mean_bytes():
+    assert parse_size("1GiB") == 268_435_456
+    assert parse_size("512MB") == 128_000_000
+
+
+def test_parse_vram_integer_means_bytes():
+    assert parse_vram_to_elements(1_073_741_824) == 268_435_456

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -1,0 +1,23 @@
+import pytest
+
+from keep_gpu.utilities.session_config import (
+    validate_busy_threshold,
+    validate_interval,
+)
+
+
+def test_validate_interval_accepts_fractional_positive_seconds():
+    assert validate_interval(0.05) == 0.05
+
+
+def test_validate_interval_rejects_non_positive_values():
+    with pytest.raises(ValueError, match="interval must be positive"):
+        validate_interval(0)
+    with pytest.raises(ValueError, match="interval must be positive"):
+        validate_interval(-0.1)
+
+
+def test_validate_busy_threshold_only_allows_minus_one_as_negative():
+    assert validate_busy_threshold(-1) == -1
+    with pytest.raises(ValueError, match="busy_threshold must be an integer >= -1"):
+        validate_busy_threshold(-2)


### PR DESCRIPTION
## Summary
- Treat digit-only `--vram` strings and public integer `vram_to_keep` values as bytes, then convert to internal float32 element counts.
- Centralize session validation for GPU IDs, interval, and busy-threshold across CLI, direct service calls, REST, and JSON-RPC.
- Make negative `busy_threshold` disable utilization backoff instead of suppressing all keep-alive compute.
- Update AGENTS, README, and docs with the clarified public contract and plan.

## Test Plan
- `PYTHONPATH=src pytest tests -q` -> 50 passed, 13 skipped
- `PYTHONPATH=src mkdocs build` -> exit 0
- `pre-commit run --all-files` -> passed