### PR TITLE
[cuda] fix: map visible ordinals for telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ This file defines how coding agents should work in this repository.
 - Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; when telemetry is unavailable and `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
+- Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` numeric/UUID tokens to the correct NVML handle. If that mapping is ambiguous or unsupported, return `None` rather than falling back to a possibly wrong physical index.
 - Global controller startup must fail clearly when GPU selection resolves to zero or duplicate devices; do not create silent no-op or duplicate-worker keep sessions.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ is invalid, and startup raises an error if discovery resolves to zero devices.
 ## What you get
 
 - Battle-tested keep-alive loop built on PyTorch.
-- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`. Valid `busy_threshold` values are `-1` or `0..100`; if utilization is unavailable and the threshold is non-negative, KeepGPU sleeps for that cycle instead of running compute.
+- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`. Valid `busy_threshold` values are `-1` or `0..100`; if utilization is unavailable and the threshold is non-negative, KeepGPU sleeps for that cycle instead of running compute. CUDA utilization checks use visible CUDA ordinals, so with `CUDA_VISIBLE_DEVICES=3,5`, rank `1` reads NVML telemetry for physical GPU `5`; ambiguous mappings are treated as unavailable telemetry.
 - CLI + API parity: same controllers power both code paths.
 - Continuous docs + CI: mkdocs + mkdocstrings build in CI to keep guidance up to date.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -35,6 +35,9 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
    - Allocates a tensor sized by way of `vram_to_keep`.
    - Starts a daemon thread that performs intervalled lightweight elementwise batches.
    - Calls `_monitor_utilization` (by way of NVML) to detect real activity.
