### PR TITLE
[cli] fix: emit structured JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file defines how coding agents should work in this repository.
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
+- CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This file defines how coding agents should work in this repository.
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
-- CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode.
+- CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Flags that matter:
   - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
     `id` is the visible ordinal accepted by `--gpu-ids`; optional
     `physical_id`/`uuid` fields are metadata only.
+  - `status`, `stop`, and `list-gpus` print structured JSON objects that tools
+    such as `jq` can parse directly.
 
 ## Embed in Python
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Flags that matter:
   - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
     `id` is the visible ordinal accepted by `--gpu-ids`; optional
     `physical_id`/`uuid` fields are metadata only.
-  - `status`, `stop`, and `list-gpus` print structured JSON objects that tools
-    such as `jq` can parse directly.
+  - `status`, `stop`, and `list-gpus` print structured JSON objects, including
+    `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
+    that tools such as `jq` can parse directly.
 
 ## Embed in Python
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -59,8 +59,9 @@ keep-gpu list-gpus
 ```
 
 The `id` field in this output is the visible ordinal to pass to `--gpu-ids`.
-`status`, `stop`, and `list-gpus` print JSON objects that can be parsed directly
-with `jq` or a single `json.loads()` call.
+`status`, `stop`, and `list-gpus` print JSON objects, including
+`{"error": "..."}` for service/runtime errors after CLI parsing succeeds, that
+can be parsed directly with `jq` or a single `json.loads()` call.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -59,6 +59,8 @@ keep-gpu list-gpus
 ```
 
 The `id` field in this output is the visible ordinal to pass to `--gpu-ids`.
+`status`, `stop`, and `list-gpus` print JSON objects that can be parsed directly
+with `jq` or a single `json.loads()` call.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/plans/fix-cli-json-output.md
+++ b/docs/plans/fix-cli-json-output.md
@@ -1,0 +1,47 @@
+# Fix CLI JSON Output Plan
+
+## Background
+
+`keep-gpu status`, `keep-gpu stop`, and `keep-gpu list-gpus` pass
+`json.dumps(result)` as `data` to Rich's `console.print_json()`. Rich treats
+that string as data and emits a top-level JSON string, so callers must decode
+twice and tools such as `jq` cannot index the output directly.
+
+## Goal
+
+Emit structured JSON objects from service CLI commands so one `json.loads()` or
+one shell JSON tool invocation sees the expected object.
+
+## Solution
+
+- Add RED CLI tests for `status`, `stop --job-id`, `stop --all`, and
+  `list-gpus` that require a single JSON decode to return a dict.
+- Update the existing stop-all fallback test to single-decode the command
+  output.
+- Print decoded result objects with `console.print_json(data=result)`.
+- Document that these CLI commands emit directly parseable JSON objects.
+
+## Tasks
+
+- [x] Add RED tests for single-decode structured JSON output.
+- [x] Implement minimal CLI output changes.
+- [x] Update `AGENTS.md`, CLI docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- Baseline: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+  passed with 34 tests.
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_status_outputs_single_decoded_json_object tests/test_cli_service_commands.py::test_stop_job_outputs_single_decoded_json_object tests/test_cli_service_commands.py::test_stop_all_outputs_single_decoded_json_object tests/test_cli_service_commands.py::test_list_gpus_outputs_single_decoded_json_object tests/test_cli_service_commands.py::test_stop_all_fallback_force_stops_managed_daemon -q`
+  failed with all five outputs decoding once to strings instead of dicts.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+  passed with 38 tests.
+- `PYTHONPATH=$PWD/src pytest tests -q` passed with 248 tests and 11 skipped.
+- `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material/MkDocs and
+  unlisted-plan warnings.
+- `pre-commit run --all-files` passed.
+- `git diff --check` passed.

--- a/docs/plans/fix-cli-json-output.md
+++ b/docs/plans/fix-cli-json-output.md
@@ -19,13 +19,17 @@ one shell JSON tool invocation sees the expected object.
 - Update the existing stop-all fallback test to single-decode the command
   output.
 - Print decoded result objects with `console.print_json(data=result)`.
-- Document that these CLI commands emit directly parseable JSON objects.
+- After CodeRabbit review, print `{"error": "..."}` JSON objects for
+  `RuntimeError` paths in the same CLI commands.
+- Document in `AGENTS.md`, README, and CLI docs that these CLI commands emit
+  directly parseable JSON objects.
 
 ## Tasks
 
 - [x] Add RED tests for single-decode structured JSON output.
 - [x] Implement minimal CLI output changes.
-- [x] Update `AGENTS.md`, CLI docs, and this plan.
+- [x] Add RED tests and implementation for single-decode JSON error objects.
+- [x] Update `AGENTS.md`, README, CLI docs, and this plan.
 - [x] Run targeted tests, full tests, docs build, pre-commit, and local
       subagent review before PR.
 - [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
@@ -40,8 +44,16 @@ one shell JSON tool invocation sees the expected object.
   failed with all five outputs decoding once to strings instead of dicts.
 - GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
   passed with 38 tests.
-- `PYTHONPATH=$PWD/src pytest tests -q` passed with 248 tests and 11 skipped.
+- `PYTHONPATH=$PWD/src pytest tests -q` passed with 249 tests and 11 skipped.
 - `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material/MkDocs and
   unlisted-plan warnings.
 - `pre-commit run --all-files` passed.
 - `git diff --check` passed.
