### PR TITLE
[rocm, telemetry] fix: map visible ranks for SMI utilization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,9 @@ This file defines how coding agents should work in this repository.
 - Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
-- Treat public `gpu_ids` as visible device ordinals after any user-supplied `CUDA_VISIBLE_DEVICES` filtering. Do not rewrite `CUDA_VISIBLE_DEVICES` inside KeepGPU command paths; reject explicit CUDA/ROCm ordinals outside the current visible device count before starting keep workers.
+- Treat public `gpu_ids` as visible device ordinals after user-supplied CUDA or ROCm visibility filtering. Do not rewrite visibility masks inside KeepGPU command paths; reject explicit CUDA/ROCm ordinals outside the current visible device count before starting keep workers.
 - Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` numeric/UUID tokens to the correct NVML handle. If that mapping is ambiguous or unsupported, return `None` rather than falling back to a possibly wrong physical index.
+- Keep ROCm telemetry aligned with visible ROCm ordinals: resolve `ROCR_VISIBLE_DEVICES` as the base mask and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. If the mapping is malformed, conflicting, unsupported, or out of range, return unavailable utilization rather than querying a guessed SMI index.
 - Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus` must expose `id` as the visible ordinal users can pass as `gpu_ids`; physical/vendor identifiers belong in explicit metadata fields such as `physical_id` and must not be accepted implicitly as selection IDs.
 - Global controller startup must fail clearly when GPU selection resolves to zero or duplicate devices; do not create silent no-op or duplicate-worker keep sessions.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
@@ -101,6 +102,7 @@ This file defines how coding agents should work in this repository.
   - `pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py`
   - `pytest tests -k threshold`
   - `pytest tests/mcp tests/utilities/test_gpu_info.py`
+  - `pytest tests/rocm_controller/test_rocm_utilization.py tests/utilities/test_gpu_info.py`
   - `pytest --run-rocm tests/rocm_controller` (only on ROCm-capable machines)
 - Respect existing pytest markers:
   - `rocm` for ROCm-only tests

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Flags that matter:
   - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
   - `--interval` (positive seconds): sleep between keep-alive bursts.
   - `--busy-threshold`: defaults to `25`; `0..100` skips work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
-  - `--gpu-ids`: target unique non-negative visible device ordinals after any user-supplied `CUDA_VISIBLE_DEVICES` filtering; otherwise all visible GPUs are guarded. Empty, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
+  - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm); otherwise all visible GPUs are guarded. Empty, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
 - Service mode commands:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
   - `keep-gpu start`: create keep session and return immediately.
@@ -106,14 +106,14 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy
 ```
 
 Pass `gpu_ids=None` to use all visible GPUs. Explicit values are visible device
-ordinals, not physical NVML IDs. Passing an empty, duplicate, or out-of-range
-list is invalid, and startup raises an error if discovery resolves to zero
-devices.
+ordinals, not physical NVML/ROCm SMI IDs. Passing an empty, duplicate, or
+out-of-range list is invalid, and startup raises an error if discovery resolves
+to zero devices.
 
 ## What you get
 
 - Battle-tested keep-alive loop built on PyTorch.
-- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`. Public entry points default `busy_threshold` to `25`. Valid values are `-1` or `0..100`; if utilization is unavailable and the threshold is non-negative, KeepGPU sleeps for that cycle instead of running compute. CUDA utilization checks use visible CUDA ordinals, so with `CUDA_VISIBLE_DEVICES=3,5`, rank `1` reads NVML telemetry for physical GPU `5`; ambiguous mappings are treated as unavailable telemetry.
+- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; optional ROCm SMI support by way of `pip install keep-gpu[rocm]`. Public entry points default `busy_threshold` to `25`. Valid values are `-1` or `0..100`; if utilization is unavailable and the threshold is non-negative, KeepGPU sleeps for that cycle instead of running compute. CUDA utilization checks use visible CUDA ordinals, so with `CUDA_VISIBLE_DEVICES=3,5`, rank `1` reads NVML telemetry for physical GPU `5`. ROCm utilization similarly resolves visible ranks through `ROCR_VISIBLE_DEVICES` and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. Ambiguous mappings are treated as unavailable telemetry.
 - CLI + API parity: same controllers power both code paths.
 - Continuous docs + CI: mkdocs + mkdocstrings build in CI to keep guidance up to date.
 
@@ -121,7 +121,7 @@ devices.
 
 - Install dev extras: `pip install -e ".[dev]"` (add `.[rocm]` if you need ROCm SMI).
 - Fast CUDA checks: `pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py tests/test_cli_thresholds.py`
