### PR TITLE
[config, service] fix: reject non-finite intervals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file defines how coding agents should work in this repository.
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
+- Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Flags that matter:
 
 - Blocking mode knobs:
   - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
-  - `--interval` (positive seconds): sleep between keep-alive bursts.
+  - `--interval` (finite positive seconds): sleep between keep-alive bursts.
   - `--busy-threshold`: defaults to `25`; `0..100` skips work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
   - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm); otherwise all visible GPUs are guarded. Empty, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
 - Service mode commands:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ drivers/toolkit can allocate VRAM outside KeepGPU.
 keep-gpu --interval 120 --gpu-ids 0 --vram 1GiB
 ```
 
-- `--interval` controls the sleep between utilization checks (seconds).
+- `--interval` controls the finite positive sleep between utilization checks (seconds).
 - `--gpu-ids` limits the job to a subset of visible device ordinals. Set
   `CUDA_VISIBLE_DEVICES` before starting KeepGPU if you need physical-device
   filtering. In service mode, `keep-gpu list-gpus` and the dashboard show these

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -90,7 +90,7 @@ The dashboard provides:
 | --- | --- | --- |
 | `--gpu-ids` | Comma-separated unique non-negative visible device ordinals. Omit to use all visible devices; startup fails if that resolves to none or if an explicit ordinal is out of range. | all |
 | `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes). | `1GiB` |
-| `--interval` | Positive seconds between keep-alive cycles. | `300` |
+| `--interval` | Finite positive seconds between keep-alive cycles. | `300` |
 | `--busy-threshold` / `--util-threshold` | `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
 
 ## Remote sessions

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -79,7 +79,8 @@ Omitting `gpu_ids` means all GPUs visible to the service process. Omitting
 `busy_threshold` uses the eco-safe default `25`. Explicit GPU values are visible
 device ordinals in that same process environment. Empty, duplicate, or
 out-of-range lists are invalid, and startup returns an error if the resolved
-selection contains zero devices.
+selection contains zero devices. `interval` must be a finite positive number of
+seconds; `NaN` and infinities are rejected before session creation.
 
 Custom `job_id` values are unique across active and starting sessions. If a
 duplicate arrives while the original start is still creating controller work,

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -24,7 +24,7 @@ train_model()                     # GPU memory is released automatically
   utilization resolves `ROCR_VISIBLE_DEVICES` as the base mask and one matching
   `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm
   SMI. If a mapping cannot be resolved, utilization is treated as unavailable.
-- `interval` is the positive pause between keep-alive bursts inside the background thread.
+- `interval` is the finite positive pause between keep-alive bursts inside the background thread.
 - `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size` handles it).
 
 ## Start/stop manually

--- a/docs/plans/reject-non-finite-intervals.md
+++ b/docs/plans/reject-non-finite-intervals.md
@@ -1,0 +1,58 @@
+# Reject Non-Finite Intervals Plan
+
+## Background
+
+KeepGPU treats `interval` as the sleep between telemetry checks and keepalive
+bursts. The shared validator currently accepts any numeric value greater than
+zero. That lets `float("nan")` through because comparisons with NaN are false,
+and JSON request bodies can contain `NaN`/`Infinity` when parsed by Python's
+default `json.loads`.
+
+## Goal
+
+Reject `NaN`, positive infinity, and negative infinity anywhere public interval
+validation is used so malformed input cannot create tight or crashing keep
+loops.
+
+## Solution
+
+- Add failing tests for non-finite values in shared interval validation.
+- Add failing JSON-RPC and REST tests proving `interval: NaN` does not create a
+  session.
+- Use `math.isfinite()` in `validate_interval()` after confirming the value is a
+  plain non-boolean number.
+- Update AGENTS and user docs to state that intervals must be finite positive
+  seconds.
+
+## Tasks
+
+- [x] Add RED tests for `validate_interval(math.nan)`,
+      `validate_interval(math.inf)`, and `validate_interval(-math.inf)`.
+- [x] Add RED JSON-RPC test for `interval: NaN` rejecting startup without
+      creating a session.
+- [x] Add RED REST test for `interval: NaN` returning HTTP 400 without creating
+      a session.
+- [x] Implement finite positive interval validation in
+      `src/keep_gpu/utilities/session_config.py`.
+- [x] Update `AGENTS.md`, README, CLI/Python/MCP/API docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  failed with 5 expected failures covering `NaN`/infinity validation and MCP
+  session creation.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  passed with 127 tests.
+- `PYTHONPATH=$PWD/src pytest tests -q` passed with 240 tests and 11 skipped.
+- `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material/MkDocs and
+  unlisted-plan warnings.
+- `pre-commit run --all-files` passed.
+- `git diff --check` passed.
+- Local subagent review found one packaging issue: this plan file was untracked.
+  The fix is to include the plan file in the branch before opening the PR.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,7 @@ These options apply when you run `keep-gpu` without subcommands.
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `--interval INTEGER` | seconds | Sleep duration between utilization checks and keep-alive batches. |
+| `--interval INTEGER` | seconds | Finite positive sleep duration between utilization checks and keep-alive batches. |
 | `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to use all visible GPUs; startup fails if that resolves to none or if an explicit ordinal is out of range. |
 | `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`). |
 | `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | `0..100` backs off when utilization is above this value or unavailable; `-1` disables utilization backoff. |
@@ -45,7 +45,7 @@ Starts a keep session and returns immediately with `job_id`.
 | --- | --- | --- |
 | `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. |
 | `--vram` | `1GiB` | Per-GPU keep memory target. |
