### PR TITLE
[controllers] fix: back off when telemetry is unknown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ This file defines how coding agents should work in this repository.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Keep lifecycle state truthful: a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Keep utilization backoff eco-safe: when telemetry is unavailable and `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 On many clusters, idle GPUs are reaped or silently shared after a short grace period. The cost of losing your reservation (or discovering another job has taken your card) can dwarf the cost of a tiny keep-alive loop. KeepGPU is a minimal, auditable guardrail:
 
 - **Predictable** – Single-purpose controller with explicit resource knobs (VRAM size, interval, utilization backoff).
-- **Polite** – Uses NVML to read utilization and backs off when the GPU is busy.
+- **Polite** – Uses telemetry to read utilization and backs off when the GPU is busy or utilization is unavailable.
 - **Portable** – Typer/Rich CLI for humans; Python API for orchestrators and notebooks.
 - **Observable** – Structured logging and optional file logs for auditing what kept the GPU alive.
 - **Power-aware** – Uses intervalled elementwise ops instead of heavy matmul floods to present “busy” utilization while keeping power and thermals lower (see `CudaGPUController._run_relu_batch` for the loop).
@@ -73,7 +73,7 @@ Flags that matter:
 - Blocking mode knobs:
   - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
   - `--interval` (positive seconds): sleep between keep-alive bursts.
-  - `--busy-threshold`: skip work when telemetry reports higher utilization; `-1` disables utilization backoff.
+  - `--busy-threshold`: skip work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
   - `--gpu-ids`: target a non-negative subset; otherwise all visible GPUs are guarded.
 - Service mode commands:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
@@ -106,7 +106,7 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy
 ## What you get
 
 - Battle-tested keep-alive loop built on PyTorch.
-- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`.
+- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`. If utilization is unavailable and `busy_threshold` is non-negative, KeepGPU sleeps for that cycle instead of running compute.
 - CLI + API parity: same controllers power both code paths.
 - Continuous docs + CI: mkdocs + mkdocstrings build in CI to keep guidance up to date.
 
@@ -147,7 +147,7 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy
 - Dashboard: `http://127.0.0.1:8765/`
 - **Mac M series limitations:**
   - GPU utilization monitoring is not available on macOS.
-  - `busy_threshold` parameter is accepted for API compatibility but has no effect.
+  - Non-negative `busy_threshold` values therefore keep MPS in conservative sleep-only mode; set `busy_threshold=-1` to opt into unconditional keepalive compute.
   - `list-gpus` reports best-effort MPS memory counters and `null` for unsupported telemetry fields.
 - Minimal client config (stdio MCP):
   ```yaml

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -35,8 +35,10 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
    - Allocates a tensor sized by way of `vram_to_keep`.
    - Starts a daemon thread that performs intervalled lightweight elementwise batches.
    - Calls `_monitor_utilization` (by way of NVML) to detect real activity.
-4. If utilization exceeds `busy_threshold`, the worker just sleeps for one more
-   `interval`. Otherwise it runs a new batch of ops.
+4. If utilization exceeds `busy_threshold`, or if utilization is unavailable
+   while `busy_threshold` is non-negative, the worker just sleeps for one more
+   `interval`. Otherwise it runs a new batch of ops. `busy_threshold=-1` is the
+   explicit unconditional mode.
 5. When you call `release()` (or exit the context), every worker sets a stop
    event, joins the thread, and clears the device cache. Release attempts every
    worker and then raises a summary if any worker failed to stop.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -84,7 +84,7 @@ The dashboard provides:
 | `--gpu-ids` | Comma-separated non-negative GPU IDs. Omit to use all visible devices. | all |
 | `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes). | `1GiB` |
 | `--interval` | Positive seconds between keep-alive cycles. | `300` |
-| `--busy-threshold` / `--util-threshold` | Back off when utilization exceeds this value; `-1` disables utilization backoff. | `-1` |
+| `--busy-threshold` / `--util-threshold` | Back off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `-1` |
 
 ## Remote sessions
 
