### PR TITLE
[telemetry] fix: clean up platform probes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ This file defines how coding agents should work in this repository.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
+- Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.
 
@@ -74,6 +75,7 @@ This file defines how coding agents should work in this repository.
 
 - CUDA telemetry should rely on `nvidia-ml-py` (imported as `pynvml` module), not the deprecated standalone `pynvml` package.
 - ROCm support is optional and should remain guarded (`rocm-smi` in extras). Imports must fail gracefully on non-ROCm machines.
+- Apple Silicon/MPS telemetry is best-effort; return a guarded MACM record with nullable memory/utilization fields rather than hiding the device.
 - CI runners generally do not have GPUs. GPU-dependent logic must have safe fallbacks and tests must avoid hard-failing in no-GPU environments.
 
 ### Testing Expectations in This Repository

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On many clusters, idle GPUs are reaped or silently shared after a short grace pe
 - **Portable** – Typer/Rich CLI for humans; Python API for orchestrators and notebooks.
 - **Observable** – Structured logging and optional file logs for auditing what kept the GPU alive.
 - **Power-aware** – Uses intervalled elementwise ops instead of heavy matmul floods to present “busy” utilization while keeping power and thermals lower (see `CudaGPUController._run_relu_batch` for the loop).
-- **NVML-backed** – GPU telemetry comes from `nvidia-ml-py` (the `pynvml` module), with optional `rocm-smi` support when you install the `rocm` extra.
+- **Telemetry-aware** – GPU telemetry comes from `nvidia-ml-py` (the `pynvml` module), optional `rocm-smi`, and best-effort MPS memory counters on Mac M series.
 
 ## Quick start (CLI)
 
@@ -141,6 +141,7 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy
 - **Mac M series limitations:**
   - GPU utilization monitoring is not available on macOS.
   - `busy_threshold` parameter is accepted for API compatibility but has no effect.
+  - `list-gpus` reports best-effort MPS memory counters and `null` for unsupported telemetry fields.
 - Minimal client config (stdio MCP):
   ```yaml
   servers:

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -11,9 +11,10 @@ schedulers that the GPU is still busy, without burning a full training workload.
    or Mac M series) and instantiates one single-GPU controller per selected device.
 3. **`CudaGPUController`** / **`RocmGPUController`** / **`MacMGPUController`** –
    Platform-specific implementations for per-GPU keep-alive loops.
-4. **GPU monitor (NVML/ROCm)** – Wraps `nvidia-ml-py` (the `pynvml` module) for CUDA
-   telemetry and optionally `rocm-smi` when installed by way of the `rocm` extra.
-   Mac M series does not support direct GPU utilization monitoring.
+4. **GPU monitor (NVML/ROCm/MPS)** – Wraps `nvidia-ml-py` (the `pynvml`
+   module) for CUDA telemetry, optionally `rocm-smi` when installed by way of
+   the `rocm` extra, and best-effort MPS memory counters on Mac M series.
+   Utilization can be unavailable on some platforms and is reported as `null`.
 5. **Utilities** – `parse_size` turns strings like `1GiB` or bare byte values into
    internal float32 tensor element counts, while `setup_logger` wires both console
    and file logging with optional colors.
@@ -57,3 +58,5 @@ Elementwise keep-alive batches:
 
 `get_platform()` inspects the system and enables the CUDA, ROCm, or Mac M series
 (MPS) path. Detection order: CUDA → ROCm → Mac M → CPU fallback.
+Vendor detection probes initialize and then shut down their telemetry libraries
+immediately, so detection does not leave NVML or ROCm SMI handles open.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -104,4 +104,4 @@ of `keep-gpu status`.
 - **Start cannot reach service**: run `keep-gpu serve --host 127.0.0.1 --port 8765`.
 - **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop` (or use `keep-gpu service-stop --force`).
 - **OOM during keep**: reduce `--vram` or free GPU memory before starting.