-- ROCm-only tests carry `@pytest.mark.rocm`; run with `pytest --run-rocm tests/rocm_controller`.
+- ROCm visibility tests use mocks and run without hardware; ROCm-only hardware tests carry `@pytest.mark.rocm` and run with `pytest --run-rocm tests/rocm_controller`.
 - Markers: `rocm` (needs ROCm stack) and `large_memory` (opt-in locally).
 
 ### MCP and service API

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -15,7 +15,11 @@ schedulers that the GPU is still busy, without burning a full training workload.
 4. **GPU monitor (NVML/ROCm/MPS)** – Wraps `nvidia-ml-py` (the `pynvml`
    module) for CUDA telemetry, optionally `rocm-smi` when installed by way of
    the `rocm` extra, and best-effort MPS memory counters on Mac M series.
-   Utilization can be unavailable on some platforms and is reported as `null`.
+   CUDA telemetry resolves `CUDA_VISIBLE_DEVICES` before querying NVML. ROCm
+   telemetry resolves `ROCR_VISIBLE_DEVICES` plus one matching
+   `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm
+   SMI. Utilization can be unavailable on some platforms and is reported as
+   `null`.
 5. **Utilities** – `parse_size` turns strings like `1GiB` or bare byte values into
    internal float32 tensor element counts, while `setup_logger` wires both console
    and file logging with optional colors.
@@ -39,12 +43,17 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
      The monitor receives the CUDA visible rank and resolves
      `CUDA_VISIBLE_DEVICES` numeric or UUID tokens before querying NVML, so
      telemetry follows the same device the worker keeps.
-4. If utilization exceeds `busy_threshold`, or if utilization is unavailable
+4. Each ROCm worker follows the same visible-rank contract. The controller keeps
+   the visible rank selected by the user, while ROCm SMI telemetry is queried by
+   the resolved physical SMI index when the environment masks are numeric,
+   unique, and unambiguous. If the mapping cannot be resolved, telemetry is
+   unavailable for that cycle.
+5. If utilization exceeds `busy_threshold`, or if utilization is unavailable
    while `busy_threshold` is non-negative, the worker just sleeps for one more
    `interval`. Otherwise it runs a new batch of ops. Public defaults use
    `busy_threshold=25`. Valid thresholds are `-1` or `0..100`;
    `busy_threshold=-1` is the explicit unconditional mode.
-5. When you call `release()` (or exit the context), every worker sets a stop
+6. When you call `release()` (or exit the context), every worker sets a stop
    event, joins the thread, and clears the device cache. Release attempts every
    worker and then raises a summary if any worker failed to stop.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,8 +149,10 @@ with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=60):
     run_cpu_bound_stage()
 ```
 
-Those `gpu_ids` are visible device ordinals after any `CUDA_VISIBLE_DEVICES`
-filtering.
+Those `gpu_ids` are visible device ordinals after CUDA or ROCm visibility
+filtering. CUDA telemetry resolves `CUDA_VISIBLE_DEVICES`; ROCm telemetry
+resolves `ROCR_VISIBLE_DEVICES` and one matching `HIP_VISIBLE_DEVICES` or
+`CUDA_VISIBLE_DEVICES` overlay before querying vendor utilization counters.
 
 From here, jump to the CLI Playbook for scenario-driven guidance or the API
 recipes if you need to embed KeepGPU in orchestration scripts.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -109,10 +109,11 @@ of `keep-gpu status`.
 
 - **`--gpu-ids` parse error**: use only comma-separated visible ordinals (`0,1`).
 - **Unexpected GPU selection**: set `CUDA_VISIBLE_DEVICES` before starting