@@ -104,4 +104,4 @@ of `keep-gpu status`.
 - **Start cannot reach service**: run `keep-gpu serve --host 127.0.0.1 --port 8765`.
 - **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop` (or use `keep-gpu service-stop --force`).
 - **OOM during keep**: reduce `--vram` or free GPU memory before starting.
-- **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra; on Mac M series, utilization is expected to be `null`.
+- **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra. With non-negative `busy_threshold`, KeepGPU sleeps when utilization is unavailable. On Mac M series, utilization is expected to be `null`, so use `--busy-threshold -1` only when you intentionally want unconditional keepalive compute.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -81,6 +81,9 @@ The dashboard provides live telemetry, tracked session state, and start/stop con
 CUDA and ROCm devices include memory and utilization when the platform APIs are
 available. Mac M series devices report best-effort MPS memory counters and use
 `null` for unsupported fields such as utilization.
+When utilization is unavailable and `busy_threshold` is non-negative, controllers
+sleep instead of running keepalive compute; `busy_threshold=-1` is the explicit
+unconditional mode.
 Stop controls show timed-out or failed releases instead of claiming success when
 the backend keeps a session visible for follow-up cleanup. Retained session cards
 show `Releasing` or `Release failed` with the backend error detail when present.

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -53,7 +53,10 @@ with GlobalGPUController(
 ```
 
 - Each `CudaGPUController` runs in its own thread.
-- `busy_threshold` throttles the keep-alive loop when utilization spikes.
+- `busy_threshold` throttles the keep-alive loop when utilization spikes. When
+  utilization telemetry is unavailable, non-negative thresholds sleep instead of
+  running compute; use `busy_threshold=-1` only for explicit unconditional
+  keepalive work.
 - `release()` uses threads too, so all GPUs free up quickly.
 
 ## Combine with schedulers or callbacks

--- a/docs/plans/telemetry-unknown-backoff.md
+++ b/docs/plans/telemetry-unknown-backoff.md
@@ -1,0 +1,51 @@
+# Telemetry-Unknown Backoff Fix Plan
+
+## Background
+
+KeepGPU advertises polite, low-power keepalive behavior through `busy_threshold`,
+but controller behavior currently fails open when utilization telemetry is
+unavailable. CUDA maps unknown NVML utilization to `0%`, ROCm runs batches when
+`rocm-smi` is unavailable, and MPS ignores `busy_threshold` entirely.
+
+## Goal
+
+Make telemetry-unavailable cycles conservative by default: if
+`busy_threshold >= 0` and utilization cannot be measured, skip keepalive compute
+for that cycle. Preserve `busy_threshold=-1` as the explicit unconditional
+keepalive mode.
+
+## Design
+
+- CUDA: keep `_monitor_utilization()` as the telemetry boundary, but return
+  `None` when utilization is unavailable. Update `_should_run_batch()` to accept
+  `Optional[int]` and return `False` for unknown utilization unless
+  `busy_threshold < 0`.
+- ROCm: add the same decision helper and route `_query_utilization()` through
+  it so missing `rocm-smi` sleeps instead of running.
+- MPS: because there is no utilization telemetry, run compute only when
+  `busy_threshold < 0`; otherwise reserve memory and sleep between cycles.
+- Docs: update AGENTS and user docs so agents/users know that unknown telemetry
+  is eco-safe and `-1` is the opt-in unconditional mode.
+
+## Tasks
+
+- [x] Add no-GPU tests for CUDA decision behavior:
+  - unknown utilization backs off when threshold is non-negative,
+  - unknown utilization runs only when threshold is `-1`,
+  - `_monitor_utilization()` preserves `None` instead of converting it to `0`.
+- [x] Add no-GPU tests for ROCm decision behavior:
+  - unknown utilization backs off when threshold is non-negative,
+  - unknown utilization runs only when threshold is `-1`.
+- [x] Add no-GPU tests for MPS decision behavior:
+  - MPS does not run batches with non-negative threshold because telemetry is
+    unavailable,
+  - MPS runs batches when threshold is `-1`.
+- [x] Implement the minimal controller changes.
+- [x] Update `AGENTS.md`, README/docs guidance, and plan verification notes.
+- [x] Run targeted controller tests, full tests, docs build, and pre-commit.
+  - `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py tests/rocm_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py -q`: 12 passed, 6 skipped.
+  - `PYTHONPATH=$PWD/src pytest tests -q`: 81 passed, 12 skipped.
+  - `PYTHONPATH=$PWD/src mkdocs build`: passed with existing Material warning and unnav'd docs notices.
+  - `pre-commit run --all-files`: passed after Black reformatted controller files.
+- [ ] Open PR, run local subagent review, resolve all comments, and squash
+  merge only when GitHub checks and local review are clean.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,7 +46,7 @@ Starts a keep session and returns immediately with `job_id`.
 | `--gpu-ids` | all | Comma-separated GPU IDs. |
 | `--vram` | `1GiB` | Per-GPU keep memory target. |
 | `--interval` | `300` | Keep cycle interval in seconds. |
