### PR TITLE
[cli] fix: verify service daemon ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ This file defines how coding agents should work in this repository.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Keep lifecycle state truthful: a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
 - Keep utilization backoff eco-safe: when telemetry is unavailable and `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Flags that matter:
   - `keep-gpu start`: create keep session and return immediately.
   - `keep-gpu status`: inspect tracked sessions, including in-progress or failed releases.
   - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
-  - `keep-gpu service-stop`: stop auto-started local daemon.
+  - `keep-gpu service-stop`: stop the ownership-verified auto-started local daemon.
   - `keep-gpu list-gpus`: fetch telemetry from local service.
 
 ## Embed in Python

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -48,7 +48,9 @@ keep-gpu stop --all
 keep-gpu service-stop
 ```
 
-If sessions are still active, stop them first or use `--force`.
+If sessions are still active, stop them first or use `--force`. Force mode skips
+the active-session RPC check, but it still stops only an ownership-verified
+daemon that KeepGPU auto-started.
 
 ### List telemetry
 
@@ -102,6 +104,6 @@ of `keep-gpu status`.
 
 - **`--gpu-ids` parse error**: use only comma-separated integers (`0,1`).
 - **Start cannot reach service**: run `keep-gpu serve --host 127.0.0.1 --port 8765`.
-- **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop` (or use `keep-gpu service-stop --force`).
+- **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop`. Use `keep-gpu service-stop --force` only for an unresponsive auto-started daemon; it still refuses to signal a PID that KeepGPU cannot verify as its own.
 - **OOM during keep**: reduce `--vram` or free GPU memory before starting.
 - **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra. With non-negative `busy_threshold`, KeepGPU sleeps when utilization is unavailable. On Mac M series, utilization is expected to be `null`, so use `--busy-threshold -1` only when you intentionally want unconditional keepalive compute.

--- a/docs/plans/service-pid-ownership.md
+++ b/docs/plans/service-pid-ownership.md
@@ -1,0 +1,43 @@
+# Service PID Ownership Implementation Plan
+
+## Background
+
+Audit agents found that `keep-gpu stop --all` can convert any `RuntimeError`
+from the service stop RPC into a daemon kill attempt when a PID file exists.
+The fallback also reports success even if `_stop_service_process()` refuses to
+stop the process. Separately, the current PID file stores only a bare integer,
+so a later PID reuse or command-line substring spoof can look like a managed
+KeepGPU daemon.
+
+Server-side duplicate `job_id` startup races and stop-all release latency are
+tracked as separate issues and are intentionally out of scope for this branch.
+
+## Goal
+
+Make service shutdown humane and ownership-safe: fallback force-stop is allowed
+only for unreachable service failures, and no CLI path may signal a daemon
+unless the auto-start ownership record verifies the process.
+
+## Solution
+
+- Store a structured daemon ownership record instead of only a bare PID.
+- Verify PID, host, port, command identity, user id, and process start identity
+  when available before signaling a process.
+- Keep `--force` as "skip active-session RPC checks", not "skip ownership".
+- Restrict `stop --all` fallback to service-unreachable/timeout failures.
+- Report an error instead of a success payload when fallback cannot verify or
+  stop the managed daemon.
+
+## Todo
+
+- [x] Add failing CLI tests for non-unreachable RPC errors, failed fallback
+      stops, unmanaged PID fallback, substring-spoof command lines, and
+      structured ownership records.
+- [x] Implement structured PID ownership helpers in `src/keep_gpu/cli.py`.
+- [x] Narrow fallback logic and require `_stop_service_process()` success before
+      reporting force-stop.
+- [x] Update `AGENTS.md`, CLI guide, and CLI reference docs with the ownership
+      rule.
+- [x] Run targeted CLI tests, full tests, docs build, and pre-commit.
+- [ ] Open a GitHub PR, run local subagent review, resolve all comments, then
+      squash merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,12 +73,12 @@ Returns GPU telemetry from service.
 
 ### `keep-gpu service-stop`
 
