### PR TITLE
[mcp] fix: support protocol handshake tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,11 @@ This file defines how coding agents should work in this repository.
   - Python API/controllers (`src/keep_gpu/single_gpu_controller/`, `src/keep_gpu/global_gpu_controller/`)
   - MCP server: `keep-gpu-mcp-server` (`src/keep_gpu/mcp/server.py`)
 - If behavior changes in one interface, update related docs/tests for that interface and check if parity is required in the others.
+- Keep the MCP server compatible with standard MCP lifecycle/tool methods
+  (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
+  preserving legacy direct JSON-RPC method calls for local scripts.
+- For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
+  and human logs belong on stderr.
 
 ### Architecture Boundaries
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ devices.
 
 ### MCP and service API
 
-- Start a simple JSON-RPC server on stdin/stdout (default):
+- Start an MCP server on stdin/stdout (default):
   ```bash
   keep-gpu-mcp-server
   ```
@@ -134,10 +134,18 @@ devices.
   ```bash
   keep-gpu-mcp-server --mode http --host 0.0.0.0 --port 8765
   ```
-- JSON-RPC request example:
+- MCP clients use the standard `initialize`, `tools/list`, and `tools/call`
+  protocol methods over stdio. KeepGPU exposes four tools: `start_keep`,
+  `stop_keep`, `status`, and `list_gpus`.
+- Legacy direct JSON-RPC method calls remain supported for scripts:
   ```json
   {"id": 1, "method": "start_keep", "params": {"gpu_ids": [0], "vram": "512MB", "interval": 60, "busy_threshold": 20}}
   ```
+- Stdio stdout is reserved for JSON protocol messages; diagnostics and logs are
+  written to stderr.
+- HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
+  same JSON-RPC messages at `/rpc`, but it is not a Streamable HTTP MCP
+  endpoint.
 - REST examples:
   ```bash
   curl http://127.0.0.1:8765/health
@@ -173,24 +181,12 @@ devices.
       command: ["keep-gpu-mcp-server"]
       adapter: stdio
   ```
-- Minimal client config (HTTP MCP):
-  ```yaml
-  servers:
-    keepgpu:
-      url: http://127.0.0.1:8765/
-      adapter: http
-  ```
 - Remote/SSH tunnel example (HTTP):
   ```bash
   keep-gpu-mcp-server --mode http --host 0.0.0.0 --port 8765
   ```
-  Client config (replace hostname/tunnel as needed):
-  ```yaml
-  servers:
-    keepgpu:
-      url: http://gpu-box.example.com:8765/
-      adapter: http
-  ```
+  Use `http://gpu-box.example.com:8765/` for the dashboard and
+  `http://gpu-box.example.com:8765/rpc` for JSON-RPC scripts.
   For untrusted networks, put the server behind your own auth/reverse-proxy or
   tunnel by way of SSH (for example, `ssh -L 8765:localhost:8765 gpu-box`).
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -2,7 +2,8 @@
 
 KeepGPU ships a local service that powers three interfaces:
 
-- JSON-RPC (`keep-gpu-mcp-server` or `/rpc`)
+- MCP over stdio (`keep-gpu-mcp-server`)
+- JSON-RPC over HTTP (`/rpc`)
 - REST API (`/api/*`)
 - Dashboard UI (`/`)
 
@@ -22,7 +23,44 @@ keep-gpu serve --host 127.0.0.1 --port 8765
 keep-gpu-mcp-server --mode http --host 127.0.0.1 --port 8765
 ```
 
-## JSON-RPC quick example
+## MCP protocol over stdio
+
+MCP clients should start with `initialize`, then discover KeepGPU actions with
+`tools/list`, then invoke an action with `tools/call`. KeepGPU exposes these
+tool names:
+
+- `start_keep`
+- `stop_keep`
+- `status`
+- `list_gpus`
+
+Minimal client config:
+
+```yaml
+servers:
+  keepgpu:
+    command: ["keep-gpu-mcp-server"]
+    adapter: stdio
+```
+
+The stdio transport writes only JSON protocol messages to stdout. KeepGPU logs
+and diagnostics go to stderr so MCP clients can parse stdout safely.
+
+## HTTP JSON-RPC quick example
+
+HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
+same JSON-RPC message shapes at `/rpc`, but it is not a Streamable HTTP MCP
+endpoint.
+
+```bash
+curl -X POST http://127.0.0.1:8765/rpc \
+  -H "content-type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}'
+```
+
+## Legacy JSON-RPC quick example
+
+Direct method calls remain available for scripts and older local integrations.
 
 ```bash
 curl -X POST http://127.0.0.1:8765/rpc \

--- a/docs/plans/mcp-protocol-handshake-tools.md
+++ b/docs/plans/mcp-protocol-handshake-tools.md
@@ -1,0 +1,63 @@
+# MCP Protocol Handshake and Tools Plan
+
+## Background
+
+KeepGPU exposes `keep-gpu-mcp-server` and documents MCP client configuration, but
+the current JSON-RPC dispatcher only accepts direct custom method names:
+`start_keep`, `stop_keep`, `status`, and `list_gpus`. Real MCP clients first
+send `initialize`, then discover tools with `tools/list`, then call tools with
+`tools/call`. Those protocol methods currently fail as unknown methods.
+
+The service also supports legacy direct JSON-RPC and REST/dashboard endpoints.
+This fix must preserve those interfaces while adding the standard MCP protocol
+entry points.
+
+## Goal
+
+Make `keep-gpu-mcp-server` usable by standard MCP clients without adding a new
+runtime dependency or changing the controller contract.
+
+## Solution
+
+- Keep `KeepGPUServer` as the single backend.
+- Add small protocol helpers in `src/keep_gpu/mcp/server.py`:
+  - `initialize` returns the negotiated protocol version, server info, and tool
+    capabilities.
+  - `notifications/initialized` is accepted as a no-response notification.
+  - `tools/list` returns tool descriptors with JSON input schemas for the four
+    KeepGPU actions.
+  - `tools/call` validates the requested tool name and routes arguments into the
+    existing methods.
+- Preserve direct JSON-RPC methods for existing scripts and tests.
+- Keep responses JSON-RPC-compatible by including `jsonrpc: "2.0"` for normal
+  request responses.
+- Keep stdio line output protocol-clean by returning no line for notifications.
+
+## Files
+
+- Modify `src/keep_gpu/mcp/server.py`
+- Modify `tests/mcp/test_server.py`
+- Modify `tests/mcp/test_http_api.py` if HTTP protocol coverage needs a transport
+  assertion beyond the shared dispatcher tests.
+- Modify `README.md` and `docs/guides/mcp.md`
+- Modify `AGENTS.md` to document MCP protocol parity expectations.
+
+## Tasks
+
+- [x] Add failing protocol tests for `initialize`, `notifications/initialized`,
+      `tools/list`, and `tools/call`.
+- [x] Add failing coverage that unknown MCP tool names return a JSON-RPC
+      invalid-params error.
+- [x] Add failing stdio coverage that stdout contains only protocol JSON.
+- [x] Implement minimal protocol helpers and route them through `_handle_request`.
+- [x] Keep legacy direct JSON-RPC calls working.
+- [x] Update README, MCP guide, and AGENTS.md.
+- [x] Run targeted MCP tests, then broader Python/docs/pre-commit checks.
+- [x] Request local subagent review before PR.
+
+## Verification
+
+- `PYTHONPATH=$PWD/src pytest tests/mcp -q`
+- `PYTHONPATH=$PWD/src pytest tests -q`
+- `PYTHONPATH=$PWD/src mkdocs build`
+- `pre-commit run --all-files`

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1,6 +1,12 @@
 """KeepGPU local service.
 
-Supports JSON-RPC over stdio/HTTP and REST-style HTTP endpoints.
+Supports MCP/JSON-RPC over stdio/HTTP and REST-style HTTP endpoints.
+
+MCP protocol methods:
+  - initialize
+  - notifications/initialized
+  - tools/list
+  - tools/call
 
 JSON-RPC methods:
   - start_keep(gpu_ids, vram, interval, busy_threshold, job_id)
@@ -35,6 +41,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import unquote, urlparse
 
+from keep_gpu import __version__
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.gpu_info import get_gpu_info
@@ -49,6 +56,95 @@ from keep_gpu.utilities.session_config import (
 logger = setup_logger(__name__)
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 MAX_JSON_BODY_BYTES = 1_000_000
+MCP_PROTOCOL_VERSION = "2025-06-18"
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+
+MCP_TOOLS: List[Dict[str, Any]] = [
+    {
+        "name": "start_keep",
+        "title": "Start KeepGPU Session",
+        "description": "Reserve VRAM on selected visible GPU ordinals.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "gpu_ids": {
+                    "type": ["array", "null"],
+                    "items": {"type": "integer", "minimum": 0},
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": "Visible GPU ordinals; null or omitted uses all.",
+                },
+                "vram": {
+                    "type": "string",
+                    "default": "1GiB",
+                    "description": "Human-readable VRAM amount to keep.",
+                },
+                "interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 300,
+                    "description": "Seconds between keep-alive checks.",
+                },
+                "busy_threshold": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 100,
+                    "default": -1,
+                    "description": "-1 disables utilization backoff; 0..100 backs off.",
+                },
+                "job_id": {
+                    "type": ["string", "null"],
+                    "description": "Optional URL-path-safe session identifier.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "stop_keep",
+        "title": "Stop KeepGPU Session",
+        "description": "Release one session by job_id, or all sessions when omitted.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": ["string", "null"],
+                    "description": "Session identifier; null or omitted stops all.",
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "status",
+        "title": "Get KeepGPU Status",
+        "description": "Return one session status or the active session list.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": ["string", "null"],
+                    "description": "Session identifier; null or omitted lists all.",
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "list_gpus",
+        "title": "List Visible GPUs",
+        "description": "List start-compatible visible GPU ordinals and metadata.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+]
 
 
 @dataclass
@@ -57,6 +153,13 @@ class Session:
     params: Dict[str, Any]
     state: str = "active"
     last_error: Optional[str] = None
+
+
+class JSONRPCError(Exception):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 class KeepGPUServer:
@@ -433,7 +536,77 @@ class KeepGPUServer:
             return
 
 
-def _handle_request(server: KeepGPUServer, payload: Dict[str, Any]) -> Dict[str, Any]:
+def _jsonrpc_result(req_id: Any, result: Dict[str, Any]) -> Dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _jsonrpc_error(req_id: Any, code: int, message: str) -> Dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _call_keepgpu_method(
+    server: KeepGPUServer, method: str, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    if method == "start_keep":
+        return server.start_keep(**params)
+    if method == "stop_keep":
+        return server.stop_keep(**params)
+    if method == "status":
+        return server.status(**params)
+    if method == "list_gpus":
+        return server.list_gpus()
+    raise JSONRPCError(JSONRPC_METHOD_NOT_FOUND, f"Unknown method: {method}")
+
+
+def _mcp_initialize_result(params: Dict[str, Any]) -> Dict[str, Any]:
+    protocol_version = params.get("protocolVersion") or MCP_PROTOCOL_VERSION
+    if protocol_version != MCP_PROTOCOL_VERSION:
+        protocol_version = MCP_PROTOCOL_VERSION
+    return {
+        "protocolVersion": protocol_version,
+        "capabilities": {"tools": {"listChanged": False}},
+        "serverInfo": {
+            "name": "keepgpu",
+            "title": "KeepGPU",
+            "version": __version__,
+        },
+        "instructions": (
+            "Use start_keep to reserve VRAM only when needed, status to inspect "
+            "sessions, stop_keep to release sessions, and list_gpus to choose "
+            "visible GPU ordinals."
+        ),
+    }
+
+
+def _mcp_tool_result(payload: Any, is_error: bool = False) -> Dict[str, Any]:
+    text = payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True)
+    return {"content": [{"type": "text", "text": text}], "isError": is_error}
+
+
+def _mcp_call_tool(server: KeepGPUServer, params: Dict[str, Any]) -> Dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments", {})
+    if not isinstance(name, str) or not name:
+        raise JSONRPCError(
+            JSONRPC_INVALID_PARAMS, "Tool call requires a non-empty tool name."
+        )
+    if not isinstance(arguments, dict):
+        raise JSONRPCError(
+            JSONRPC_INVALID_PARAMS, "Tool call arguments must be an object."
+        )
+    if name not in {tool["name"] for tool in MCP_TOOLS}:
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
+    try:
+        return _mcp_tool_result(_call_keepgpu_method(server, name, arguments))
+    except Exception as exc:
+        return _mcp_tool_result(str(exc), True)
+
+
+def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, Any]]:
     """
     Dispatch a JSON-RPC payload to the server and return a response dict.
 
@@ -442,30 +615,59 @@ def _handle_request(server: KeepGPUServer, payload: Dict[str, Any]) -> Dict[str,
         payload: Dict with "method", optional "params", and optional "id".
 
     Returns:
-        JSON-RPC-style dict containing either "result" or "error" plus "id".
+        JSON-RPC-style dict containing either "result" or "error" plus "id",
+        or None for JSON-RPC notifications that do not expect a response.
     """
-    method = payload.get("method")
-    params = payload.get("params", {}) or {}
-    req_id = payload.get("id")
+    req_id = None
     try:
-        if method == "start_keep":
-            result = server.start_keep(**params)
-        elif method == "stop_keep":
-            result = server.stop_keep(**params)
-        elif method == "status":
-            result = server.status(**params)
-        elif method == "list_gpus":
-            result = server.list_gpus()
+        if not isinstance(payload, dict):
+            raise JSONRPCError(
+                JSONRPC_INVALID_REQUEST, "JSON-RPC messages must be objects."
+            )
+        method = payload.get("method")
+        params = payload.get("params", {})
+        req_id = payload.get("id")
+        if not isinstance(method, str) or not method:
+            raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Request method is required.")
+        if (
+            "id" not in payload
+            or not isinstance(req_id, (str, int))
+            or isinstance(req_id, bool)
+        ):
+            if method.startswith("notifications/") and "id" not in payload:
+                return None
+            raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Requests must include an id.")
+        if method.startswith("notifications/"):
+            raise JSONRPCError(
+                JSONRPC_INVALID_REQUEST, "Notifications must not include an id."
+            )
+        if params is None:
+            params = {}
+        if not isinstance(params, dict):
+            raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params must be an object")
+        if method == "initialize":
+            result = _mcp_initialize_result(params)
+        elif method == "tools/list":
+            result = {"tools": MCP_TOOLS}
+        elif method == "tools/call":
+            result = _mcp_call_tool(server, params)
         else:
-            raise ValueError(f"Unknown method: {method}")
-        return {"id": req_id, "result": result}
+            result = _call_keepgpu_method(server, method, params)
+        return _jsonrpc_result(req_id, result)
+    except JSONRPCError as exc:
+        return _jsonrpc_error(req_id, exc.code, exc.message)
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Request failed")
-        return {"id": req_id, "error": {"message": str(exc)}}
+        return _jsonrpc_error(req_id, JSONRPC_INTERNAL_ERROR, str(exc))
 
 
 class _JSONRPCHandler(BaseHTTPRequestHandler):
     server_version = "KeepGPU-MCP/0.1"
+
+    def _empty_response(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("content-length", "0")
+        self.end_headers()
 
     def _json_response(self, status: int, payload: Dict[str, Any]) -> None:
         data = json.dumps(payload).encode("utf-8")
@@ -629,6 +831,9 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             # JSON-RPC compatibility endpoint.
             if path in ("/", "/rpc"):
                 response = _handle_request(server_ref, payload)
+                if response is None:
+                    self._empty_response(202)
+                    return
                 self._json_response(200, response)
                 return
 
@@ -683,8 +888,12 @@ def run_stdio(server: KeepGPUServer) -> None:
         try:
             payload = json.loads(line)
             response = _handle_request(server, payload)
+        except json.JSONDecodeError as exc:
+            response = _jsonrpc_error(None, JSONRPC_PARSE_ERROR, str(exc))
         except Exception as exc:
-            response = {"error": {"message": str(exc)}}
+            response = _jsonrpc_error(None, JSONRPC_INTERNAL_ERROR, str(exc))
+        if response is None:
+            continue
         sys.stdout.write(json.dumps(response) + "\n")
         sys.stdout.flush()
 

--- a/src/keep_gpu/utilities/logger.py
+++ b/src/keep_gpu/utilities/logger.py
@@ -27,7 +27,7 @@ def _parse_log_level(env_value: Optional[str], default: Optional[int]) -> Option
 
 def _build_console_handler(level: int) -> logging.Handler:
     """Create a colored console handler with filename:lineno."""
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(level)
     color_fmt = "%(log_color)s%(asctime)s [%(levelname)s] %(name)s (%(filename)s:%(lineno)d): %(message)s"
     plain_fmt = (

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,5 +1,10 @@
+import json
+import os
+import subprocess
+import sys
 import threading
 import time
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -296,6 +301,252 @@ def test_list_gpus():
     server = make_server()
     info = server.list_gpus()
     assert "gpus" in info
+
+
+def test_mcp_initialize_returns_server_capabilities():
+    server = make_server()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "probe", "version": "0"},
+        },
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 1
+    result = resp["result"]
+    assert result["protocolVersion"] == "2025-06-18"
+    assert "tools" in result["capabilities"]
+    assert result["serverInfo"]["name"] == "keepgpu"
+    assert result["serverInfo"]["title"] == "KeepGPU"
+    assert result["serverInfo"]["version"]
+
+
+def test_mcp_initialized_notification_has_no_response():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+
+    resp = _handle_request(server, req)
+
+    assert resp is None
+
+
+def test_mcp_tools_list_exposes_keepgpu_actions():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 2
+    tools = {tool["name"]: tool for tool in resp["result"]["tools"]}
+    assert set(tools) == {"start_keep", "stop_keep", "status", "list_gpus"}
+    start_schema = tools["start_keep"]["inputSchema"]
+    assert start_schema["type"] == "object"
+    assert start_schema["properties"]["gpu_ids"]["items"]["type"] == "integer"
+    assert start_schema["properties"]["busy_threshold"]["default"] == -1
+    assert tools["status"]["inputSchema"]["properties"]["job_id"]["type"] == [
+        "string",
+        "null",
+    ]
+
+
+def test_mcp_tools_call_routes_to_existing_status_method():
+    server = make_server()
+    job_id = server.start_keep(job_id="mcp-job", gpu_ids=[0])["job_id"]
+    req = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": "status", "arguments": {"job_id": job_id}},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 3
+    result = resp["result"]
+    assert result["isError"] is False
+    assert result["content"][0]["type"] == "text"
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["active"] is True
+    assert payload["job_id"] == "mcp-job"
+    assert payload["params"]["gpu_ids"] == [0]
+
+
+def test_mcp_tools_call_unknown_tool_returns_protocol_error():
+    server = make_server()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {"name": "not_a_tool", "arguments": {}},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 4
+    assert resp["error"]["code"] == -32602
+    assert resp["error"]["message"] == "Unknown tool: not_a_tool"
+
+
+def test_mcp_tools_call_rejects_non_object_arguments():
+    server = make_server()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/call",
+        "params": {"name": "status", "arguments": []},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 5
+    assert resp["error"]["code"] == -32602
+    assert resp["error"]["message"] == "Tool call arguments must be an object."
+
+
+def test_jsonrpc_unknown_method_returns_method_not_found_code():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "id": 6, "method": "not_a_method", "params": {}}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 6
+    assert resp["error"]["code"] == -32601
+    assert resp["error"]["message"] == "Unknown method: not_a_method"
+
+
+def test_mcp_requests_require_id():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "method": "tools/list", "params": {}}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] is None
+    assert resp["error"]["code"] == -32600
+    assert resp["error"]["message"] == "Requests must include an id."
+
+
+def test_mcp_unrecognized_notification_has_no_response():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {}}
+
+    resp = _handle_request(server, req)
+
+    assert resp is None
+
+
+def test_mcp_notification_with_id_is_invalid_request():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "id": 7, "method": "notifications/initialized"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 7
+    assert resp["error"]["code"] == -32600
+    assert resp["error"]["message"] == "Notifications must not include an id."
+
+
+def test_mcp_stdio_stdout_contains_only_protocol_json():
+    request = {
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "tools/list",
+    }
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "keep_gpu.mcp.server"],
+        input=json.dumps(request) + "\n",
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(stdout_lines) == 1
+    response = json.loads(stdout_lines[0])
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 8
+    assert sorted(tool["name"] for tool in response["result"]["tools"]) == [
+        "list_gpus",
+        "start_keep",
+        "status",
+        "stop_keep",
+    ]
+
+
+def test_mcp_stdio_parse_errors_are_jsonrpc_errors():
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "keep_gpu.mcp.server"],
+        input="{not json}\n",
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(stdout_lines) == 1
+    response = json.loads(stdout_lines[0])
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] is None
+    assert response["error"]["code"] == -32700
+    assert "Expecting property name" in response["error"]["message"]
+
+
+def test_mcp_stdio_non_object_messages_are_invalid_request_errors():
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "keep_gpu.mcp.server"],
+        input='["not", "an", "object"]\n',
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(stdout_lines) == 1
+    response = json.loads(stdout_lines[0])
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] is None
+    assert response["error"]["code"] == -32600
+    assert response["error"]["message"] == "JSON-RPC messages must be objects."
 
 
 def test_end_to_end_jsonrpc():


### PR DESCRIPTION
## Summary
- Add MCP lifecycle/tool protocol handling for stdio clients: initialize, notifications/initialized, tools/list, and tools/call.
- Preserve legacy direct JSON-RPC methods while adding JSON-RPC error codes and stricter invalid-request/invalid-params handling.
- Keep MCP stdio stdout protocol-only by moving console diagnostics to stderr, and clarify that HTTP mode is JSON-RPC/REST/dashboard rather than Streamable HTTP MCP.

## Verification
- RED: protocol tests failed on unknown initialize/tools methods before implementation.
- RED: stdio test failed while logs were emitted on stdout.
- RED: review-feedback tests failed before JSON-RPC error codes, invalid-params, and non-object message handling were fixed.
- PYTHONPATH=$PWD/src pytest tests -q -> 214 passed, 12 skipped
- PYTHONPATH=$PWD/src mkdocs build -> succeeded
- pre-commit run --all-files -> passed
- git diff --check -> clean
- Local subagent review: no Critical/Important/Minor issues remain

## Notes
- Standard MCP client support in this PR is stdio. HTTP mode continues to serve KeepGPU JSON-RPC/REST/dashboard surfaces and is documented as not being a Streamable HTTP MCP endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for standard MCP client flow, including initialization, tool listing, and tool calls.
  * Exposed KeepGPU tools for starting, stopping, checking status, and listing GPUs.

* **Bug Fixes**
  * Improved protocol handling for invalid requests, unknown methods, and malformed input.
  * Updated console logging so protocol output stays on standard out and logs go to standard error.

* **Documentation**
  * Expanded MCP and API docs with updated client examples, endpoint guidance, and legacy compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->