-| `--busy-threshold` / `--util-threshold` | `-1` | Backoff threshold. |
+| `--busy-threshold` / `--util-threshold` | `-1` | Back off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional custom id. |
 | `--host` | `127.0.0.1` | Service host to contact. |
 | `--port` | `8765` | Service port to contact. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,7 +23,7 @@ These options apply when you run `keep-gpu` without subcommands.
 | `--interval INTEGER` | seconds | Sleep duration between utilization checks and keep-alive batches. |
 | `--gpu-ids TEXT` | comma-separated non-negative ints | Subset of GPUs to guard (for example, `0,2`). Omit to use all visible GPUs. |
 | `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`). |
-| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | Back off when utilization is above this value; `-1` disables utilization backoff. |
+| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | Back off when utilization is above this value or unavailable; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
 
 ## Service mode

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -389,7 +389,10 @@ def main(
         -1,
         "--busy-threshold",
         "--util-threshold",
-        help="Max utilization threshold before backing off (blocking mode).",
+        help=(
+            "Back off when utilization is above this percent or telemetry is "
+            "unavailable; -1 disables utilization backoff (blocking mode)."
+        ),
     ),
 ):
     """Run blocking keep-alive mode when no subcommand is provided."""
@@ -433,7 +436,10 @@ def start(
         -1,
         "--busy-threshold",
         "--util-threshold",
-        help="Back off when utilization exceeds this percent.",
+        help=(
+            "Back off when utilization is above this percent or telemetry is "
+            "unavailable; -1 disables utilization backoff."
+        ),
     ),
     job_id: Optional[str] = typer.Option(
         None,

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -126,7 +126,9 @@ class KeepGPUServer:
             gpu_ids: GPU indices to target; None uses all available GPUs.
             vram: Human-readable VRAM size to keep (for example, "1GiB").
             interval: Seconds between controller checks/actions.
-            busy_threshold: Utilization above which the controller backs off.
+            busy_threshold: Backoff threshold. Non-negative values back off when
+                utilization is above this percent or telemetry is unavailable;
+                ``-1`` disables utilization backoff for unconditional keepalive.
             job_id: Optional session identifier; a UUID is generated if omitted.
 
         Returns:

--- a/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.session_config import validate_interval
@@ -52,3 +52,17 @@ class BaseGPUController:
         This is a placeholder for subclasses to implement their logic.
         """
         raise NotImplementedError("Subclasses must implement this method.")
+
+    @staticmethod
+    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
+        """
+        Return whether keep-alive compute should run for current utilization.
+
+        A negative busy threshold is the explicit unconditional mode. Otherwise,
+        unknown telemetry is treated conservatively as a reason to sleep.
+        """
+        if busy_threshold < 0:
+            return True
+        if gpu_utilization is None:
+            return False
+        return gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -186,9 +186,9 @@ class CudaGPUController(BaseGPUController):
                 gpu_utilization = self._monitor_utilization(self.rank)
                 if not self._should_run_batch(gpu_utilization, self.busy_threshold):
                     logger.debug(
-                        "rank %s: GPU busy (%d%%), sleeping longer",
+                        "rank %s: GPU utilization unavailable or busy (%s%%), sleeping longer",
                         self.rank,
-                        gpu_utilization,
+                        "n/a" if gpu_utilization is None else gpu_utilization,
                     )
                 else:
                     self._run_relu_batch(matrix)
@@ -232,15 +232,18 @@ class CudaGPUController(BaseGPUController):
     # Utilization monitor
     # ------------------------------------------------------------------
     @staticmethod
-    def _monitor_utilization(rank: int) -> int:
+    def _monitor_utilization(rank: int) -> Optional[int]:
         """
         Return current GPU utilization (%) for `rank`.
-        Falls back to 0 when NVML is unavailable.
+        Returns None when telemetry is unavailable.
         """
-        utilization = get_gpu_utilization(rank)
-        return utilization if utilization is not None else 0
+        return get_gpu_utilization(rank)
 
     @staticmethod
-    def _should_run_batch(gpu_utilization: int, busy_threshold: int) -> bool:
+    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
         """Return whether keep-alive compute should run for this utilization."""
-        return busy_threshold < 0 or gpu_utilization <= busy_threshold
+        if busy_threshold < 0:
+            return True
+        if gpu_utilization is None:
+            return False
+        return gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -186,9 +186,9 @@ class CudaGPUController(BaseGPUController):
                 gpu_utilization = self._monitor_utilization(self.rank)
                 if not self._should_run_batch(gpu_utilization, self.busy_threshold):
                     logger.debug(
-                        "rank %s: GPU utilization unavailable or busy (%s%%), sleeping longer",
+                        "rank %s: GPU utilization unavailable or busy (%s), sleeping longer",
                         self.rank,
-                        "n/a" if gpu_utilization is None else gpu_utilization,
+                        "n/a" if gpu_utilization is None else f"{gpu_utilization}%",
                     )
                 else:
                     self._run_relu_batch(matrix)
@@ -238,12 +238,3 @@ class CudaGPUController(BaseGPUController):
         Returns None when telemetry is unavailable.
         """
         return get_gpu_utilization(rank)
-
-    @staticmethod
-    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
-        """Return whether keep-alive compute should run for this utilization."""
-        if busy_threshold < 0:
-            return True
-        if gpu_utilization is None:
-            return False
-        return gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -41,12 +41,6 @@ class MacMGPUController(BaseGPUController):
         self._thread: Optional[threading.Thread] = None
         self._num_elements: Optional[int] = None
 
-        logger.debug(
-            "rank %s: busy_threshold=%s ignored on macOS MPS (API compatibility)",
-            self.rank,
-            self.busy_threshold,
-        )
-
     def keep(self) -> None:
         if self._thread and self._thread.is_alive():
             logger.warning("rank %s: keep thread already running", self.rank)
@@ -134,7 +128,14 @@ class MacMGPUController(BaseGPUController):
 
         while not stop_evt.is_set():
             try:
-                self._run_batch(tensor)
+                if self._should_run_batch(None, self.busy_threshold):
+                    self._run_batch(tensor)
+                else:
+                    logger.debug(
+                        "rank %s: MPS utilization unavailable; sleeping because busy_threshold=%s",
+                        self.rank,
+                        self.busy_threshold,
+                    )
                 if stop_evt.wait(self.interval):
                     break
             except RuntimeError as exc:
@@ -165,3 +166,11 @@ class MacMGPUController(BaseGPUController):
             self.rank,
             (toc - tic) * 1000 / max(1, self.iterations),
         )