+     The monitor receives the CUDA visible rank and resolves
+     `CUDA_VISIBLE_DEVICES` numeric or UUID tokens before querying NVML, so
+     telemetry follows the same device the worker keeps.
 4. If utilization exceeds `busy_threshold`, or if utilization is unavailable
    while `busy_threshold` is non-negative, the worker just sleeps for one more
    `interval`. Otherwise it runs a new batch of ops. Valid thresholds are `-1`

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -18,6 +18,10 @@ train_model()                     # GPU memory is released automatically
 ```
 
 - `rank` matches the CUDA device index (after any `CUDA_VISIBLE_DEVICES` filtering).
+  Utilization backoff resolves that visible rank through `CUDA_VISIBLE_DEVICES`
+  before querying NVML; for example, with `CUDA_VISIBLE_DEVICES=3,5`, rank `1`
+  reads physical GPU `5`. If the mapping cannot be resolved, utilization is
+  treated as unavailable.
 - `interval` is the positive pause between keep-alive bursts inside the background thread.
 - `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size` handles it).
 

--- a/docs/plans/cuda-visible-device-telemetry.md
+++ b/docs/plans/cuda-visible-device-telemetry.md
@@ -1,0 +1,49 @@
+# CUDA Visible-Device Telemetry Plan
+
+## Background
+
+CUDA controllers use visible CUDA ordinals such as `cuda:0`, while NVML indexes
+physical devices. When `CUDA_VISIBLE_DEVICES=3,5`, visible CUDA rank `1` refers
+to physical GPU `5`, but the current NVML monitor queries physical index `1`.
+That can make eco backoff decisions from the wrong GPU and run keepalive compute
+on a busy device.
+
+## Goal
+
+Make CUDA utilization backoff read telemetry for the same device that the CUDA
+controller is keeping, preserving conservative sleep-only behavior when the
+visible-rank to NVML-handle mapping cannot be determined.
+
+## Design
+
+- Keep `CudaGPUController` passing its visible CUDA rank to the monitor.
+- Teach `NVMLMonitor` to resolve that visible rank through
+  `CUDA_VISIBLE_DEVICES` before querying NVML.
+- If `CUDA_VISIBLE_DEVICES` is unset, keep the current direct index behavior.
+- If `CUDA_VISIBLE_DEVICES` contains numeric device IDs, map visible rank to the
+  corresponding physical NVML index.
+- If it contains UUID tokens, use `nvmlDeviceGetHandleByUUID` when available.
+- If the token is missing, out of range, empty, or unsupported, return `None`
+  rather than querying a possibly wrong physical GPU. Non-negative
+  `busy_threshold` already treats `None` as a conservative sleep cycle.
+- Update docs and `AGENTS.md` so contributors preserve this visible-rank
+  mapping when changing CUDA telemetry.
+
+## Todo
+
+- [x] Add failing monitor tests for `CUDA_VISIBLE_DEVICES=3,5` proving visible
+      rank `1` queries physical index `5`.
+- [x] Add failing tests for out-of-range, invalid, and unsupported UUID tokens
+      returning `None` instead of falling back to the visible ordinal.
+- [x] Add failing tests for invalid or unsupported tokens before the requested
+      visible ordinal returning `None` for later ordinals.
+- [x] Add UUID-token coverage for NVML modules that support
+      `nvmlDeviceGetHandleByUUID`.
+- [x] Implement visible CUDA rank to NVML handle resolution in
+      `src/keep_gpu/utilities/gpu_monitor.py`.
+- [x] Update `AGENTS.md`, README, and Python/CLI docs with the CUDA telemetry
+      mapping behavior.
+- [x] Run targeted GPU monitor/CUDA tests, full tests, docs build,
+      pre-commit, and local subagent review.
+- [ ] Open the PR, wait for PR checks/reviews, resolve every required comment,
+      squash merge, and clean up the worktree.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -109,6 +109,6 @@ digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
 
 | Variable | Effect |
 | --- | --- |
-| `CUDA_VISIBLE_DEVICES` | Standard CUDA filtering. Blocking mode honors it before `--gpu-ids`. |
+| `CUDA_VISIBLE_DEVICES` | Standard CUDA filtering. Blocking mode honors it before `--gpu-ids`; CUDA utilization telemetry maps visible ordinals through numeric or UUID tokens before querying NVML, and unresolved mappings report unavailable telemetry. |
 | `CONSOLE_LOG_LEVEL` | Console log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `no`). |
 | `FILE_LOG_LEVEL` | File log level; writes logs under `./logs/` when enabled. |

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import os
 import threading
 from typing import Optional
 
@@ -64,11 +65,49 @@ class NVMLMonitor:
             return None
 
         try:
-            handle = self._nvml.nvmlDeviceGetHandleByIndex(index)
+            handle = self._get_handle_for_visible_index(index)
+            if handle is None:
+                return None
             rates = self._nvml.nvmlDeviceGetUtilizationRates(handle)
             return int(rates.gpu)
         except self._nvml.NVMLError as exc:
             logger.debug("NVML query failed for GPU %s: %s", index, exc)
+            return None
+
+    def _get_handle_for_visible_index(self, index: int):
+        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if cuda_visible_devices is None:
+            return self._nvml.nvmlDeviceGetHandleByIndex(index)
+
+        tokens = [token.strip() for token in cuda_visible_devices.split(",")]
+        if index < 0 or index >= len(tokens):
+            return None
+
+        handle = None
+        for visible_index, token in enumerate(tokens[: index + 1]):
+            handle = self._get_handle_for_visible_token(token)
+            if handle is None:
+                return None
+            if visible_index == index:
+                return handle
+        return None
+
+    def _get_handle_for_visible_token(self, token: str):
+        if not token:
+            return None
+
+        if token.isdigit():
+            try:
+                return self._nvml.nvmlDeviceGetHandleByIndex(int(token))
+            except self._nvml.NVMLError:
+                return None
+
+        uuid_lookup = getattr(self._nvml, "nvmlDeviceGetHandleByUUID", None)
+        if uuid_lookup is None:
+            return None
+        try:
+            return uuid_lookup(token)
+        except self._nvml.NVMLError:
             return None
 
 

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -105,10 +105,14 @@ class NVMLMonitor:
         uuid_lookup = getattr(self._nvml, "nvmlDeviceGetHandleByUUID", None)
         if uuid_lookup is None:
             return None
-        try:
-            return uuid_lookup(token)
-        except self._nvml.NVMLError:
-            return None
+        for uuid in (token, token.encode("utf-8")):
+            try:
+                return uuid_lookup(uuid)
+            except self._nvml.NVMLError:
+                return None
+            except (AttributeError, TypeError):
+                continue
+        return None
 
 
 _nvml_monitor = NVMLMonitor(pynvml)

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -9,10 +9,27 @@ class DummyNVML:
     class NVMLError(Exception):
         pass
 
-    def __init__(self, should_fail: bool = False, gpu_util: int = 50) -> None:
+    def __init__(
+        self,
+        should_fail: bool = False,
+        gpu_util: int = 50,
+        util_by_index: dict[int, int] | None = None,
+        util_by_uuid: dict[str, int] | None = None,
+        fail_uuid_lookup: bool = False,
+        support_uuid_lookup: bool = False,
+        invalid_indexes: set[int] | None = None,
+    ) -> None:
         self.should_fail = should_fail
         self.gpu_util = gpu_util
         self.init_calls = 0
+        self.queried_indexes: list[int] = []
+        self.queried_uuids: list[str] = []
+        self.util_by_index = util_by_index or {}
+        self.util_by_uuid = util_by_uuid or {}
+        self.fail_uuid_lookup = fail_uuid_lookup
+        self.invalid_indexes = invalid_indexes or set()
+        if support_uuid_lookup:
+            self.nvmlDeviceGetHandleByUUID = self._nvmlDeviceGetHandleByUUID
 
     def nvmlInit(self):
         self.init_calls += 1
@@ -25,10 +42,25 @@ class DummyNVML:
     def nvmlDeviceGetHandleByIndex(self, index: int):
         if self.should_fail:
             raise self.NVMLError("handle failure")
+        if index in self.invalid_indexes:
+            raise self.NVMLError("invalid index")
+        self.queried_indexes.append(index)
         return types.SimpleNamespace(index=index)
 
+    def _nvmlDeviceGetHandleByUUID(self, uuid: str):
+        self.queried_uuids.append(uuid)
+        if self.fail_uuid_lookup:
+            raise self.NVMLError("uuid lookup failure")
+        return types.SimpleNamespace(uuid=uuid)
+
     def nvmlDeviceGetUtilizationRates(self, handle):
-        return types.SimpleNamespace(gpu=self.gpu_util)
+        if hasattr(handle, "uuid"):
+            return types.SimpleNamespace(
+                gpu=self.util_by_uuid.get(handle.uuid, self.gpu_util)
+            )
+        return types.SimpleNamespace(
+            gpu=self.util_by_index.get(handle.index, self.gpu_util)
+        )
 
 
 def test_monitor_returns_none_when_nvml_missing():
@@ -36,16 +68,129 @@ def test_monitor_returns_none_when_nvml_missing():
     assert monitor.get_gpu_utilization(0) is None
 
 
-def test_monitor_reads_gpu_utilization():
+def test_monitor_reads_gpu_utilization(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     dummy = DummyNVML(gpu_util=73)
     monitor = NVMLMonitor(dummy)
     assert monitor.get_gpu_utilization(1) == 73
     # second call reuses initialization
     assert monitor.get_gpu_utilization(2) == 73
     assert dummy.init_calls == 1
+    assert dummy.queried_indexes == [1, 2]
 
 
-def test_monitor_handles_nvml_errors():
+def test_monitor_handles_nvml_errors(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     dummy = DummyNVML(should_fail=True)
     monitor = NVMLMonitor(dummy)
     assert monitor.get_gpu_utilization(0) is None
+
+
+def test_monitor_maps_visible_ordinal_through_numeric_cuda_visible_devices(
+    monkeypatch,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3, 5")
+    dummy = DummyNVML(util_by_index={5: 85})
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(1) == 85
+    assert dummy.queried_indexes == [3, 5]
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_for_out_of_range_visible_ordinal(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,5")
+    dummy = DummyNVML(gpu_util=99)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(2) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_when_prior_token_is_invalid(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,-1,2")
+    dummy = DummyNVML(util_by_index={2: 99})
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(2) is None
+    assert dummy.queried_indexes == [0]
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_when_prior_token_is_empty(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,,2")
+    dummy = DummyNVML(util_by_index={2: 99})
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(2) is None
+    assert dummy.queried_indexes == [0]
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_when_prior_numeric_index_is_invalid(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,99,2")
+    dummy = DummyNVML(util_by_index={2: 99}, invalid_indexes={99})
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(2) is None
+    assert dummy.queried_indexes == [0]
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_for_empty_cuda_visible_devices_token(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,,5")
+    dummy = DummyNVML(gpu_util=99)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(1) is None
+    assert dummy.queried_indexes == [3]
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_for_uuid_token_without_lookup_support(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(gpu_util=99)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_queries_uuid_token_when_nvml_supports_uuid_lookup(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(
+        gpu_util=99,
+        util_by_uuid={"GPU-abc123": 42},
+        support_uuid_lookup=True,
+    )
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) == 42
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123"]
+
+
+def test_monitor_returns_none_when_uuid_lookup_fails(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(fail_uuid_lookup=True, support_uuid_lookup=True)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123"]
+
+
+def test_monitor_returns_none_when_prior_uuid_lookup_fails(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123,2")
+    dummy = DummyNVML(
+        util_by_index={2: 99},
+        fail_uuid_lookup=True,
+        support_uuid_lookup=True,
+    )
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(1) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123"]

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -14,8 +14,10 @@ class DummyNVML:
         should_fail: bool = False,
         gpu_util: int = 50,
         util_by_index: dict[int, int] | None = None,
-        util_by_uuid: dict[str, int] | None = None,
+        util_by_uuid: dict[object, int] | None = None,
         fail_uuid_lookup: bool = False,
+        uuid_requires_bytes: bool = False,
+        uuid_always_type_error: bool = False,
         support_uuid_lookup: bool = False,
         invalid_indexes: set[int] | None = None,
     ) -> None:
@@ -23,10 +25,12 @@ class DummyNVML:
         self.gpu_util = gpu_util
         self.init_calls = 0
         self.queried_indexes: list[int] = []
-        self.queried_uuids: list[str] = []
+        self.queried_uuids: list[object] = []
         self.util_by_index = util_by_index or {}
         self.util_by_uuid = util_by_uuid or {}
         self.fail_uuid_lookup = fail_uuid_lookup
+        self.uuid_requires_bytes = uuid_requires_bytes
+        self.uuid_always_type_error = uuid_always_type_error
         self.invalid_indexes = invalid_indexes or set()
         if support_uuid_lookup:
             self.nvmlDeviceGetHandleByUUID = self._nvmlDeviceGetHandleByUUID
@@ -49,6 +53,10 @@ class DummyNVML:
 
     def _nvmlDeviceGetHandleByUUID(self, uuid: str):
         self.queried_uuids.append(uuid)
+        if self.uuid_always_type_error or (
+            self.uuid_requires_bytes and isinstance(uuid, str)
+        ):
+            raise TypeError("uuid must be bytes")
         if self.fail_uuid_lookup:
             raise self.NVMLError("uuid lookup failure")
         return types.SimpleNamespace(uuid=uuid)
@@ -170,6 +178,36 @@ def test_monitor_queries_uuid_token_when_nvml_supports_uuid_lookup(monkeypatch):
     assert monitor.get_gpu_utilization(0) == 42
     assert dummy.queried_indexes == []
     assert dummy.queried_uuids == ["GPU-abc123"]
+
+
+def test_monitor_retries_uuid_token_as_bytes_after_type_error(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(
+        gpu_util=99,
+        util_by_uuid={b"GPU-abc123": 61},
+        support_uuid_lookup=True,
+        uuid_requires_bytes=True,
+    )
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) == 61
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]
+
+
+def test_monitor_returns_none_when_uuid_lookup_type_errors_for_all_inputs(
+    monkeypatch,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(
+        support_uuid_lookup=True,
+        uuid_always_type_error=True,
+    )
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]
 
 
 def test_monitor_returns_none_when_uuid_lookup_fails(monkeypatch):


### PR DESCRIPTION
## Summary
- Map CUDA visible ordinals through `CUDA_VISIBLE_DEVICES` before querying NVML utilization.
- Treat ambiguous, invalid, unsupported, or failed mappings as unavailable telemetry so non-negative busy-threshold mode sleeps instead of running keepalive compute.
- Add monitor coverage for numeric, UUID, invalid, empty, and out-of-range mappings, plus README/docs/AGENTS guidance.

## Verification
- `git diff --check`
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_monitor.py tests/cuda_controller/test_throttle.py -q` (`17 passed, 1 skipped`)
- `PYTHONPATH=$PWD/src pytest tests -q` (`185 passed, 12 skipped`)
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`

## Local Review
- Noether local subagent review requested against `origin/main..HEAD`; merge will wait for review and GitHub checks/comments.
