### PR TITLE
[mcp] fix: reserve job ids during startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ This file defines how coding agents should work in this repository.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Keep lifecycle state truthful: a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
+- Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
+- Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
 - Keep utilization backoff eco-safe: when telemetry is unavailable and `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,15 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy
   curl http://127.0.0.1:8765/health
   curl http://127.0.0.1:8765/api/sessions
   ```
-- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info).
+- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). Custom `job_id` values must be unique across active and starting sessions.
 - Stop responses distinguish completed cleanup from partial cleanup:
   `stopped` means released, while `timed_out` sessions remain visible as
   `stopping` until background cleanup completes and `failed` sessions remain
   visible with `state` and `last_error`.
+- Stop requests wait for in-progress starts to settle, so a session that is
+  still starting is not reported as missing or skipped by stop-all.
+- Stop-all only covers sessions active or already starting when that request
+  begins; later concurrent starts belong to a later stop request.
 - Dashboard cards mirror that lifecycle state so a retained session shows
   `Releasing` or `Release failed` instead of being presented as a fully active
   keepalive.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -37,6 +37,10 @@ Methods:
 - `status(job_id?)`
 - `list_gpus()`
 
+Custom `job_id` values are unique across active and starting sessions. If a
+duplicate arrives while the original start is still creating controller work,
+the duplicate is rejected before another controller begins keep-alive work.
+
 `stop_keep` returns additive outcome fields:
 
 ```json
@@ -49,6 +53,12 @@ release later succeeds, the session is removed; if it fails, the session remains
 visible with `state="stop_failed"` and `last_error` describing what happened. A
 job id only appears in `stopped` after cleanup has completed within the stop
 request timeout.
+
+If `stop_keep` arrives while a matching session is still starting, the service
+waits for startup to settle before deciding whether the job exists. Stop-all
+requests also wait for in-progress starts before taking their session snapshot.
+For stop-all, starts that begin after that request's initial snapshot are not
+stopped by that request.
 
 ## REST quick examples
 

--- a/docs/plans/session-start-reservation.md
+++ b/docs/plans/session-start-reservation.md
@@ -1,0 +1,44 @@
+# Session Start Reservation Implementation Plan
+
+## Background
+
+`KeepGPUServer.start_keep()` checks whether a `job_id` is active, releases the
+session lock, starts controller work, then checks the map again. Two concurrent
+requests with the same custom `job_id` can both start controller work; one only
+loses after keep-alive work has already begun. The losing cleanup path also
+risks doing controller release work while holding the session lock.
+
+Stop-all release parallelism is a separate issue and is intentionally out of
+scope for this branch.
+
+## Goal
+
+Reject duplicate custom `job_id` requests while the first request is still
+starting, before the duplicate constructs or starts any controller work.
+
+## Solution
+
+- Add a `_starting_job_ids` reservation set guarded by `_sessions_lock`.
+- Reserve the final `job_id` before constructing or starting a controller.
+- Reject duplicates when a `job_id` is either active or reserved.
+- Remove the reservation in all success and failure paths.
+- Use a condition on the session lock so targeted and stop-all requests wait
+  for starting sessions to settle before deciding what can be released.
+- Keep controller `keep()` and `release()` work outside `_sessions_lock`.
+
+## Todo
+
+- [x] Add failing server tests showing a concurrent duplicate `job_id` is
+      rejected before the duplicate controller starts.
+- [x] Add a cleanup test showing a failed start removes the reservation so the
+      same `job_id` can be retried.
+- [x] Add stop tests showing targeted and stop-all requests do not miss a
+      session that is still starting.
+- [x] Add stop-all snapshot coverage so starts created after stop-all begins
+      are not waited on or stopped by that request.
+- [x] Implement `_starting_job_ids` reservation in `KeepGPUServer.start_keep()`.
+- [x] Update `AGENTS.md` and service docs for custom `job_id` uniqueness during
+      active and starting sessions.
+- [x] Run targeted MCP tests, full tests, docs build, and pre-commit.
+- [ ] Open a GitHub PR, run local subagent review, resolve all comments, then
+      squash merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,7 +47,7 @@ Starts a keep session and returns immediately with `job_id`.
 | `--vram` | `1GiB` | Per-GPU keep memory target. |
 | `--interval` | `300` | Keep cycle interval in seconds. |
 | `--busy-threshold` / `--util-threshold` | `-1` | Back off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
-| `--job-id` | auto | Optional custom id. |
+| `--job-id` | auto | Optional custom id. Must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact. |
 | `--port` | `8765` | Service port to contact. |
 | `--auto-start/--no-auto-start` | `--auto-start` | Auto-start local service if unavailable. |
@@ -66,6 +66,11 @@ Starts a keep session and returns immediately with `job_id`.
 | `--job-id` | Stop one session. |
 | `--all` | Stop all sessions. |
 | `--host`, `--port` | Service host/port. |
+
+Stop waits for in-progress starts to settle before returning `not found` or
+taking the stop-all snapshot, so starting sessions are not silently skipped.
+For `--all`, starts that begin after that command's initial snapshot are not
+stopped by that command.
 
 ### `keep-gpu list-gpus`
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -64,7 +64,9 @@ class KeepGPUServer:
         controller_factory: Optional[Callable[..., GlobalGPUController]] = None,
     ) -> None:
         self._sessions: Dict[str, Session] = {}
+        self._starting_job_ids: set[str] = set()
         self._sessions_lock = threading.RLock()
+        self._sessions_cond = threading.Condition(self._sessions_lock)
         self._controller_factory = controller_factory or GlobalGPUController
         atexit.register(self.shutdown)
 
@@ -144,20 +146,26 @@ class KeepGPUServer:
 
         job_id = job_id or str(uuid.uuid4())
         with self._sessions_lock:
-            if job_id in self._sessions:
+            if job_id in self._sessions or job_id in self._starting_job_ids:
                 raise ValueError(f"job_id {job_id} already exists")
+            self._starting_job_ids.add(job_id)
 
-        controller = self._controller_factory(
-            gpu_ids=gpu_ids,
-            interval=interval,
-            vram_to_keep=vram,
-            busy_threshold=busy_threshold,
-        )
-        controller.keep()
+        try:
+            controller = self._controller_factory(
+                gpu_ids=gpu_ids,
+                interval=interval,
+                vram_to_keep=vram,
+                busy_threshold=busy_threshold,
+            )
+            controller.keep()
+        except Exception:
+            with self._sessions_lock:
+                self._starting_job_ids.discard(job_id)
+                self._sessions_cond.notify_all()
+            raise
+
         with self._sessions_lock:
-            if job_id in self._sessions:
-                controller.release()
-                raise ValueError(f"job_id {job_id} already exists")
+            self._starting_job_ids.discard(job_id)
             self._sessions[job_id] = Session(
                 controller=controller,
                 params={
@@ -167,6 +175,7 @@ class KeepGPUServer:
                     "busy_threshold": busy_threshold,
                 },
             )
+            self._sessions_cond.notify_all()
         logger.info("Started keep session %s on GPUs %s", job_id, gpu_ids)
         return {"job_id": job_id}
 
@@ -240,6 +249,8 @@ class KeepGPUServer:
         """
         if job_id:
             with self._sessions_lock:
+                while job_id in self._starting_job_ids:
+                    self._sessions_cond.wait()
                 session = self._sessions.get(job_id)
                 if session and session.state == "stopping":
                     result = self._empty_stop_result()
@@ -288,6 +299,9 @@ class KeepGPUServer:
             return result
 
         with self._sessions_lock:
+            starting_to_wait_for = set(self._starting_job_ids)
+            while starting_to_wait_for & self._starting_job_ids:
+                self._sessions_cond.wait()
             session_items = list(self._sessions.items())
             releasable_items = []
             result = self._empty_stop_result()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -60,9 +60,10 @@ def test_start_rejects_negative_gpu_id():
 
     try:
         server.start_keep(gpu_ids=[0, -1])
-        assert False, "Expected ValueError"
     except ValueError as exc:
         assert "gpu_ids must contain non-negative integers" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
 
     assert server.status()["active_jobs"] == []
 
@@ -137,6 +138,288 @@ def test_status_all():
     assert job_statuses[job_a]["params"]["gpu_ids"] == [0]
     assert job_statuses[job_b]["params"]["gpu_ids"] == [1]
     assert "controller" not in job_statuses[job_a]
+
+
+def test_concurrent_duplicate_job_id_rejected_before_second_keep():
+    first_keep_entered = threading.Event()
+    first_keep_release = threading.Event()
+    controllers = []
+    keep_calls = []
+    first_result = {}
+
+    class SlowFirstController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.index = len(controllers) + 1
+            controllers.append(self)
+
+        def keep(self):
+            keep_calls.append(self.index)
+            self.kept = True
+            if self.index == 1:
+                first_keep_entered.set()
+                first_keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: SlowFirstController(**kwargs))
+    )
+
+    def start_first():
+        try:
+            first_result["value"] = server.start_keep(job_id="shared-job")
+        except Exception as exc:  # pragma: no cover - failure diagnostic
+            first_result["error"] = exc
+
+    thread = threading.Thread(target=start_first)
+    thread.start()
+    assert first_keep_entered.wait(timeout=1.0)
+
+    second_error = None
+    try:
+        try:
+            server.start_keep(job_id="shared-job")
+        except ValueError as exc:
+            second_error = exc
+    finally:
+        first_keep_release.set()
+        thread.join(timeout=1.0)
+
+    assert isinstance(second_error, ValueError)
+    assert "job_id shared-job already exists" in str(second_error)
+    assert len(controllers) == 1
+    assert keep_calls == [1]
+    assert first_result["value"] == {"job_id": "shared-job"}
+    assert server.status("shared-job")["active"] is True
+
+
+def test_failed_start_releases_job_id_reservation():
+    attempts = 0
+
+    class FailsOnceController(DummyController):
+        def keep(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("start failed")
+            self.kept = True
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: FailsOnceController(**kwargs))
+    )
+
+    try:
+        server.start_keep(job_id="retry-job")
+    except RuntimeError as exc:
+        assert "start failed" in str(exc)
+    else:
+        raise AssertionError("Expected first start to fail")
+
+    result = server.start_keep(job_id="retry-job")
+
+    assert result == {"job_id": "retry-job"}
+    assert attempts == 2
+    assert server.status("retry-job")["active"] is True
+
+
+def test_factory_failure_releases_job_id_reservation():
+    attempts = 0
+
+    def factory(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("factory failed")
+        return DummyController(**kwargs)
+
+    server = KeepGPUServer(controller_factory=cast(Any, factory))
+
+    try:
+        server.start_keep(job_id="factory-retry-job")
+    except RuntimeError as exc:
+        assert "factory failed" in str(exc)
+    else:
+        raise AssertionError("Expected first start to fail")
+
+    result = server.start_keep(job_id="factory-retry-job")
+
+    assert result == {"job_id": "factory-retry-job"}
+    assert attempts == 2
+    assert server.status("factory-retry-job")["active"] is True
+
+
+def test_stop_keep_waits_for_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    stop_waiting_for_startup = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class SlowStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: SlowStartController(**kwargs))
+    )
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    def start_job():
+        start_result["value"] = server.start_keep(job_id="starting-job")
+
+    def stop_job():
+        stop_result["value"] = server.stop_keep("starting-job")
+
+    start_thread = threading.Thread(target=start_job)
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(target=stop_job)
+    stop_thread.start()
+    assert stop_waiting_for_startup.wait(timeout=1.0)
+    keep_release.set()
+
+    start_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+    assert stop_result["value"]["stopped"] == ["starting-job"]
+    assert controllers[0].released is True
+    assert server.status("starting-job")["active"] is False
+
+
+def test_stop_all_waits_for_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    stop_waiting_for_startup = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class SlowStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: SlowStartController(**kwargs))
+    )
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    def start_job():
+        start_result["value"] = server.start_keep(job_id="starting-job")
+
+    def stop_all():
+        stop_result["value"] = server.stop_keep()
+
+    start_thread = threading.Thread(target=start_job)
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(target=stop_all)
+    stop_thread.start()
+    assert stop_waiting_for_startup.wait(timeout=1.0)
+    keep_release.set()
+
+    start_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+    assert stop_result["value"]["stopped"] == ["starting-job"]
+    assert controllers[0].released is True
+    assert server.status("starting-job")["active"] is False
+
+
+def test_stop_all_waits_only_for_sessions_starting_at_snapshot(monkeypatch):
+    keep_entered = [threading.Event(), threading.Event()]
+    keep_release = [threading.Event(), threading.Event()]
+    stop_waiting_for_startup = threading.Event()
+    stop_completed = threading.Event()
+    controllers = []
+    start_results = {}
+    stop_result = {}
+
+    class SlowStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.index = len(controllers)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered[self.index].set()
+            keep_release[self.index].wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: SlowStartController(**kwargs))
+    )
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    def start_job(job_id):
+        start_results[job_id] = server.start_keep(job_id=job_id)
+
+    def stop_all():
+        stop_result["value"] = server.stop_keep()
+        stop_completed.set()
+
+    first_start_thread = threading.Thread(target=start_job, args=("first-job",))
+    first_start_thread.start()
+    assert keep_entered[0].wait(timeout=1.0)
+
+    stop_thread = threading.Thread(target=stop_all)
+    stop_thread.start()
+    assert stop_waiting_for_startup.wait(timeout=1.0)
+
+    second_start_thread = threading.Thread(target=start_job, args=("second-job",))
+    second_start_thread.start()
+    assert keep_entered[1].wait(timeout=1.0)
+
+    keep_release[0].set()
+    first_start_thread.join(timeout=1.0)
+    assert stop_completed.wait(timeout=1.0)
+
+    assert start_results["first-job"] == {"job_id": "first-job"}
+    assert stop_result["value"]["stopped"] == ["first-job"]
+    assert controllers[0].released is True
+    assert controllers[1].released is False
+
+    keep_release[1].set()
+    second_start_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert start_results["second-job"] == {"job_id": "second-job"}
+    assert server.status("first-job")["active"] is False
+    assert server.status("second-job")["active"] is True
+    server.stop_keep("second-job")
 
 
 def test_stop_keep_returns_timeout_payload(monkeypatch):


### PR DESCRIPTION
## Summary
- reserve custom `job_id` values while MCP sessions are still starting
- reject duplicate active or starting `job_id` values before duplicate controller construction/keep work
- clear reservations after controller factory or keep startup failures so retries work
- make targeted and stop-all requests wait for in-progress starts before deciding what can be released
- preserve stop-all snapshot semantics by waiting only for sessions already starting when stop-all begins
- document active/startup uniqueness and stop-during-startup behavior in README, MCP guide, CLI reference, AGENTS, and the plan doc

## Verification
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_factory_failure_releases_job_id_reservation -q` -> 1 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q` -> 3 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> 29 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 98 passed, 12 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> built successfully; existing Material/MkDocs warning and docs/plans nav notices only
- `pre-commit run --all-files` -> all hooks passed

## Review
- Local subagent review found a factory-construction reservation leak and a test assertion gap; both are fixed in this PR.
- Gemini review found stop-during-startup misses and a redundant post-start duplicate guard; both are fixed in the updated PR.
- Follow-up local review found stop-all future-starter waiting and scheduler-dependent tests; both are fixed in the updated PR.
- Final local review was merge-ready; its doc-precision suggestion is included in the final update.
- CodeRabbit flagged `assert False` exception guards in tests; the touched test file now uses explicit `AssertionError` branches.

## Out of Scope
- Stop-all release parallelism remains a separate follow-up issue/branch.