+
+    @staticmethod
+    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
+        if busy_threshold < 0:
+            return True
+        if gpu_utilization is None:
+            return False
+        return gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -166,11 +166,3 @@ class MacMGPUController(BaseGPUController):
             self.rank,
             (toc - tic) * 1000 / max(1, self.iterations),
         )
-
-    @staticmethod
-    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
-        if busy_threshold < 0:
-            return True
-        if gpu_utilization is None:
-            return False
-        return gpu_utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -118,14 +118,6 @@ class RocmGPUController(BaseGPUController):
             logger.debug("ROCm utilization query failed: %s", exc)
             return None
 
-    @staticmethod
-    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
-        if busy_threshold < 0:
-            return True
-        if gpu_utilization is None:
-            return False
-        return gpu_utilization <= busy_threshold
-
     def _keep_loop(self) -> None:
         stop_evt = self._stop_evt
         if stop_evt is None:
@@ -188,9 +180,9 @@ class RocmGPUController(BaseGPUController):
                     self._run_batch(tensor)
                 else:
                     logger.debug(
-                        "rank %s: GPU utilization unavailable or busy (%s%%), sleeping",
+                        "rank %s: GPU utilization unavailable or busy (%s), sleeping",
                         self.rank,
-                        "n/a" if util is None else util,
+                        "n/a" if util is None else f"{util}%",
                     )
                 if stop_evt.wait(self.interval):
                     break

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -118,6 +118,14 @@ class RocmGPUController(BaseGPUController):
             logger.debug("ROCm utilization query failed: %s", exc)
             return None
 