-  KeepGPU, then pass visible ordinals by way of `--gpu-ids`. KeepGPU does not
-  rewrite `CUDA_VISIBLE_DEVICES` in blocking mode. In service mode, ordinals are
-  interpreted in the already-running service process environment.
+  KeepGPU on CUDA, or `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES` before
+  starting KeepGPU on ROCm, then pass visible ordinals by way of `--gpu-ids`.
+  KeepGPU does not rewrite visibility masks in blocking mode. In service mode,
+  ordinals are interpreted in the already-running service process environment.
 - **Start cannot reach service**: run `keep-gpu serve --host 127.0.0.1 --port 8765`.
 - **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop`. Use `keep-gpu service-stop --force` only for an unresponsive auto-started daemon; it still refuses to signal a PID that KeepGPU cannot verify as its own.
 - **OOM during keep**: reduce `--vram` or free GPU memory before starting.
-- **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra. Valid `busy_threshold` values are `-1` or `0..100`, and omitted CLI values default to `25`. With non-negative `busy_threshold`, KeepGPU sleeps when utilization is unavailable. On Mac M series, utilization is expected to be `null`, so use `--busy-threshold -1` only when you intentionally want unconditional keepalive compute.
+- **No utilization data**: on CUDA, ensure `nvidia-ml-py` works and `nvidia-smi` is available; on ROCm, check the optional `rocm-smi` extra and avoid conflicting `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` masks. ROCm telemetry resolves visible ranks through `ROCR_VISIBLE_DEVICES` plus one HIP/CUDA overlay and reports unavailable utilization rather than guessing when the mapping is malformed or ambiguous. Valid `busy_threshold` values are `-1` or `0..100`, and omitted CLI values default to `25`. With non-negative `busy_threshold`, KeepGPU sleeps when utilization is unavailable. On Mac M series, utilization is expected to be `null`, so use `--busy-threshold -1` only when you intentionally want unconditional keepalive compute.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -125,6 +125,9 @@ curl http://127.0.0.1:8765/api/sessions
 `/api/gpus` returns start-compatible visible ordinals as `id`/`visible_id`.
 Optional `physical_id` or `uuid` fields describe the underlying vendor device
 only; clients should not send those metadata values as `gpu_ids`.
+On ROCm, `physical_id` is included only when KeepGPU can safely resolve
+`ROCR_VISIBLE_DEVICES` and one matching HIP/CUDA overlay to a ROCm SMI index;
+otherwise utilization is reported as unavailable rather than guessed.
 
 Start and stop by way of REST:
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -17,11 +17,13 @@ with CudaGPUController(rank=0, interval=0.5, vram_to_keep="1.5GiB"):
 train_model()                     # GPU memory is released automatically
 ```
 
