### PR TITLE
[mcp, cli] fix: validate custom job ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file defines how coding agents should work in this repository.
 - Keep lifecycle state truthful: a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
+- Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
 - Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; when telemetry is unavailable and `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ is invalid, and startup raises an error if discovery resolves to zero devices.
   curl http://127.0.0.1:8765/health
   curl http://127.0.0.1:8765/api/sessions
   ```
-- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). Omitting `gpu_ids` uses all visible GPUs, but empty or duplicate lists are invalid and startup fails if no GPUs resolve. Custom `job_id` values must be unique across active and starting sessions.
+- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). Omitting `gpu_ids` uses all visible GPUs, but empty or duplicate lists are invalid and startup fails if no GPUs resolve. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`.
 - Stop responses distinguish completed cleanup from partial cleanup:
   `stopped` means released, while `timed_out` sessions remain visible as
   `stopping` until background cleanup completes and `failed` sessions remain

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -44,6 +44,10 @@ devices.
 Custom `job_id` values are unique across active and starting sessions. If a
 duplicate arrives while the original start is still creating controller work,
 the duplicate is rejected before another controller begins keep-alive work.
+Only `null`/omitted means "generate an ID" for `start_keep` or "all sessions"
+for `status` and `stop_keep`. Custom IDs must be non-empty strings containing
+only letters, digits, `.`, `_`, `-`, or `~`; invalid IDs return an error before
+session state changes.
 
 `stop_keep` returns additive outcome fields:
 

--- a/docs/plans/mcp-job-id-validation.md
+++ b/docs/plans/mcp-job-id-validation.md
@@ -1,0 +1,54 @@
+# MCP Job ID Validation Plan
+
+## Background
+
+`KeepGPUServer.stop_keep(job_id="")` currently follows the same branch as
+`job_id=None`, so a malformed targeted stop can release every active session.
+Custom `job_id` values are also accepted as any Python object. That can create
+integer-keyed sessions that REST paths cannot address, or path-shaped IDs that
+make `/api/sessions/{job_id}` ambiguous.
+
+## Goal
+
+Make custom session identifiers explicit, stable, and safe across Python,
+JSON-RPC, REST, CLI, and dashboard-facing service contracts. Only `None` means
+"omitted"; invalid custom IDs must fail before a session starts or stops.
+
+## Design
+
+- Add a shared `validate_job_id()` helper in
+  `src/keep_gpu/utilities/session_config.py`.
+- Keep `None` as the only omitted/all-sessions sentinel.
+- Require custom `job_id` values to be non-empty URL-path-safe strings without
+  trimming or other normalization, so a REST session URL maps to exactly one
+  session key.
+- Use the helper in `KeepGPUServer.start_keep()`, `stop_keep()`, and `status()`.
+- Let JSON-RPC and REST reuse the same server validation instead of carrying a
+  parallel rule set.
+- Update README, MCP/API docs, and `AGENTS.md` so contributors keep the session
+  contract aligned.
+
+## Todo
+
+- [x] Add failing unit tests for `validate_job_id()` accepting `None` and
+      safe strings while rejecting empty, non-string, whitespace, slash, and
+      query-shaped IDs.
+- [x] Add failing server tests proving `stop_keep(job_id="")` and JSON-RPC
+      `stop_keep` with an empty ID return errors without stopping active
+      sessions.
+- [x] Add failing service tests proving invalid custom IDs are rejected at
+      session start and do not create sessions.
+- [x] Add failing REST path tests proving extra or decoded-invalid job ID path
+      segments are rejected without stopping another session.
+- [x] Address local review feedback with failing tests for targeted REST query
+      strings and CLI explicit empty `--job-id` forwarding.
+- [x] Address re-review feedback with failing tests for REST semicolon path
+      parameters before targeted session lookup or stop.
+- [x] Address final local review feedback with failing tests for malformed REST
+      collection paths before stop-all can run.
+- [x] Implement shared `job_id` validation and wire it through server start,
+      stop, and status paths.
+- [x] Update `AGENTS.md`, README, MCP guide, and API reference with the custom
+      ID contract.
+- [x] Run targeted session/service tests, full tests, docs build, pre-commit,
+      and local subagent review before opening the PR.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,6 +8,11 @@ For global sessions, `gpu_ids=None` means all visible GPUs. Passing an empty or
 duplicate list is invalid, and startup raises `ValueError` if discovery resolves
 to zero devices.
 
+For service session IDs, `job_id=None` is the only omitted/all-sessions
+sentinel. Custom IDs must be non-empty strings containing only letters, digits,
+`.`, `_`, `-`, or `~`; invalid values raise `ValueError` before session state
+changes.
+
 ::: keep_gpu.cli
     options:
       show_source: true

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,6 +89,10 @@ Stops the ownership-verified local daemon process created by auto-start logic.
 
 ## Service HTTP endpoints
 
+Only omitted/`null` `job_id` values mean generated IDs or all-sessions, depending
+on the method. Custom IDs must be non-empty strings containing only letters,
+digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
+
 | Endpoint | Method | Purpose |
 | --- | --- | --- |
 | `/health` | GET | Service liveness probe. |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -674,7 +674,7 @@ def status(
     try:
         result = _rpc_call(
             "status",
-            {"job_id": job_id} if job_id else {},
+            {} if job_id is None else {"job_id": job_id},
             host,
             port,
         )
@@ -700,7 +700,7 @@ def stop(
 ):
     """Stop one session or all sessions."""
     try:
-        if not job_id and not all_sessions:
+        if job_id is None and not all_sessions:
             raise RuntimeError("Provide --job-id or use --all.")
         if all_sessions:
             result = _stop_all_sessions_with_fallback(host, port)

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -43,6 +43,7 @@ from keep_gpu.utilities.session_config import (
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
+    validate_job_id,
 )
 
 logger = setup_logger(__name__)
@@ -144,7 +145,9 @@ class KeepGPUServer:
         busy_threshold = validate_busy_threshold(busy_threshold)
         parse_vram_to_elements(vram)
 
-        job_id = job_id or str(uuid.uuid4())
+        job_id = validate_job_id(job_id)
+        if job_id is None:
+            job_id = str(uuid.uuid4())
         with self._sessions_lock:
             if job_id in self._sessions or job_id in self._starting_job_ids:
                 raise ValueError(f"job_id {job_id} already exists")
@@ -247,7 +250,8 @@ class KeepGPUServer:
             Dict with "stopped", "timed_out", "failed", and "errors" fields.
             If a specific job_id was not found, a "message" field explains the miss.
         """
-        if job_id:
+        job_id = validate_job_id(job_id)
+        if job_id is not None:
             with self._sessions_lock:
                 while job_id in self._starting_job_ids:
                     self._sessions_cond.wait()
@@ -366,7 +370,8 @@ class KeepGPUServer:
         return self._finalize_stop_result(result)
 
     def status(self, job_id: Optional[str] = None) -> Dict[str, Any]:
-        if job_id:
+        job_id = validate_job_id(job_id)
+        if job_id is not None:
             with self._sessions_lock:
                 session = self._sessions.get(job_id)
                 if not session:
@@ -483,6 +488,30 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(content)
 
+    def _job_id_from_session_path(self, path: str) -> str:
+        prefix = "/api/sessions/"
+        if not path.startswith(prefix):
+            raise ValueError("Missing job_id")
+        encoded_job_id = path[len(prefix) :]
+        if encoded_job_id == "" or encoded_job_id.endswith("/"):
+            raise ValueError("Missing job_id")
+        if "/" in encoded_job_id:
+            raise ValueError("Invalid job_id path")
+        job_id = unquote(encoded_job_id)
+        validated = validate_job_id(job_id)
+        if validated is None:
+            raise ValueError("Missing job_id")
+        return validated
+
+    def _reject_session_route_components(self, parsed) -> bool:
+        if parsed.params or parsed.query or parsed.fragment:
+            self._json_response(
+                400,
+                {"error": {"message": "Invalid session path for job_id"}},
+            )
+            return True
+        return False
+
     def do_GET(self):  # noqa: N802
         parsed = urlparse(self.path)
         path = parsed.path
@@ -495,12 +524,17 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             self._json_response(200, server_ref.list_gpus())
             return
         if path == "/api/sessions":
+            if self._reject_session_route_components(parsed):
+                return
             self._json_response(200, server_ref.status())
             return
         if path.startswith("/api/sessions/"):
-            job_id = unquote(path.rsplit("/", 1)[-1]).strip()
-            if not job_id:
-                self._json_response(400, {"error": {"message": "Missing job_id"}})
+            if self._reject_session_route_components(parsed):
+                return
+            try:
+                job_id = self._job_id_from_session_path(path)
+            except ValueError as exc:
+                self._json_response(400, {"error": {"message": str(exc)}})
                 return
             self._json_response(200, server_ref.status(job_id=job_id))
             return
@@ -524,6 +558,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         try:
             payload = self._read_json_body()
             if path == "/api/sessions":
+                if self._reject_session_route_components(parsed):
+                    return
                 allowed_fields = {
                     "gpu_ids",
                     "vram",
@@ -584,12 +620,17 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
 
         if path == "/api/sessions":
+            if self._reject_session_route_components(parsed):
+                return
             self._json_response(200, server_ref.stop_keep(job_id=None))
             return
         if path.startswith("/api/sessions/"):
-            job_id = unquote(path.rsplit("/", 1)[-1]).strip()
-            if not job_id:
-                self._json_response(400, {"error": {"message": "Missing job_id"}})
+            if self._reject_session_route_components(parsed):
+                return
+            try:
+                job_id = self._job_id_from_session_path(path)
+            except ValueError as exc:
+                self._json_response(400, {"error": {"message": str(exc)}})
                 return
             self._json_response(200, server_ref.stop_keep(job_id=job_id))
             return

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -1,4 +1,7 @@
+import re
 from typing import Any, List, Optional, Union
+
+_JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9._~-]+$")
 
 
 def _is_plain_int(value: Any) -> bool:
@@ -40,3 +43,14 @@ def validate_busy_threshold(busy_threshold: Any) -> int:
     ):
         raise ValueError("busy_threshold must be -1 or an integer between 0 and 100")
     return busy_threshold
+
+
+def validate_job_id(job_id: Any) -> Optional[str]:
+    """Validate public session job_id input."""
+    if job_id is None:
+        return None
+    if not isinstance(job_id, str):
+        raise ValueError("job_id must be a URL-path-safe non-empty string")
+    if not job_id.strip() or not _JOB_ID_PATTERN.fullmatch(job_id):
+        raise ValueError("job_id must be a URL-path-safe non-empty string")
+    return job_id

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -32,6 +32,18 @@ def make_server() -> KeepGPUServer:
     return KeepGPUServer(controller_factory=cast(Any, dummy_factory))
 
 
+def _start_http_server(server: KeepGPUServer):
+    class _Server(TCPServer):
+        allow_reuse_address = True
+
+    httpd = _Server(("127.0.0.1", 0), _JSONRPCHandler)
+    httpd.keepgpu_server = server  # type: ignore[attr-defined]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    return httpd, thread, base
+
+
 def _request_json(method, url, payload=None):
     data = None
     if payload is not None:
@@ -394,6 +406,217 @@ def test_http_post_rejects_busy_threshold_above_percent_range():
             in payload["error"]["message"]
         )
         assert server.status()["active_jobs"] == []
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_post_rejects_invalid_job_id_without_creating_session():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "gpu_ids": [0],
+                "vram": "64MB",
+                "interval": 20,
+                "busy_threshold": 5,
+                "job_id": "",
+            },
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status()["active_jobs"] == []
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_get_rejects_invalid_decoded_job_id_path():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}/api/sessions/bad%3Fjob")
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_get_rejects_query_shaped_job_id_path():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "GET", f"{base}/api/sessions/{active_job_id}?bad=query"
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_get_rejects_parameterized_job_id_path():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "GET", f"{base}/api/sessions/{active_job_id};bad"
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_invalid_decoded_job_id_path_without_stopping_session():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("DELETE", f"{base}/api/sessions/bad%2Fjob")
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_query_shaped_job_id_path_without_stopping_session():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "DELETE", f"{base}/api/sessions/{active_job_id}?bad=query"
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_parameterized_job_id_path_without_stopping_session():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "DELETE", f"{base}/api/sessions/{active_job_id};bad"
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_extra_session_path_segment_without_stopping_session():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "DELETE", f"{base}/api/sessions/prefix/{active_job_id}"
+        )
+
+        assert status_code == 400
+        assert "job_id" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_query_shaped_collection_path_without_stopping_sessions():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("DELETE", f"{base}/api/sessions?bad=query")
+
+        assert status_code == 400
+        assert "session path" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_delete_rejects_parameterized_collection_path_without_stopping_sessions():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("DELETE", f"{base}/api/sessions;bad")
+
+        assert status_code == 400
+        assert "session path" in payload["error"]["message"]
+        assert server.status(active_job_id)["active"] is True
+        assert controller.released is False
     finally:
         httpd.shutdown()
         httpd.server_close()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2,6 +2,8 @@ import threading
 import time
 from typing import Any, cast
 
+import pytest
+
 from keep_gpu.mcp.server import KeepGPUServer, _handle_request
 
 
@@ -155,6 +157,64 @@ def test_jsonrpc_rejects_busy_threshold_above_percent_range():
         in resp["error"]["message"]
     )
     assert server.status()["active_jobs"] == []
+
+
+@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+def test_start_keep_rejects_invalid_job_id_before_starting_controller(job_id):
+    controllers = []
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            controllers.append(self)
+            super().__init__(**kwargs)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+
+    with pytest.raises(ValueError, match="job_id"):
+        server.start_keep(job_id=job_id)
+
+    assert controllers == []
+    assert server.status()["active_jobs"] == []
+
+
+@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+def test_status_rejects_invalid_job_id_without_changing_sessions(job_id):
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+
+    with pytest.raises(ValueError, match="job_id"):
+        server.status(job_id=job_id)
+
+    assert server.status(active_job_id)["active"] is True
+
+
+@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+def test_stop_keep_rejects_invalid_job_id_without_stopping_sessions(job_id):
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+
+    with pytest.raises(ValueError, match="job_id"):
+        server.stop_keep(job_id=job_id)
+
+    assert server.status(active_job_id)["active"] is True
+    assert controller.released is False
+
+
+def test_jsonrpc_stop_keep_rejects_empty_job_id_without_stopping_sessions():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    req = {"id": 1, "method": "stop_keep", "params": {"job_id": ""}}
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert "job_id" in resp["error"]["message"]
+    assert server.status(active_job_id)["active"] is True
+    assert controller.released is False
 
 
 def test_stop_all():

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -118,6 +118,43 @@ def test_stop_requires_job_id_or_all():
     assert "Provide --job-id or use --all" in result.output
 
 
+def test_status_forwards_explicit_empty_job_id_to_service(monkeypatch):
+    called = {}
+
+    def fake_rpc(method, params, host, port):
+        called["rpc"] = (method, params, host, port)
+        raise RuntimeError("job_id must be a URL-path-safe non-empty string")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", ""])
+
+    assert result.exit_code == 1
+    assert "job_id must be a URL-path-safe non-empty string" in result.output
+    method, params, _host, _port = called["rpc"]
+    assert method == "status"
+    assert params == {"job_id": ""}
+
+
+def test_stop_forwards_explicit_empty_job_id_to_service(monkeypatch):
+    called = {}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        called["rpc"] = (method, params, host, port, timeout)
+        raise RuntimeError("job_id must be a URL-path-safe non-empty string")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", ""])
+
+    assert result.exit_code == 1
+    assert "job_id must be a URL-path-safe non-empty string" in result.output
+    method, params, _host, _port, timeout = called["rpc"]
+    assert method == "stop_keep"
+    assert params == {"job_id": ""}
+    assert timeout == 45.0
+
+
 def test_blocking_mode_remains_default(monkeypatch):
     called = {}
 

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -1,5 +1,8 @@
+import uuid
+
 import pytest
 
+from keep_gpu.utilities import session_config
 from keep_gpu.utilities.session_config import (
     validate_busy_threshold,
     validate_gpu_ids,
@@ -53,3 +56,35 @@ def test_validate_busy_threshold_rejects_non_plain_integers(value):
         ValueError, match="busy_threshold must be -1 or an integer between 0 and 100"
     ):
         validate_busy_threshold(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "job-123", "job_123", "job.123", "job~123", str(uuid.uuid4())],
+)
+def test_validate_job_id_accepts_omitted_and_url_path_safe_strings(value):
+    assert session_config.validate_job_id(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        " ",
+        "\t",
+        123,
+        True,
+        ["job-123"],
+        "job/123",
+        "job?123",
+        "job#123",
+        "job 123",
+        " job-123",
+        "job-123 ",
+        "job%123",
+        "job:123",
+    ],
+)
+def test_validate_job_id_rejects_invalid_custom_ids(value):
+    with pytest.raises(ValueError, match="job_id"):
+        session_config.validate_job_id(value)


### PR DESCRIPTION
## Summary
- centralize custom `job_id` validation so only `None`/omitted means generated or all-sessions
- reject empty, non-string, and non URL-path-safe session IDs before start/status/stop mutates session state
- harden REST collection and targeted session routes against malformed path params/query/fragments
- preserve explicit empty `--job-id` in CLI service commands so service validation rejects it
- update AGENTS, README, MCP/API/CLI docs, and add a focused plan

## Verification
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py -q` -> 130 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 173 passed, 12 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed, with existing MkDocs Material warning and un-nav docs notices
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed before commit

## Local review
- Local subagent review completed with no Critical, Important, or Minor issues after three review/fix rounds.
- Review-driven regressions added for targeted and collection REST query/path-param cases plus CLI explicit empty `--job-id` forwarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session IDs are now validated more consistently across the app and APIs.
  * Explicit empty `--job-id` values are now passed through correctly in CLI status/stop commands.

* **Bug Fixes**
  * Invalid session IDs are rejected before any session changes occur.
  * HTTP session routes now return clear `400` errors for malformed paths or invalid IDs.
  * `null`/omitted IDs are handled consistently as generated IDs or all-sessions actions, depending on the command.

* **Documentation**
  * Updated API, CLI, MCP, and README guidance to match the new session ID rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->