+- CodeRabbit review:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_requires_job_id_or_all tests/test_cli_service_commands.py::test_status_forwards_explicit_empty_job_id_to_service tests/test_cli_service_commands.py::test_stop_forwards_explicit_empty_job_id_to_service tests/test_cli_service_commands.py::test_list_gpus_error_outputs_single_decoded_json_object tests/test_cli_service_commands.py::test_stop_handles_service_timeout_without_traceback -q`
+  failed before the error-output fix because command errors still printed Rich
+  text, then passed with 5 tests after printing `{"error": "..."}` objects.
+- Follow-up local review found the docs overpromised JSON for Typer parse errors
+  and the plan had the previous full-suite count. Wording now limits JSON error
+  objects to service/runtime errors after CLI parsing succeeds, and verification
+  records the final 249-test full-suite run.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,6 +59,8 @@ Starts a keep session and returns immediately with `job_id`.
 | `--job-id` | Optional session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. |
 | `--host`, `--port` | Service host/port. |
 
+Prints a directly parseable JSON object.
+
 ### `keep-gpu stop`
 
 | Option | Description |
@@ -73,12 +75,14 @@ For `--all`, starts that begin after that command's initial snapshot are not
 stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
+The output is a directly parseable JSON object.
 
 ### `keep-gpu list-gpus`
 
 Returns GPU telemetry from service. `id` and `visible_id` are the visible
 ordinals accepted by `--gpu-ids` and service `gpu_ids`; optional `physical_id`
-or `uuid` fields are metadata only.
+or `uuid` fields are metadata only. The output is a directly parseable JSON
+object.
 
 ### `keep-gpu service-stop`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,7 +59,8 @@ Starts a keep session and returns immediately with `job_id`.
 | `--job-id` | Optional session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. |
 | `--host`, `--port` | Service host/port. |
 
-Prints a directly parseable JSON object.
+Prints a directly parseable JSON object, including `{"error": "..."}` for
+service/runtime errors after CLI parsing succeeds.
 
 ### `keep-gpu stop`
 
@@ -75,14 +76,16 @@ For `--all`, starts that begin after that command's initial snapshot are not
 stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
-The output is a directly parseable JSON object.
+The output is a directly parseable JSON object, including `{"error": "..."}` for
+service/runtime errors after CLI parsing succeeds.
 
 ### `keep-gpu list-gpus`
 
 Returns GPU telemetry from service. `id` and `visible_id` are the visible
 ordinals accepted by `--gpu-ids` and service `gpu_ids`; optional `physical_id`
 or `uuid` fields are metadata only. The output is a directly parseable JSON
-object.
+object, including `{"error": "..."}` for service/runtime errors after CLI
+parsing succeeds.
 
 ### `keep-gpu service-stop`
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -684,7 +684,7 @@ def status(
         )
         console.print_json(data=result)
     except RuntimeError as exc:
-        console.print(f"[bold red]Error: {exc}[/bold red]")
+        console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 
@@ -718,7 +718,7 @@ def stop(
             )
         console.print_json(data=result)
     except RuntimeError as exc:
-        console.print(f"[bold red]Error: {exc}[/bold red]")
+        console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 
@@ -732,7 +732,7 @@ def list_gpus(
         result = _rpc_call("list_gpus", {}, host, port)
         console.print_json(data=result)
     except RuntimeError as exc:
-        console.print(f"[bold red]Error: {exc}[/bold red]")
+        console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -682,7 +682,7 @@ def status(
             host,
             port,
         )
-        console.print_json(data=json.dumps(result))
+        console.print_json(data=result)
     except RuntimeError as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc
@@ -716,7 +716,7 @@ def stop(
                 port,
                 timeout=45.0,
             )
-        console.print_json(data=json.dumps(result))
+        console.print_json(data=result)
     except RuntimeError as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc
@@ -730,7 +730,7 @@ def list_gpus(
     """List GPU telemetry from local service."""
     try:
         result = _rpc_call("list_gpus", {}, host, port)
-        console.print_json(data=json.dumps(result))
+        console.print_json(data=result)
     except RuntimeError as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -7,6 +7,12 @@ from keep_gpu import cli
 runner = CliRunner()
 
 
+def _single_decoded_json_object(output):
+    payload = json.loads(output)
+    assert isinstance(payload, dict)
+    return payload
+
+
 def test_start_command_uses_rpc(monkeypatch):
     called = {}
 
@@ -189,6 +195,72 @@ def test_stop_forwards_explicit_empty_job_id_to_service(monkeypatch):
     assert timeout == 45.0
 
 
+def test_status_outputs_single_decoded_json_object(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {}
+        return {"active": True, "active_jobs": [{"job_id": "job-1"}]}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload["active"] is True
+    assert payload["active_jobs"][0]["job_id"] == "job-1"
+
+
+def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "job-1"}
+        assert timeout == 45.0
+        return {"stopped": ["job-1"], "timed_out": [], "failed": [], "errors": {}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload["stopped"] == ["job-1"]
+
+
+def test_stop_all_outputs_single_decoded_json_object(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_stop_all_sessions_with_fallback",
+        lambda host, port: {
+            "stopped": ["job-1"],
+            "timed_out": [],
+            "failed": [],
+            "errors": {},
+        },
+    )
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload["stopped"] == ["job-1"]
+
+
+def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "list_gpus"
+        assert params == {}
+        return {"gpus": [{"id": 0, "name": "GPU 0"}]}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["list-gpus"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload["gpus"][0]["id"] == 0
+
+
 def test_blocking_mode_defaults_to_eco_safe_busy_threshold(monkeypatch):
     called = {}
 
@@ -335,7 +407,7 @@ def test_stop_all_fallback_force_stops_managed_daemon(monkeypatch):
 
     assert result.exit_code == 0
     assert "force-stopped local daemon" in result.output
-    payload = json.loads(json.loads(result.output))
+    payload = _single_decoded_json_object(result.output)
     assert payload["stopped"] == []
     assert payload["timed_out"] == []
     assert payload["failed"] == []

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -155,7 +155,8 @@ def test_start_command_rejects_busy_threshold_above_percent_range(monkeypatch):
 def test_stop_requires_job_id_or_all():
     result = runner.invoke(cli.app, ["stop"])
     assert result.exit_code == 1
-    assert "Provide --job-id or use --all" in result.output
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "Provide --job-id or use --all."
 
 
 def test_status_forwards_explicit_empty_job_id_to_service(monkeypatch):
@@ -170,7 +171,8 @@ def test_status_forwards_explicit_empty_job_id_to_service(monkeypatch):
     result = runner.invoke(cli.app, ["status", "--job-id", ""])
 
     assert result.exit_code == 1
-    assert "job_id must be a URL-path-safe non-empty string" in result.output
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
     method, params, _host, _port = called["rpc"]
     assert method == "status"
     assert params == {"job_id": ""}
@@ -188,7 +190,8 @@ def test_stop_forwards_explicit_empty_job_id_to_service(monkeypatch):
     result = runner.invoke(cli.app, ["stop", "--job-id", ""])
 
     assert result.exit_code == 1
-    assert "job_id must be a URL-path-safe non-empty string" in result.output
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
     method, params, _host, _port, timeout = called["rpc"]
     assert method == "stop_keep"
     assert params == {"job_id": ""}
@@ -259,6 +262,21 @@ def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
     assert result.exit_code == 0
     payload = _single_decoded_json_object(result.output)
     assert payload["gpus"][0]["id"] == 0
+
+
+def test_list_gpus_error_outputs_single_decoded_json_object(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "list_gpus"
+        assert params == {}
+        raise RuntimeError("telemetry service unavailable")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["list-gpus"])
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "telemetry service unavailable"
 
 
 def test_blocking_mode_defaults_to_eco_safe_busy_threshold(monkeypatch):
@@ -384,8 +402,9 @@ def test_stop_handles_service_timeout_without_traceback(monkeypatch):
     result = runner.invoke(cli.app, ["stop", "--all"])
 
     assert result.exit_code == 1
-    assert "Cannot reach KeepGPU service" in result.output
-    assert "service-stop --force" in result.output
+    payload = _single_decoded_json_object(result.output)
+    assert "Cannot reach KeepGPU service" in payload["error"]
+    assert "service-stop --force" in payload["error"]
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Summary
- emit CLI service results as structured JSON objects instead of top-level JSON strings
- cover `status`, `stop --job-id`, `stop --all`, `list-gpus`, and stop-all fallback with single-decode tests
- document directly parseable CLI JSON output in AGENTS, README, and CLI docs

## Verification
- Baseline: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with 34 tests
- RED: focused JSON-output tests failed with all five outputs decoding once to strings instead of dicts
- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with 38 tests
- `PYTHONPATH=$PWD/src pytest tests -q` passed with 248 tests and 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material/MkDocs and unlisted-plan warnings
- `pre-commit run --all-files` passed
- `git diff --check` passed

## Local Review
- Local subagent review found no issues and independently reran the CLI service command shard (`38 passed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI commands now return directly parseable JSON objects for `status`, `stop`, and `list-gpus`, making their output easier to use with tools like `jq` or `json.loads()`.
  * Updated command output behavior to be consistent across the affected CLI actions.
* **Documentation**
  * Clarified in the README and CLI docs that these commands emit structured JSON for machine-readable workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->