-- **No utilization data**: ensure `nvidia-ml-py` works and `nvidia-smi` is available.
+- **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra; on Mac M series, utilization is expected to be `null`.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -65,6 +65,9 @@ http://127.0.0.1:8765/
 ```
 
 The dashboard provides live telemetry, active sessions, and start/stop controls.
+CUDA and ROCm devices include memory and utilization when the platform APIs are
+available. Mac M series devices report best-effort MPS memory counters and use
+`null` for unsupported fields such as utilization.
 
 ## Remote and security notes
 

--- a/docs/plans/telemetry-probe-hygiene.md
+++ b/docs/plans/telemetry-probe-hygiene.md
@@ -22,5 +22,10 @@ Make hardware probing lifecycle-safe and make telemetry visible on CUDA, ROCm, a
 - [x] Implement platform probe cleanup and ROCm API alignment.
 - [x] Implement guarded MPS telemetry in `gpu_info.py`.
 - [x] Update docs and AGENTS.md.
-- [ ] Run targeted tests, docs build, and pre-commit.
-- [ ] Open PR, run local subagent review, resolve all comments, then squash merge only when clean.
+- [x] Run targeted tests, docs build, and pre-commit.
+  - `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py tests/utilities/test_gpu_info.py -q`: 12 passed, 1 skipped.
+  - `PYTHONPATH=$PWD/src pytest tests -q`: 62 passed, 12 skipped.
+  - `PYTHONPATH=$PWD/src mkdocs build`: passed with existing Material warning and unnav'd docs notices.
+  - `pre-commit run --all-files`: passed.
+- [x] Open PR, run local subagent review, and resolve all comments.
+- [ ] Squash merge only when GitHub checks and local re-review are clean.

--- a/docs/plans/telemetry-probe-hygiene.md
+++ b/docs/plans/telemetry-probe-hygiene.md
@@ -1,0 +1,26 @@
+# Telemetry Probe Hygiene Fix Plan
+
+## Background
+
+Audit agents found that platform probes can initialize vendor libraries without shutting them down, ROCm detection uses an API name inconsistent with the rest of KeepGPU, mocked NVML telemetry is skipped in no-GPU CI, and Apple Silicon/MPS can be controlled but reports no telemetry.
+
+## Goal
+
+Make hardware probing lifecycle-safe and make telemetry visible on CUDA, ROCm, and MPS without requiring GPUs in CI.
+
+## Solution
+
+- Shut down NVML after CUDA detection probes.
+- Use `rsmi_init()` / `rsmi_shut_down()` for ROCm detection, matching telemetry and controller code.
+- Run mocked NVML telemetry tests on no-GPU CI.
+- Add guarded MPS telemetry that reports one `macm` device with nullable memory fields when MPS counters are unavailable.
+- Update docs and AGENTS.md with telemetry/probe expectations.
+
+## Todo
+
+- [x] Add failing tests for NVML probe shutdown, ROCm probe API alignment, no-GPU mocked NVML telemetry, and MPS telemetry.
+- [x] Implement platform probe cleanup and ROCm API alignment.
+- [x] Implement guarded MPS telemetry in `gpu_info.py`.
+- [x] Update docs and AGENTS.md.
+- [ ] Run targeted tests, docs build, and pre-commit.
+- [ ] Open PR, run local subagent review, resolve all comments, then squash merge only when clean.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,7 +85,7 @@ Stops local daemon process created by auto-start logic.
 | Endpoint | Method | Purpose |
 | --- | --- | --- |
 | `/health` | GET | Service liveness probe. |
-| `/api/gpus` | GET | GPU telemetry (`id`, `name`, memory, utilization). |
+| `/api/gpus` | GET | GPU telemetry (`id`, `name`, memory, utilization; unsupported fields are `null`). |
 | `/api/sessions` | GET | Active keep sessions. |
 | `/api/sessions/{job_id}` | GET | One session status. |
 | `/api/sessions` | POST | Start session (`gpu_ids`, `vram`, `interval`, `busy_threshold`, `job_id`). |

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -136,10 +136,47 @@ def _query_torch() -> List[Dict[str, Any]]:
     return infos
 
 
+def _safe_mps_memory_value(method_name: str) -> int | None:
+    try:
+        mps = getattr(torch, "mps")
+        method = getattr(mps, method_name)
+        return int(method())
+    except Exception as exc:
+        logger.debug("MPS memory query %s failed: %s", method_name, exc)
+        return None
+
+
+def _query_mps() -> List[Dict[str, Any]]:
+    try:
+        if not torch.backends.mps.is_available():
+            return []
+    except Exception as exc:
+        logger.debug("MPS availability query failed: %s", exc)
+        return []
+
+    current_allocated = _safe_mps_memory_value("current_allocated_memory")
+    driver_allocated = _safe_mps_memory_value("driver_allocated_memory")
+    recommended_max = _safe_mps_memory_value("recommended_max_memory")
+
+    return [
+        {
+            "id": 0,
+            "platform": "macm",
+            "name": "Apple Silicon GPU",
+            "memory_total": recommended_max,
+            "memory_used": (
+                driver_allocated if driver_allocated is not None else current_allocated
+            ),
+            "utilization": None,
+            "memory_allocated": current_allocated,
+        }
+    ]
+
+
 def get_gpu_info() -> List[Dict[str, Any]]:
     """
     Return a list of GPU info dicts: id, platform, name, memory_total, memory_used, utilization.
-    Tries NVML first (CUDA), then ROCm SMI, then falls back to torch.cuda data.
+    Tries NVML first (CUDA), then ROCm SMI, then torch.cuda, then MPS data.
     """
     try:
         infos = _query_nvml()
@@ -155,7 +192,11 @@ def get_gpu_info() -> List[Dict[str, Any]]:
     except Exception as exc:
         logger.debug("ROCm info failed: %s", exc)
 
-    return _query_torch()
+    infos = _query_torch()
+    if infos:
+        return infos
+
+    return _query_mps()
 
 
 __all__ = ["get_gpu_info"]

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -192,9 +192,12 @@ def get_gpu_info() -> List[Dict[str, Any]]:
     except Exception as exc:
         logger.debug("ROCm info failed: %s", exc)
 
-    infos = _query_torch()
-    if infos:
-        return infos
+    try:
+        infos = _query_torch()
+        if infos:
+            return infos
+    except Exception as exc:
+        logger.debug("Torch GPU info failed: %s", exc)
 
     return _query_mps()
 

--- a/src/keep_gpu/utilities/platform_manager.py
+++ b/src/keep_gpu/utilities/platform_manager.py
@@ -36,6 +36,10 @@ def _check_cuda():
         import pynvml  # provided by nvidia-ml-py
 
         pynvml.nvmlInit()
+        try:
+            pynvml.nvmlShutdown()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.debug("NVML shutdown after probe failed: %s", exc)
         return True
     except Exception as exc:
         logger.debug("NVML unavailable: %s", exc)
@@ -52,7 +56,11 @@ def _check_rocm():
     try:
         import rocm_smi
 
-        rocm_smi.rocm_smi_init()
+        rocm_smi.rsmi_init()
+        try:
+            rocm_smi.rsmi_shut_down()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.debug("ROCm SMI shutdown after probe failed: %s", exc)
         return True
     except Exception as exc:
         logger.debug("ROCm SMI unavailable: %s", exc)

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -208,3 +208,50 @@ def test_get_gpu_info_mps_allows_missing_memory_methods(monkeypatch):
     assert infos[0]["platform"] == "macm"
     assert infos[0]["memory_total"] is None
     assert infos[0]["memory_used"] is None
+
+
+def test_get_gpu_info_mps_fallback_survives_torch_cuda_probe_failure(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+
+    class BrokenCuda:
+        @staticmethod
+        def is_available():
+            raise RuntimeError("cuda probe failed")
+
+    class DummyMPSBackend:
+        @staticmethod
+        def is_available():
+            return True
+
+    class DummyMPS:
+        @staticmethod
+        def current_allocated_memory():
+            return 64
+
+        @staticmethod
+        def driver_allocated_memory():
+            return 128
+
+        @staticmethod
+        def recommended_max_memory():
+            return 512
+
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": BrokenCuda,
+            "backends": type("Backends", (), {"mps": DummyMPSBackend}),
+            "mps": DummyMPS,
+            "version": type("V", (), {"hip": None}),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "macm"
+    assert infos[0]["memory_total"] == 512
+    assert infos[0]["memory_used"] == 128

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -16,10 +16,6 @@ class DummyNVMLUtil:
         self.gpu = gpu
 
 
-@pytest.mark.skipif(
-    not hasattr(gpu_info, "torch") or not gpu_info.torch.cuda.is_available(),
-    reason="CUDA not available for NVML path",
-)
 def test_get_gpu_info_nvml(monkeypatch):
     class DummyNVML:
         def __init__(self):
@@ -63,6 +59,7 @@ def test_get_gpu_info_nvml(monkeypatch):
     assert info["memory_total"] == 2048
     assert info["memory_used"] == 1024
     assert info["utilization"] == 55
+    assert dummy_nvml.shutdown_calls == 1
 
 
 @pytest.mark.rocm
@@ -124,3 +121,90 @@ def test_get_gpu_info_rocm(monkeypatch):
     assert info["utilization"] == 77
     assert info["memory_total"] == 100
     assert info["memory_used"] == 50
+
+
+def test_get_gpu_info_mps(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+
+    class DummyCuda:
+        @staticmethod
+        def is_available():
+            return False
+
+    class DummyMPSBackend:
+        @staticmethod
+        def is_available():
+            return True
+
+    class DummyMPS:
+        @staticmethod
+        def current_allocated_memory():
+            return 128
+
+        @staticmethod
+        def driver_allocated_memory():
+            return 256
+
+        @staticmethod
+        def recommended_max_memory():
+            return 1024
+
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": DummyCuda,
+            "backends": type("Backends", (), {"mps": DummyMPSBackend}),
+            "mps": DummyMPS,
+            "version": type("V", (), {"hip": None}),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert infos == [
+        {
+            "id": 0,
+            "platform": "macm",
+            "name": "Apple Silicon GPU",
+            "memory_total": 1024,
+            "memory_used": 256,
+            "utilization": None,
+            "memory_allocated": 128,
+        }
+    ]
+
+
+def test_get_gpu_info_mps_allows_missing_memory_methods(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+
+    class DummyCuda:
+        @staticmethod
+        def is_available():
+            return False
+
+    class DummyMPSBackend:
+        @staticmethod
+        def is_available():
+            return True
+
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": DummyCuda,
+            "backends": type("Backends", (), {"mps": DummyMPSBackend}),
+            "version": type("V", (), {"hip": None}),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "macm"
+    assert infos[0]["memory_total"] is None
+    assert infos[0]["memory_used"] is None

--- a/tests/utilities/test_platform_manager.py
+++ b/tests/utilities/test_platform_manager.py
@@ -90,3 +90,49 @@ def test_cuda_detection_falls_back_to_nvml(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
     assert pm._check_cuda() is True
+
+
+def test_cuda_detection_shuts_down_nvml_probe(monkeypatch):
+    _reset_cache(monkeypatch)
+    monkeypatch.setattr(pm.torch.cuda, "is_available", lambda: False)
+
+    class DummyNVML:
+        init_calls = 0
+        shutdown_calls = 0
+
+        @classmethod
+        def nvmlInit(cls):
+            cls.init_calls += 1
+
+        @classmethod
+        def nvmlShutdown(cls):
+            cls.shutdown_calls += 1
+
+    monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
+
+    assert pm._check_cuda() is True
+    assert DummyNVML.init_calls == 1
+    assert DummyNVML.shutdown_calls == 1
+
+
+def test_rocm_detection_uses_rsmi_api(monkeypatch):
+    _reset_cache(monkeypatch)
+    monkeypatch.setattr(pm.torch.cuda, "is_available", lambda: False)
+
+    class DummyROCM:
+        init_calls = 0
+        shutdown_calls = 0
+
+        @classmethod
+        def rsmi_init(cls):
+            cls.init_calls += 1
+
+        @classmethod
+        def rsmi_shut_down(cls):
+            cls.shutdown_calls += 1
+
+    monkeypatch.setitem(sys.modules, "rocm_smi", DummyROCM)
+
+    assert pm._check_rocm() is True
+    assert DummyROCM.init_calls == 1
+    assert DummyROCM.shutdown_calls == 1


### PR DESCRIPTION
## Summary
- Shut down NVML and ROCm SMI vendor probes after detection so platform discovery does not leave telemetry handles open.
- Align ROCm detection with the `rsmi_init` / `rsmi_shut_down` API used by the rest of KeepGPU.
- Add guarded MPS telemetry so Mac M series reports a `macm` device with best-effort memory counters and nullable unsupported fields.
- Update AGENTS.md, README, architecture, MCP, CLI reference, and the implementation plan docs.

## Test Plan
- [x] `PYTHONPATH=src pytest tests/utilities/test_platform_manager.py tests/utilities/test_gpu_info.py -q`
- [x] `PYTHONPATH=src pytest tests -q`
- [x] `PYTHONPATH=src mkdocs build`
- [x] `pre-commit run --all-files`