-Stops local daemon process created by auto-start logic.
+Stops the ownership-verified local daemon process created by auto-start logic.
 
 | Option | Description |
 | --- | --- |
 | `--host`, `--port` | Service host/port. |
-| `--force` | Stop daemon even if tracked sessions still exist. |
+| `--force` | Skip active-session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
 
 ## Service HTTP endpoints
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -30,6 +31,18 @@ console = Console()
 logger = setup_logger(__name__)
 
 
+class ServiceUnreachableError(RuntimeError):
+    """Raised when the local service cannot be reached."""
+
+
+class ServiceResponseError(RuntimeError):
+    """Raised when the local service responds with an invalid HTTP payload."""
+
+
+class ServiceRPCError(RuntimeError):
+    """Raised when the local service returns a JSON-RPC error."""
+
+
 def _runtime_dir() -> Path:
     runtime_dir = Path.home() / ".keepgpu"
     runtime_dir.mkdir(parents=True, exist_ok=True)
@@ -44,18 +57,126 @@ def _service_pid_path(host: str, port: int) -> Path:
     return _runtime_dir() / f"service-{host.replace('.', '_')}-{port}.pid"
 
 
-def _read_service_pid(host: str, port: int) -> Optional[int]:
+def _service_command(host: str, port: int) -> List[str]:
+    return [
+        sys.executable,
+        "-m",
+        "keep_gpu.mcp.server",
+        "--mode",
+        "http",
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+
+
+def _process_start_identity(pid: int) -> Optional[str]:
+    try:
+        stat_path = Path(f"/proc/{pid}/stat")
+        if not stat_path.exists():
+            return None
+        raw_stat = stat_path.read_text(encoding="utf-8", errors="replace")
+        after_comm = raw_stat.rsplit(")", 1)[1].strip().split()
+        return after_comm[19]
+    except Exception:
+        return None
+
+
+def _process_uid(pid: int) -> Optional[int]:
+    try:
+        return Path(f"/proc/{pid}").stat().st_uid
+    except Exception:
+        try:
+            out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "uid="],
+                text=True,
+            )
+            return int(out.strip())
+        except Exception:
+            return None
+
+
+def _process_cmdline(pid: int) -> List[str]:
+    try:
+        proc_cmdline = Path(f"/proc/{pid}/cmdline")
+        if proc_cmdline.exists():
+            raw = proc_cmdline.read_bytes()
+            return [
+                part.decode("utf-8", errors="replace")
+                for part in raw.split(b"\x00")
+                if part
+            ]
+        command = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "command="],
+            text=True,
+        ).strip()
+        return shlex.split(command)
+    except Exception:
+        return []
+
+
+def _is_keepgpu_service_argv(
+    argv: List[str], host: Optional[str] = None, port: Optional[int] = None
+) -> bool:
+    expected_tail = [
+        "-m",
+        "keep_gpu.mcp.server",
+        "--mode",
+        "http",
+    ]
+    if host is not None and port is not None:
+        expected_tail.extend(["--host", host, "--port", str(port)])
+    if len(argv) != len(expected_tail) + 1:
+        return False
+    return argv[1:] == expected_tail
+
+
+def _build_service_pid_record(host: str, port: int, pid: int) -> Dict[str, Any]:
+    return {
+        "pid": pid,
+        "host": host,
+        "port": port,
+        "argv": _service_command(host, port),
+        "uid": _process_uid(pid),
+        "start_time": _process_start_identity(pid),
+        "created_at": time.time(),
+    }
+
+
+def _read_service_pid_record(host: str, port: int) -> Optional[Dict[str, Any]]:
     pid_path = _service_pid_path(host, port)
     if not pid_path.exists():
         return None
     try:
-        return int(pid_path.read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
+        raw = pid_path.read_text(encoding="utf-8").strip()
+        payload = json.loads(raw)
+    except (OSError, json.JSONDecodeError, ValueError):
         return None
+    if isinstance(payload, int):
+        return {"pid": payload, "legacy": True}
+    if not isinstance(payload, dict):
+        return None
+    try:
+        payload["pid"] = int(payload["pid"])
+        payload["port"] = int(payload["port"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return payload
+
+
+def _read_service_pid(host: str, port: int) -> Optional[int]:
+    record = _read_service_pid_record(host, port)
+    if record is None:
+        return None
+    return record["pid"]
 
 
 def _write_service_pid(host: str, port: int, pid: int) -> None:
-    _service_pid_path(host, port).write_text(str(pid), encoding="utf-8")
+    record = _build_service_pid_record(host, port, pid)
+    _service_pid_path(host, port).write_text(
+        json.dumps(record, sort_keys=True), encoding="utf-8"
+    )
 
 
 def _clear_service_pid(host: str, port: int) -> None:
@@ -138,15 +259,17 @@ def _http_json_request(
             try:
                 return json.loads(body)
             except (json.JSONDecodeError, ValueError) as exc:
-                raise RuntimeError(
+                raise ServiceResponseError(
                     f"Non-JSON response from service endpoint: {url}"
                 ) from exc
     except HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
         detail = body or str(exc)
-        raise RuntimeError(f"Service HTTP error: {detail}") from exc
+        raise ServiceResponseError(f"Service HTTP error: {detail}") from exc
     except (URLError, TimeoutError, OSError) as exc:
-        raise RuntimeError(f"Cannot reach KeepGPU service at {url}: {exc}") from exc
+        raise ServiceUnreachableError(
+            f"Cannot reach KeepGPU service at {url}: {exc}"
+        ) from exc
 
 
 def _service_available(host: str, port: int) -> bool:
@@ -170,20 +293,7 @@ def _start_service_process(host: str, port: int) -> int:
         else:
             popen_kwargs["start_new_session"] = True
 
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "keep_gpu.mcp.server",
-                "--mode",
-                "http",
-                "--host",
-                host,
-                "--port",
-                str(port),
-            ],
-            **popen_kwargs,
-        )
+        process = subprocess.Popen(_service_command(host, port), **popen_kwargs)
     _write_service_pid(host, port, process.pid)
     return process.pid
 
@@ -212,12 +322,44 @@ def _ensure_service_running(host: str, port: int, auto_start: bool = True) -> bo
     )
 
 
-def _stop_service_process(host: str, port: int, timeout: float = 3.0) -> bool:
-    pid = _read_service_pid(host, port)
-    if pid is None:
+def _record_matches_running_process(
+    record: Dict[str, Any], host: str, port: int
+) -> bool:
+    if record.get("legacy"):
+        return False
+    if "uid" not in record or "start_time" not in record:
+        return False
+    if record.get("host") != host or record.get("port") != port:
+        return False
+    argv = record.get("argv")
+    if not isinstance(argv, list) or not all(isinstance(part, str) for part in argv):
+        return False
+    if not _is_keepgpu_service_argv(argv, host, port):
+        return False
+    pid = record["pid"]
+    if _process_cmdline(pid) != argv:
         return False
 
-    if not _is_managed_keepgpu_pid(pid):
+    recorded_uid = record.get("uid")
+    current_uid = _process_uid(pid)
+    if recorded_uid != current_uid:
+        return False
+
+    recorded_start = record.get("start_time")
+    current_start = _process_start_identity(pid)
+    if recorded_start != current_start:
+        return False
+
+    return True
+
+
+def _stop_service_process(host: str, port: int, timeout: float = 3.0) -> bool:
+    record = _read_service_pid_record(host, port)
+    if record is None:
+        return False
+    pid = record["pid"]
+
+    if not _record_matches_running_process(record, host, port):
         _clear_service_pid(host, port)
         return False
 
@@ -237,33 +379,25 @@ def _stop_service_process(host: str, port: int, timeout: float = 3.0) -> bool:
             return True
         time.sleep(0.1)
 
+    if not _record_matches_running_process(record, host, port):
+        _clear_service_pid(host, port)
+        return False
+
     try:
         os.kill(pid, signal.SIGKILL)
     except OSError:
         _clear_service_pid(host, port)
         return False
-    time.sleep(0.1)
-    _clear_service_pid(host, port)
-    return True
-
-
-def _is_managed_keepgpu_pid(pid: int) -> bool:
-    try:
-        proc_cmdline = Path(f"/proc/{pid}/cmdline")
-        if proc_cmdline.exists():
-            cmdline = proc_cmdline.read_text(encoding="utf-8", errors="replace")
-            cmdline = cmdline.replace("\x00", " ")
-        else:
-            cmdline = subprocess.check_output(
-                ["ps", "-p", str(pid), "-o", "command="],
-                text=True,
-            ).strip()
-    except Exception:
-        return False
-
-    return (
-        "keep_gpu.mcp.server" in cmdline and "--mode" in cmdline and "http" in cmdline
-    )
+    deadline = time.time() + max(0.5, min(timeout, 3.0))
+    while time.time() < deadline:
+        if not _pid_alive(pid):
+            _clear_service_pid(host, port)
+            return True
+        if not _record_matches_running_process(record, host, port):
+            _clear_service_pid(host, port)
+            return False
+        time.sleep(0.1)
+    return False
 
 
 def _rpc_call(
@@ -283,27 +417,41 @@ def _rpc_call(
     )
     if "error" in response:
         error = response["error"]
-        raise RuntimeError(error.get("message", str(error)))
+        raise ServiceRPCError(error.get("message", str(error)))
     return response.get("result", {})
+
+
+def _is_service_unreachable_error(exc: RuntimeError) -> bool:
+    if isinstance(exc, ServiceUnreachableError):
+        return True
+    if isinstance(exc, (ServiceRPCError, ServiceResponseError)):
+        return False
+    message = str(exc).lower()
+    return "cannot reach keepgpu service" in message or "timed out" in message
 
 
 def _stop_all_sessions_with_fallback(host: str, port: int) -> Dict[str, Any]:
     try:
         return _rpc_call("stop_keep", {}, host, port, timeout=45.0)
     except RuntimeError as exc:
+        if not _is_service_unreachable_error(exc):
+            raise
         managed_pid = _read_service_pid(host, port)
         if managed_pid and _pid_alive(managed_pid):
-            _stop_service_process(host, port)
-            return {
-                "stopped": [],
-                "timed_out": [],
-                "failed": [],
-                "errors": {},
-                "message": (
-                    "Service stop RPC timed out; force-stopped local daemon "
-                    f"pid={managed_pid}. Reserved VRAM should be released by process exit."
-                ),
-            }
+            if _stop_service_process(host, port):
+                return {
+                    "stopped": [],
+                    "timed_out": [],
+                    "failed": [],
+                    "errors": {},
+                    "message": (
+                        "Service stop RPC timed out; force-stopped local daemon "
+                        f"pid={managed_pid}. Reserved VRAM should be released by process exit."
+                    ),
+                }
+            raise RuntimeError(
+                f"{exc}. No ownership-verified daemon could be force-stopped."
+            ) from exc
         raise RuntimeError(
             f"{exc}. If service is unresponsive, run `keep-gpu service-stop --force`."
         ) from exc

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -216,6 +216,237 @@ def test_stop_all_fallback_force_stops_managed_daemon(monkeypatch):
     assert payload["errors"] == {}
 
 
+def test_stop_all_does_not_fallback_for_rpc_application_error(monkeypatch):
+    called = {"stop_process": False}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        raise RuntimeError("validation failed")
+
+    def fake_stop_process(host, port):
+        called["stop_process"] = True
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 1
+    assert "validation failed" in result.output
+    assert "force-stopped local daemon" not in result.output
+    assert called["stop_process"] is False
+
+
+def test_stop_all_fallback_requires_stop_process_success(monkeypatch):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        raise RuntimeError(
+            "Cannot reach KeepGPU service at http://127.0.0.1:8765/rpc: timed out"
+        )
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_stop_service_process", lambda host, port: False)
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 1
+    assert "Cannot reach KeepGPU service" in result.output
+    assert "ownership-verified daemon could be force-stopped" in result.output
+    assert "force-stopped local daemon" not in result.output
+
+
+def test_process_uid_uses_ps_when_proc_uid_is_unavailable(monkeypatch):
+    class MissingProcPath:
+        def __init__(self, _path):
+            pass
+
+        def stat(self):
+            raise OSError("no proc")
+
+    monkeypatch.setattr(cli, "Path", MissingProcPath)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "1001\n",
+    )
+
+    assert cli._process_uid(4321) == 1001
+
+
+def test_process_uid_returns_none_when_target_uid_is_unknown(monkeypatch):
+    class MissingProcPath:
+        def __init__(self, _path):
+            pass
+
+        def stat(self):
+            raise OSError("no proc")
+
+    monkeypatch.setattr(cli, "Path", MissingProcPath)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("ps failed")),
+    )
+
+    assert cli._process_uid(4321) is None
+
+
+def test_stop_service_process_requires_structured_ownership_record(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    cli._service_pid_path("127.0.0.1", 8765).write_text("4321", encoding="utf-8")
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+
+
+def test_stop_service_process_rejects_record_missing_identity(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "argv": cli._service_command("127.0.0.1", 8765),
+    }
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+
+
+def test_stop_service_process_rejects_unknown_current_start_identity(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: None)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+
+
+def test_stop_service_process_stops_matching_owned_daemon(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+
+    alive = {"value": True}
+    kills = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        alive["value"] = False
+
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: alive["value"])
+    monkeypatch.setattr(cli.os, "kill", fake_kill)
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0.5)
+
+    assert stopped is True
+    assert kills == [(4321, cli.signal.SIGTERM)]
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
+def test_stop_service_process_rechecks_ownership_before_sigkill(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+
+    cmdline = {"value": cli._service_command("127.0.0.1", 8765)}
+    monkeypatch.setattr(cli, "_process_cmdline", lambda pid: cmdline["value"])
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        if sig == cli.signal.SIGTERM:
+            cmdline["value"] = ["python", "other.py"]
+
+    monkeypatch.setattr(cli.os, "kill", fake_kill)
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == [(4321, cli.signal.SIGTERM)]
+
+
+def test_stop_service_process_confirms_sigkill_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == [(4321, cli.signal.SIGTERM), (4321, cli.signal.SIGKILL)]
+    assert cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
+def test_write_service_pid_stores_ownership_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+
+    payload = json.loads(
+        cli._service_pid_path("127.0.0.1", 8765).read_text(encoding="utf-8")
+    )
+    assert payload["pid"] == 4321
+    assert payload["host"] == "127.0.0.1"
+    assert payload["port"] == 8765
+    assert payload["argv"] == cli._service_command("127.0.0.1", 8765)
+    assert payload["uid"] == cli._process_uid(4321)
+    assert "start_time" in payload
+    assert "created_at" in payload
+
+
 def test_service_stop_force_skips_rpc(monkeypatch):
     called = {"rpc": 0}
 
@@ -267,10 +498,12 @@ def test_http_json_request_wraps_non_json_response(monkeypatch):
         assert "Non-JSON response from service endpoint" in str(exc)
 
 
-def test_stop_service_process_rejects_unmanaged_pid(monkeypatch):
-    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 4321)
-    monkeypatch.setattr(cli, "_is_managed_keepgpu_pid", lambda pid: False)
-    monkeypatch.setattr(cli, "_clear_service_pid", lambda host, port: None)
+def test_stop_service_process_rejects_mismatched_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(cli, "_process_cmdline", lambda pid: ["python", "other.py"])
     monkeypatch.setattr(
         cli.os,
         "kill",


### PR DESCRIPTION
## Summary
- store structured ownership records for auto-started service daemons instead of bare PID files
- require ownership verification before service-stop, force-stop, or stop-all fallback can signal a PID
- restrict stop-all fallback to unreachable/timeout service failures and report errors when fallback cannot verify a daemon
- update AGENTS/docs and add a branch plan for the PID ownership fix

## Out of scope
- server-side duplicate job_id startup races and stop-all release latency are tracked for a separate branch/PR

## Verification
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q
- PYTHONPATH=$PWD/src pytest tests -q
- PYTHONPATH=$PWD/src mkdocs build
- pre-commit run --all-files