-| `--interval` | `300` | Keep cycle interval in seconds. |
+| `--interval` | `300` | Finite positive keep cycle interval in seconds. |
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional custom id. Must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact. |
@@ -101,7 +101,7 @@ digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
 | `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unsupported fields are `null`). |
 | `/api/sessions` | GET | Tracked keep sessions, including `state="starting"` during startup and `state`/`last_error` for in-progress or failed stops. |
 | `/api/sessions/{job_id}` | GET | One session status, including `state` and `last_error` when active or starting. |
-| `/api/sessions` | POST | Start session (`gpu_ids`, `vram`, `interval`, `busy_threshold`, `job_id`); omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |
+| `/api/sessions` | POST | Start session (`gpu_ids`, `vram`, finite positive `interval`, `busy_threshold`, `job_id`); omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |
 | `/api/sessions` | DELETE | Stop all sessions; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/api/sessions/{job_id}` | DELETE | Stop one session; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/rpc` | POST | JSON-RPC compatibility endpoint. |

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -1,3 +1,4 @@
+import math
 import re
 from typing import Any, List, Optional, Union
 
@@ -32,7 +33,9 @@ def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
 
 def validate_interval(interval: Any) -> Union[int, float]:
     """Validate public interval input in seconds."""
-    if not _is_plain_number(interval) or interval <= 0:
+    if not _is_plain_number(interval) or not math.isfinite(interval):
+        raise ValueError("interval must be finite and positive")
+    if interval <= 0:
         raise ValueError("interval must be positive")
     return interval
 

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -1,4 +1,5 @@
 import json
+import math
 import threading
 from typing import Any, cast
 from urllib.error import HTTPError
@@ -477,6 +478,32 @@ def test_http_post_rejects_non_positive_interval():
         )
         assert status_code == 400
         assert "interval must be positive" in payload["error"]["message"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_http_post_rejects_nan_interval_without_creating_session():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "gpu_ids": [0],
+                "vram": "64MB",
+                "interval": math.nan,
+                "busy_threshold": 5,
+            },
+        )
+
+        assert status_code == 400
+        assert "interval must be finite and positive" in payload["error"]["message"]
+        assert server.status()["active_jobs"] == []
     finally:
         httpd.shutdown()
         httpd.server_close()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import subprocess
 import sys
@@ -232,6 +233,21 @@ def test_jsonrpc_rejects_non_positive_interval():
 
     assert "error" in resp
     assert "interval must be positive" in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
+def test_jsonrpc_rejects_nan_interval_without_creating_session():
+    server = make_server()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"gpu_ids": [0], "interval": math.nan},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert "interval must be finite and positive" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
 

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -1,3 +1,4 @@
+import math
 import uuid
 
 import pytest
@@ -19,6 +20,12 @@ def test_validate_interval_rejects_non_positive_values():
         validate_interval(0)
     with pytest.raises(ValueError, match="interval must be positive"):
         validate_interval(-0.1)
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_validate_interval_rejects_non_finite_values(value):
+    with pytest.raises(ValueError, match="interval must be finite and positive"):
+        validate_interval(value)
 
 
 def test_validate_gpu_ids_rejects_empty_list():


### PR DESCRIPTION
## Summary
- reject NaN and infinite public interval values in the shared session validator
- cover validator, JSON-RPC, and REST paths so malformed intervals cannot create keep sessions
- document finite positive interval semantics in AGENTS, README, and user docs

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q` failed with 5 expected failures before the fix
- GREEN: `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q` passed with 127 tests
- `PYTHONPATH=$PWD/src pytest tests -q` passed with 240 tests and 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material/MkDocs and unlisted-plan warnings
- `pre-commit run --all-files` passed
- `git diff --check` passed

## Local Review
- Local subagent review found one packaging issue: the plan file was untracked. Resolved by including `docs/plans/reject-non-finite-intervals.md` in the commit.