+    @staticmethod
+    def _should_run_batch(gpu_utilization: Optional[int], busy_threshold: int) -> bool:
+        if busy_threshold < 0:
+            return True
+        if gpu_utilization is None:
+            return False
+        return gpu_utilization <= busy_threshold
+
     def _keep_loop(self) -> None:
         stop_evt = self._stop_evt
         if stop_evt is None:
@@ -176,14 +184,14 @@ class RocmGPUController(BaseGPUController):
         while not stop_evt.is_set():
             try:
                 util = self._query_utilization()
-                if (
-                    util is not None
-                    and self.busy_threshold >= 0
-                    and util > self.busy_threshold
-                ):
-                    logger.debug("rank %s: GPU busy (%d%%), sleeping", self.rank, util)
-                else:
+                if self._should_run_batch(util, self.busy_threshold):
                     self._run_batch(tensor)
+                else:
+                    logger.debug(
+                        "rank %s: GPU utilization unavailable or busy (%s%%), sleeping",
+                        self.rank,
+                        "n/a" if util is None else util,
+                    )
                 if stop_evt.wait(self.interval):
                     break
             except RuntimeError as exc:

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -9,11 +9,22 @@ from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
 def test_negative_busy_threshold_disables_backoff_without_gpu():
     assert CudaGPUController._should_run_batch(0, -1) is True
     assert CudaGPUController._should_run_batch(100, -1) is True
+    assert CudaGPUController._should_run_batch(None, -1) is True
 
 
 def test_non_negative_busy_threshold_backs_off_above_limit_without_gpu():
     assert CudaGPUController._should_run_batch(10, 10) is True
     assert CudaGPUController._should_run_batch(11, 10) is False
+    assert CudaGPUController._should_run_batch(None, 10) is False
+
+
+def test_cuda_monitor_preserves_unknown_utilization(monkeypatch):
+    monkeypatch.setattr(
+        "keep_gpu.single_gpu_controller.cuda_gpu_controller.get_gpu_utilization",
+        lambda rank: None,
+    )
+
+    assert CudaGPUController._monitor_utilization(0) is None
 
 
 def test_cuda_controller_rejects_busy_threshold_below_minus_one_without_gpu():

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -1,0 +1,9 @@
+from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
+
+
+def test_macm_unknown_utilization_backs_off_when_threshold_enabled():
+    assert MacMGPUController._should_run_batch(None, 10) is False
+
+
+def test_macm_unknown_utilization_runs_when_backoff_disabled():
+    assert MacMGPUController._should_run_batch(None, -1) is True

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -1,0 +1,9 @@
+from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
+
+
+def test_rocm_unknown_utilization_backs_off_when_threshold_enabled():
+    assert RocmGPUController._should_run_batch(None, 10) is False
+
+
+def test_rocm_unknown_utilization_runs_when_backoff_disabled():
+    assert RocmGPUController._should_run_batch(None, -1) is True


### PR DESCRIPTION
## Summary
- Preserve unknown utilization as unknown instead of treating it as 0%.
- Make CUDA, ROCm, and MPS sleep when telemetry is unavailable and busy_threshold is non-negative.
- Document the eco-safe policy and keep busy_threshold=-1 as the explicit unconditional mode.

## Test Plan
- PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py tests/rocm_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py -q
- PYTHONPATH=$PWD/src pytest tests -q
- PYTHONPATH=$PWD/src mkdocs build
- pre-commit run --all-files

## Local Review
- Pending fresh local subagent review before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified utilization-based backoff behavior across the app: when telemetry is unavailable and the threshold is non-negative, keep-alive work is skipped for that cycle.
  * Added explicit `-1` handling as an unconditional mode that continues work regardless of utilization.
* **Bug Fixes**
  * Improved controller behavior on CUDA, ROCm, and macOS MPS so unknown utilization no longer gets treated like zero activity.
* **Documentation**
  * Updated CLI, API, architecture, and README guidance to reflect the new threshold semantics and telemetry-unavailable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->