-- `rank` matches the CUDA device index (after any `CUDA_VISIBLE_DEVICES` filtering).
-  Utilization backoff resolves that visible rank through `CUDA_VISIBLE_DEVICES`
-  before querying NVML; for example, with `CUDA_VISIBLE_DEVICES=3,5`, rank `1`
-  reads physical GPU `5`. If the mapping cannot be resolved, utilization is
-  treated as unavailable.
+- `rank` matches the visible device index after environment filtering.
+  CUDA utilization backoff resolves that visible rank through
+  `CUDA_VISIBLE_DEVICES` before querying NVML; for example, with
+  `CUDA_VISIBLE_DEVICES=3,5`, rank `1` reads physical GPU `5`. ROCm
+  utilization resolves `ROCR_VISIBLE_DEVICES` as the base mask and one matching
+  `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm
+  SMI. If a mapping cannot be resolved, utilization is treated as unavailable.
 - `interval` is the positive pause between keep-alive bursts inside the background thread.
 - `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size` handles it).
 
@@ -58,7 +60,7 @@ with GlobalGPUController(
 
 - Each `CudaGPUController` runs in its own thread.
 - `gpu_ids=None` means all visible GPUs. Explicit values are visible device
-  ordinals after any `CUDA_VISIBLE_DEVICES` filtering. Empty, duplicate, or
+  ordinals after CUDA or ROCm visibility filtering. Empty, duplicate, or
   out-of-range lists are invalid, and startup raises `ValueError` if the
   resolved selection contains zero devices.
 - `busy_threshold` defaults to `25` and accepts `-1` or a percentage in
@@ -96,6 +98,7 @@ def main():
   process is already using the GPU.
 - **Controllers never stop** – Ensure you call `release()` even when exceptions
   occur. Context managers are the safest way to guarantee cleanup.
-- **Need ROCm/CPU fallback?** – `GlobalGPUController` currently raises
-  `NotImplementedError` outside CUDA platforms. Catch the exception and skip the
-  guard logic if you deploy to mixed hardware fleets.
+- **Need a CPU-only fallback?** – `GlobalGPUController` supports CUDA, ROCm, and
+  Mac M backends when the matching PyTorch/runtime stack is available. In
+  CPU-only environments, catch the startup error and skip the guard logic for
+  that run.

--- a/docs/plans/rocm-visible-rank-telemetry.md
+++ b/docs/plans/rocm-visible-rank-telemetry.md
@@ -1,0 +1,76 @@
+# ROCm Visible-Rank Telemetry Plan
+
+## Background
+
+Public GPU selection uses visible ordinals after user-supplied visibility masks,
+but ROCm telemetry currently sends those visible ranks directly to
+`rocm_smi.rsmi_dev_busy_percent_get()`. With masks such as
+`HIP_VISIBLE_DEVICES=3,5`, visible rank `1` refers to physical GPU `5`, while
+the current code queries SMI index `1`.
+
+## Goal
+
+Keep ROCm keepalive backoff and GPU listing telemetry aligned with the same
+visible ordinals users pass to KeepGPU. If the visible-to-physical mapping is
+ambiguous, return unavailable utilization instead of querying a possibly wrong
+device.
+
+## Solution
+
+- Add a small ROCm visibility resolver in `src/keep_gpu/utilities/` shared by
+  the ROCm controller and `gpu_info`.
+- Resolve `ROCR_VISIBLE_DEVICES` as the base mask, then apply one
+  `HIP_VISIBLE_DEVICES` or `CUDA_VISIBLE_DEVICES` overlay. If both HIP and CUDA
+  masks are set, they must normalize to the same numeric token list.
+- Accept only unique non-negative numeric tokens. Empty, `-1`, malformed,
+  duplicate, unsupported, out-of-range, or conflicting overlay masks resolve to
+  unavailable telemetry.
+- Use the resolved physical SMI index for `rsmi_dev_busy_percent_get()`;
+  otherwise return `None` so non-negative `busy_threshold` sleeps.
+- Keep GPU listing IDs as visible ordinals and add `physical_id` only when the
+  ROCm SMI index is known.
+
+## Tasks
+
+- [x] Add failing no-hardware tests for `RocmGPUController._query_utilization()`
+      mapping visible rank `1` through `HIP_VISIBLE_DEVICES=3,5` to SMI index
+      `5`.
+- [x] Add failing no-hardware tests that malformed or conflicting ROCm
+      visibility masks return `None` and do not call SMI.
+- [x] Add failing no-hardware `gpu_info` tests that list visible IDs while
+      querying resolved physical SMI indexes and exposing `physical_id`.
+- [x] Implement the shared resolver and route ROCm controller/listing telemetry
+      through it.
+- [x] Update `AGENTS.md`, README, CLI/Python/API docs, and this plan's
+      verification notes.
+- [x] Run targeted tests, full tests, docs build, and pre-commit.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- Red checks:
+  - Initial test setup was corrected after `vram_to_keep=1` proved invalid.
+  - Final RED run failed as expected: current code returned visible-index
+    utilization (`40`/`41`) and omitted ROCm `physical_id`.
+- Green check completed:
+  - `PYTHONPATH=$PWD/src pytest tests/rocm_controller/test_rocm_utilization.py tests/utilities/test_gpu_info.py -q`
+  - Result: `24 passed, 1 skipped`.
+- Completed checks:
+  - `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/utilities/test_gpu_info.py -q`
+    - Result: `26 passed, 1 skipped`.
+  - `PYTHONPATH=$PWD/src pytest tests -q`
+    - Result: `235 passed, 11 skipped`.
+  - `PYTHONPATH=$PWD/src mkdocs build`
+    - Result: passed with the existing Material warning and unlisted plan-page
+      notices.
+  - `pre-commit run --all-files`
+    - Result: passed.
+  - `git diff --check`
+    - Result: passed.
+- Local subagent review:
+  - Initial review found the new resolver/plan were untracked and one stale
+    Python guide note still described CUDA-only fallback.
+  - Follow-up review after staging the new files and updating the Python guide
+    returned no remaining must-fix findings.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,9 +5,17 @@ module exposes the Typer entry point, while the controllers and utilities power
 both the command-line and Python recipes.
 
 For global sessions, `gpu_ids=None` means all visible GPUs. Explicit values are
-visible device ordinals after any `CUDA_VISIBLE_DEVICES` filtering. Passing an
+visible device ordinals after CUDA or ROCm visibility filtering. Passing an
 empty, duplicate, or out-of-range list is invalid, and startup raises
-`ValueError` if discovery resolves to zero devices.
+`ValueError` if discovery resolves to zero devices. Telemetry may expose
+metadata such as `physical_id`, but those fields are not accepted as selection
+IDs.
+
+CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
+querying NVML. ROCm telemetry resolves `ROCR_VISIBLE_DEVICES` as the base mask
+and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before
+querying ROCm SMI. Unresolved mappings report unavailable utilization instead
+of falling back to a possibly wrong physical device.
 
 Public controller, CLI, REST, JSON-RPC, and MCP defaults use
 `busy_threshold=25`. Pass `busy_threshold=-1` only when you intentionally want

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -111,6 +111,8 @@ digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
 
 | Variable | Effect |
 | --- | --- |
-| `CUDA_VISIBLE_DEVICES` | Standard CUDA filtering. Set it before starting KeepGPU; `--gpu-ids` selects visible ordinals after filtering, and service mode uses the daemon process environment. CUDA utilization telemetry maps visible ordinals through numeric or UUID tokens before querying NVML, and unresolved mappings report unavailable telemetry. |
+| `CUDA_VISIBLE_DEVICES` | Standard CUDA filtering, and a HIP-compatible ROCm overlay when `HIP_VISIBLE_DEVICES` is unset. Set it before starting KeepGPU; `--gpu-ids` selects visible ordinals after filtering, and service mode uses the daemon process environment. CUDA utilization telemetry maps visible ordinals through numeric or UUID tokens before querying NVML, and unresolved mappings report unavailable telemetry. ROCm utilization treats this as one overlay on top of `ROCR_VISIBLE_DEVICES` and reports unavailable telemetry when it conflicts with `HIP_VISIBLE_DEVICES`. |
+| `ROCR_VISIBLE_DEVICES` | ROCm base visibility mask. KeepGPU keeps `gpu_ids` as visible ordinals while resolving this mask before querying ROCm SMI telemetry. Unsupported, malformed, duplicate, or out-of-range numeric masks report unavailable utilization instead of guessing a physical SMI index. |
+| `HIP_VISIBLE_DEVICES` | ROCm HIP-layer visibility overlay. If both `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES` are set, they must describe the same numeric overlay for ROCm telemetry to query ROCm SMI; otherwise utilization is unavailable and non-negative `busy_threshold` values sleep for that cycle. |
 | `CONSOLE_LOG_LEVEL` | Console log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `no`). |
 | `FILE_LOG_LEVEL` | File log level; writes logs under `./logs/` when enabled. |

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -10,6 +10,7 @@ from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
 )
+from keep_gpu.utilities.rocm_visibility import resolve_rocm_visible_rank_to_smi_index
 
 logger = setup_logger(__name__)
 
@@ -114,8 +115,11 @@ class RocmGPUController(BaseGPUController):
     def _query_utilization(self) -> Optional[int]:
         if not self._rocm_smi:
             return None
+        smi_index = resolve_rocm_visible_rank_to_smi_index(self.rank, self._rocm_smi)
+        if smi_index is None:
+            return None
         try:
-            util = self._rocm_smi.rsmi_dev_busy_percent_get(self.rank)
+            util = self._rocm_smi.rsmi_dev_busy_percent_get(smi_index)
             return int(util)
         except Exception as exc:  # pragma: no cover - env-specific
             logger.debug("ROCm utilization query failed: %s", exc)

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -174,9 +174,10 @@ def _query_rocm() -> List[Dict[str, Any]]:
             )
             util = None
             if physical_id is not None:
+                # ROCm SMI utilization probes are best effort.
                 try:
                     util = int(rocm_smi.rsmi_dev_busy_percent_get(physical_id))
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     logger.debug("ROCm util query failed for %s: %s", physical_id, exc)
 
             try:

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, List, Optional
 import torch
 
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.rocm_visibility import (
+    resolve_rocm_visible_rank_to_smi_index,
+    rocm_monitor_device_count,
+)
 
 logger = setup_logger(__name__)
 
@@ -158,16 +162,22 @@ def _query_rocm() -> List[Dict[str, Any]]:
     current_device = None
     try:
         rocm_smi.rsmi_init()
+        monitor_count = rocm_monitor_device_count(rocm_smi)
         if torch.cuda.is_available():
             current_device = torch.cuda.current_device()
         # Use torch to enumerate devices for names/memory
         count = torch.cuda.device_count() if torch.cuda.is_available() else 0
         for idx in range(count):
+            physical_id = resolve_rocm_visible_rank_to_smi_index(
+                idx,
+                monitor_count=monitor_count,
+            )
             util = None
-            try:
-                util = int(rocm_smi.rsmi_dev_busy_percent_get(idx))
-            except Exception as exc:
-                logger.debug("ROCm util query failed for %s: %s", idx, exc)
+            if physical_id is not None:
+                try:
+                    util = int(rocm_smi.rsmi_dev_busy_percent_get(physical_id))
+                except Exception as exc:
+                    logger.debug("ROCm util query failed for %s: %s", physical_id, exc)
 
             try:
                 torch.cuda.set_device(idx)
@@ -181,17 +191,18 @@ def _query_rocm() -> List[Dict[str, Any]]:
             except Exception:
                 name = f"rocm:{idx}"
 
-            infos.append(
-                {
-                    "id": idx,
-                    "visible_id": idx,
-                    "platform": "rocm",
-                    "name": name,
-                    "memory_total": int(total) if total is not None else None,
-                    "memory_used": int(used) if used is not None else None,
-                    "utilization": util,
-                }
-            )
+            info = {
+                "id": idx,
+                "visible_id": idx,
+                "platform": "rocm",
+                "name": name,
+                "memory_total": int(total) if total is not None else None,
+                "memory_used": int(used) if used is not None else None,
+                "utilization": util,
+            }
+            if physical_id is not None:
+                info["physical_id"] = physical_id
+            infos.append(info)
     finally:
         if current_device is not None:
             try:

--- a/src/keep_gpu/utilities/rocm_visibility.py
+++ b/src/keep_gpu/utilities/rocm_visibility.py
@@ -25,9 +25,10 @@ def rocm_monitor_device_count(rocm_smi) -> Optional[int]:
     count_fn = getattr(rocm_smi, "rsmi_num_monitor_devices", None)
     if count_fn is None:
         return None
+    # ROCm SMI probes can fail with vendor-specific errors.
     try:
         count = int(count_fn())
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     return count if count >= 0 else None
 

--- a/src/keep_gpu/utilities/rocm_visibility.py
+++ b/src/keep_gpu/utilities/rocm_visibility.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+_UNSET = object()
+
+
+def _parse_numeric_mask(name: str) -> Optional[Tuple[int, ...]]:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+
+    tokens = [token.strip() for token in raw.split(",")]
+    if not tokens or any(not token or not token.isdigit() for token in tokens):
+        return ()
+
+    values = tuple(int(token) for token in tokens)
+    if len(set(values)) != len(values):
+        return ()
+    return values
+
+
+def rocm_monitor_device_count(rocm_smi) -> Optional[int]:
+    count_fn = getattr(rocm_smi, "rsmi_num_monitor_devices", None)
+    if count_fn is None:
+        return None
+    try:
+        count = int(count_fn())
+    except Exception:
+        return None
+    return count if count >= 0 else None
+
+
+def _physical_ids_available(
+    physical_ids: Tuple[int, ...],
+    monitor_count: Optional[int],
+) -> bool:
+    if monitor_count is None:
+        return True
+    return all(physical_id < monitor_count for physical_id in physical_ids)
+
+
+def _effective_overlay_mask() -> Optional[Tuple[int, ...]]:
+    hip_mask = _parse_numeric_mask("HIP_VISIBLE_DEVICES")
+    cuda_mask = _parse_numeric_mask("CUDA_VISIBLE_DEVICES")
+
+    if hip_mask == () or cuda_mask == ():
+        return ()
+    if hip_mask is not None and cuda_mask is not None:
+        return hip_mask if hip_mask == cuda_mask else ()
+    return hip_mask if hip_mask is not None else cuda_mask
+
+
+def resolve_rocm_visible_rank_to_smi_index(
+    visible_rank: int,
+    rocm_smi=None,
+    *,
+    monitor_count=_UNSET,
+) -> Optional[int]:
+    if visible_rank < 0:
+        return None
+
+    if monitor_count is _UNSET:
+        monitor_count = rocm_monitor_device_count(rocm_smi)
+
+    base_mask = _parse_numeric_mask("ROCR_VISIBLE_DEVICES")
+    overlay_mask = _effective_overlay_mask()
+    if base_mask == () or overlay_mask == ():
+        return None
+
+    if base_mask is None and overlay_mask is None:
+        if monitor_count is not None and visible_rank >= monitor_count:
+            return None
+        return visible_rank
+
+    if base_mask is not None:
+        if not _physical_ids_available(base_mask, monitor_count):
+            return None
+        if overlay_mask is None:
+            visible_physical_ids = base_mask
+        else:
+            if any(rank >= len(base_mask) for rank in overlay_mask):
+                return None
+            visible_physical_ids = tuple(base_mask[rank] for rank in overlay_mask)
+    else:
+        assert overlay_mask is not None
+        visible_physical_ids = overlay_mask
+        if not _physical_ids_available(visible_physical_ids, monitor_count):
+            return None
+
+    if visible_rank >= len(visible_physical_ids):
+        return None
+    return visible_physical_ids[visible_rank]
+
+
+__all__ = [
+    "resolve_rocm_visible_rank_to_smi_index",
+    "rocm_monitor_device_count",
+]

--- a/tests/rocm_controller/test_rocm_utilization.py
+++ b/tests/rocm_controller/test_rocm_utilization.py
@@ -1,36 +1,112 @@
 import sys
 
-import pytest
-
-from keep_gpu.single_gpu_controller import rocm_gpu_controller as rgc
+from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
 
 
-@pytest.mark.rocm
-def test_query_rocm_utilization_with_mock(monkeypatch, rocm_available):
-    if not rocm_available:
-        pytest.skip("ROCm stack not available")
+class DummyRocmSMI:
+    def __init__(self, util_by_index: dict[int, int] | None = None, count: int = 8):
+        self.util_by_index = util_by_index or {}
+        self.count = count
+        self.queried_indexes: list[int] = []
 
-    class DummyRocmSMI:
-        calls = 0
+    def rsmi_num_monitor_devices(self):
+        return self.count
 
-        @classmethod
-        def rsmi_init(cls):
-            cls.calls += 1
+    def rsmi_dev_busy_percent_get(self, index):
+        self.queried_indexes.append(index)
+        return self.util_by_index.get(index, 40 + index)
 
-        @staticmethod
-        def rsmi_dev_busy_percent_get(index):
-            assert index == 1
-            return 42
 
-        @classmethod
-        def rsmi_shut_down(cls):
-            cls.calls += 1
+def _controller_with_dummy_smi(monkeypatch, rank: int, dummy: DummyRocmSMI):
+    monkeypatch.setitem(sys.modules, "rocm_smi", dummy)
+    return RocmGPUController(rank=rank, vram_to_keep=4)
 
-    # Ensure the counter is reset to avoid leaking state between tests
-    DummyRocmSMI.calls = 0
-    monkeypatch.setitem(sys.modules, "rocm_smi", DummyRocmSMI)
-    util = rgc._query_rocm_utilization(1)
-    assert util == 42
-    assert DummyRocmSMI.calls == 2  # init + shutdown
-    # Reset after test for cleanliness
-    DummyRocmSMI.calls = 0
+
+def test_rocm_utilization_defaults_visible_rank_to_smi_index(monkeypatch):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(util_by_index={1: 71})
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() == 71
+    assert dummy.queried_indexes == [1]
+
+
+def test_rocm_utilization_maps_hip_visible_rank_to_smi_index(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3,5")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(util_by_index={5: 88})
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() == 88
+    assert dummy.queried_indexes == [5]
+
+
+def test_rocm_utilization_composes_rocr_base_and_hip_visible_mask(monkeypatch):
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "2,4")
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(util_by_index={4: 91})
+    controller = _controller_with_dummy_smi(monkeypatch, rank=0, dummy=dummy)
+
+    assert controller._query_utilization() == 91
+    assert dummy.queried_indexes == [4]
+
+
+def test_rocm_utilization_uses_cuda_mask_when_hip_is_unset(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,5")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(util_by_index={5: 89})
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() == 89
+    assert dummy.queried_indexes == [5]
+
+
+def test_rocm_utilization_treats_conflicting_hip_cuda_masks_as_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3,5")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,6")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI()
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() is None
+    assert dummy.queried_indexes == []
+
+
+def test_rocm_utilization_treats_malformed_mask_as_unavailable(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,,2")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI()
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() is None
+    assert dummy.queried_indexes == []
+
+
+def test_rocm_utilization_treats_out_of_range_mask_as_unavailable(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,9")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(count=4)
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() is None
+    assert dummy.queried_indexes == []
+
+
+def test_rocm_utilization_treats_unresolved_uuid_mask_as_unavailable(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "GPU-abc123")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI()
+    controller = _controller_with_dummy_smi(monkeypatch, rank=0, dummy=dummy)
+
+    assert controller._query_utilization() is None
+    assert dummy.queried_indexes == []

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -63,6 +63,90 @@ class MultiGPUDummyNVML:
         self.shutdown_calls += 1
 
 
+class DummyTorchCudaROCm:
+    def __init__(self, count: int = 2):
+        self.count = count
+        self.current = 0
+        self.set_devices: list[int] = []
+
+    @staticmethod
+    def is_available():
+        return True
+
+    def current_device(self):
+        return self.current
+
+    def device_count(self):
+        return self.count
+
+    def set_device(self, idx):
+        self.set_devices.append(idx)
+        self.current = idx
+
+    @staticmethod
+    def mem_get_info():
+        return (50, 100)
+
+    @staticmethod
+    def get_device_name(idx):
+        return f"ROCm {idx}"
+
+
+class DummyROCMSMI:
+    def __init__(self, util_by_index: dict[int, int] | None = None, count: int = 8):
+        self.util_by_index = util_by_index or {}
+        self.count = count
+        self.queried_indexes: list[int] = []
+        self.init_calls = 0
+        self.shutdown_calls = 0
+
+    def rsmi_init(self):
+        self.init_calls += 1
+
+    def rsmi_num_monitor_devices(self):
+        return self.count
+
+    def rsmi_dev_busy_percent_get(self, idx):
+        self.queried_indexes.append(idx)
+        return self.util_by_index.get(idx, 40 + idx)
+
+    def rsmi_shut_down(self):
+        self.shutdown_calls += 1
+
+
+def _install_rocm_gpu_info_mocks(
+    monkeypatch,
+    *,
+    count: int = 2,
+    util_by_index: dict[int, int] | None = None,
+    smi_count: int = 8,
+):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    dummy_rocm = DummyROCMSMI(util_by_index=util_by_index, count=smi_count)
+    monkeypatch.setitem(sys.modules, "rocm_smi", dummy_rocm)
+
+    dummy_cuda = DummyTorchCudaROCm(count=count)
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": dummy_cuda,
+            "version": type("V", (), {"hip": "6.0"}),
+            "backends": type(
+                "Backends",
+                (),
+                {
+                    "mps": type(
+                        "MPSBackend", (), {"is_available": staticmethod(lambda: False)}
+                    )
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+    return dummy_rocm, dummy_cuda
+
+
 def test_get_gpu_info_nvml(monkeypatch):
     class DummyNVML:
         def __init__(self):
@@ -222,6 +306,64 @@ def test_get_gpu_info_nvml_duplicate_resolved_uuid_devices_hides_all(monkeypatch
     assert dummy_nvml.queried_indexes == []
     assert dummy_nvml.queried_uuids == ["GPU-a", "GPU-b"]
     assert dummy_nvml.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_maps_visible_ids_to_physical_smi_indexes(monkeypatch):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2,4")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        util_by_index={2: 82, 4: 84},
+    )
+
+    infos = gpu_info.get_gpu_info()
+
+    assert [info["id"] for info in infos] == [0, 1]
+    assert [info["visible_id"] for info in infos] == [0, 1]
+    assert [info["physical_id"] for info in infos] == [2, 4]
+    assert [info["name"] for info in infos] == ["ROCm 0", "ROCm 1"]
+    assert [info["utilization"] for info in infos] == [82, 84]
+    assert dummy_rocm.queried_indexes == [2, 4]
+    assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_composes_rocr_base_and_hip_visible_mask(monkeypatch):
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "2,4")
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        count=1,
+        util_by_index={4: 94},
+    )
+
+    infos = gpu_info.get_gpu_info()
+
+    assert [info["id"] for info in infos] == [0]
+    assert [info["visible_id"] for info in infos] == [0]
+    assert [info["physical_id"] for info in infos] == [4]
+    assert [info["utilization"] for info in infos] == [94]
+    assert dummy_rocm.queried_indexes == [4]
+    assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_unresolved_mask_keeps_visible_records_without_utilization(
+    monkeypatch,
+):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,,2")
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(monkeypatch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert [info["id"] for info in infos] == [0, 1]
+    assert [info["visible_id"] for info in infos] == [0, 1]
+    assert [info.get("physical_id") for info in infos] == [None, None]
+    assert [info["utilization"] for info in infos] == [None, None]
+    assert dummy_rocm.queried_indexes == []
+    assert dummy_rocm.shutdown_calls == 1
 
 
 @pytest.mark.rocm

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -360,7 +360,7 @@ def test_get_gpu_info_rocm_unresolved_mask_keeps_visible_records_without_utiliza
 
     assert [info["id"] for info in infos] == [0, 1]
     assert [info["visible_id"] for info in infos] == [0, 1]
-    assert [info.get("physical_id") for info in infos] == [None, None]
+    assert all("physical_id" not in info for info in infos)
     assert [info["utilization"] for info in infos] == [None, None]
     assert dummy_rocm.queried_indexes == []
     assert dummy_rocm.shutdown_calls == 1


### PR DESCRIPTION
## Summary
- Resolve ROCm visible GPU ranks through `ROCR_VISIBLE_DEVICES` plus one matching HIP/CUDA overlay before querying ROCm SMI utilization.
- Keep `id`/`visible_id` as start-compatible visible ordinals and add `physical_id` only when the ROCm SMI index is known.
- Document the ROCm visible-rank telemetry contract across CLI, Python, API/MCP, architecture, README, AGENTS, and the implementation plan.

## Test Plan
- [x] RED: new no-hardware ROCm tests failed on current code because it queried visible indexes directly and omitted `physical_id`.
- [x] `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/utilities/test_gpu_info.py -q` (`26 passed, 1 skipped`)
- [x] `PYTHONPATH=$PWD/src pytest tests -q` (`235 passed, 11 skipped`)
- [x] `PYTHONPATH=$PWD/src mkdocs build` (passed with existing Material warning and unlisted plan-page notices)
- [x] `pre-commit run --all-files`
- [x] `git diff --check && git diff --cached --check`
- [x] Local subagent review: initial comments resolved; follow-up re-check returned no remaining must-fix findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer ROCm GPU visibility handling, including support for visible device ordinals across CUDA and ROCm environments.
  * GPU info now includes physical device IDs when they can be resolved.

* **Bug Fixes**
  * Utilization data is now marked unavailable when GPU visibility mappings are ambiguous, invalid, or out of range.
  * GPU selection and telemetry now better match the device users actually see after visibility filtering.

* **Documentation**
  * Expanded setup, CLI, API, and troubleshooting docs for CUDA/ROCm visibility masks and GPU ordinal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->