### PR TITLE
[mcp] fix: map JSON-RPC validation errors to invalid params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file defines how coding agents should work in this repository.
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
+- JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -75,6 +75,10 @@ Methods:
 - `status(job_id?)`
 - `list_gpus()`
 
+For direct JSON-RPC calls, public validation failures and unknown parameters
+return JSON-RPC `-32602 Invalid params`. Unexpected server failures use
+`-32603 Internal error`.
+
 REST session creation accepts a JSON object body, not arrays or scalar values.
 Omitting `gpu_ids` means all GPUs visible to the service process. Omitting
 `busy_threshold` uses the eco-safe default `25`. Explicit GPU values are visible

--- a/docs/plans/jsonrpc-invalid-params-code.md
+++ b/docs/plans/jsonrpc-invalid-params-code.md
@@ -1,0 +1,78 @@
+# JSON-RPC Invalid Params Code Plan
+
+## Background
+
+Direct legacy JSON-RPC calls to `start_keep`, `stop_keep`, and `status` use the
+shared public validators, but their `ValueError`s currently fall through
+`_handle_request()`'s generic exception handler and return `-32603 Internal
+error`. These are user input errors and should return JSON-RPC `-32602 Invalid
+params`.
+
+## Goal
+
+Map public parameter validation failures from direct JSON-RPC method calls to
+`-32602` while preserving `-32603` for real internal failures.
+
+## Solution
+
+- Add RED assertions that direct JSON-RPC validation errors return `-32602`.
+- Add RED coverage for invalid `vram` values and unknown direct-method
+  parameters.
+- Explicitly validate allowed params for direct KeepGPU methods before
+  dispatch.
+- Mark public session validation failures with a narrow `SessionInputError`
+  wrapper so JSON-RPC maps user input errors to `-32602` without converting
+  controller/runtime `ValueError`s away from `-32603`.
+- Document the JSON-RPC error-code contract.
+
+## Tasks
+
+- [x] Add RED JSON-RPC error-code tests for existing validation cases.
+- [x] Add RED invalid `vram` and unknown-parameter tests.
+- [x] Add RED regression that runtime `ValueError`s still return `-32603`.
+- [x] Implement explicit direct-method param validation and validation-error
+      mapping.
+- [x] Update `AGENTS.md`, MCP docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED focused regression run before implementation:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k 'jsonrpc_rejects_empty_gpu_ids or jsonrpc_rejects_duplicate_gpu_ids or jsonrpc_rejects_non_positive_interval or jsonrpc_rejects_nan_interval_without_creating_session or jsonrpc_rejects_busy_threshold_above_percent_range or jsonrpc_rejects_invalid_vram_type_without_creating_session or jsonrpc_rejects_unknown_direct_method_param_without_internal_error or jsonrpc_stop_keep_rejects_empty_job_id_without_stopping_sessions'`
+  failed with `-32603 != -32602`.
+- GREEN focused regression run after implementation: same command, `8 passed`.
+- GREEN MCP server shard after implementation:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`, `70 passed`.
+- Local subagent code review found the first implementation caught every
+  `ValueError` from direct method dispatch, incorrectly mapping controller
+  startup failures to `-32602`.
+- RED review regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k 'runtime_value_error_remains_internal_error'`
+  failed with `-32602 != -32603`.
+- GREEN focused review regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k 'runtime_value_error_remains_internal_error or jsonrpc_rejects_invalid_vram_type_without_creating_session or jsonrpc_rejects_unknown_direct_method_param_without_internal_error or jsonrpc_rejects_empty_gpu_ids or jsonrpc_stop_keep_rejects_empty_job_id_without_stopping_sessions'`,
+  `5 passed`.
+- GREEN MCP server shard after review fix:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`, `71 passed`.
+
+- Pre-review branch gate, to rerun after the review fix:
+  - `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`: `70 passed`.
+  - `PYTHONPATH=$PWD/src pytest tests -q`: `251 passed, 11 skipped`.
+  - `PYTHONPATH=$PWD/src mkdocs build`: passed. Existing Material for MkDocs
+    version warning and docs-nav notices were emitted.
+  - `pre-commit run --all-files`: passed.
+  - `git diff --check`: passed.
+
+Post-review branch gate before local re-check:
+
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`: `71 passed`.
+- `PYTHONPATH=$PWD/src pytest tests -q`: `252 passed, 11 skipped`.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed. Existing Material for MkDocs
+  version warning and docs-nav notices were emitted.
+- `pre-commit run --all-files`: passed.
+- `git diff --check`: passed.
+- Local subagent code review re-check: passed with no critical, important, or
+  minor findings.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -163,6 +163,17 @@ class JSONRPCError(Exception):
         self.message = message
 
 
+class SessionInputError(ValueError):
+    """Public session input validation error."""
+
+
+def _validate_public_session_input(validator: Callable[..., Any], *args: Any) -> Any:
+    try:
+        return validator(*args)
+    except (TypeError, ValueError) as exc:
+        raise SessionInputError(str(exc)) from exc
+
+
 class KeepGPUServer:
     def __init__(
         self,
@@ -246,12 +257,14 @@ class KeepGPUServer:
         Raises:
             ValueError: If the provided job_id already exists.
         """
-        gpu_ids = validate_gpu_ids(gpu_ids)
-        interval = validate_interval(interval)
-        busy_threshold = validate_busy_threshold(busy_threshold)
-        parse_vram_to_elements(vram)
+        gpu_ids = _validate_public_session_input(validate_gpu_ids, gpu_ids)
+        interval = _validate_public_session_input(validate_interval, interval)
+        busy_threshold = _validate_public_session_input(
+            validate_busy_threshold, busy_threshold
+        )
+        _validate_public_session_input(parse_vram_to_elements, vram)
 
-        job_id = validate_job_id(job_id)
+        job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is None:
             job_id = str(uuid.uuid4())
         params = {
@@ -262,7 +275,7 @@ class KeepGPUServer:
         }
         with self._sessions_lock:
             if job_id in self._sessions or job_id in self._starting_job_ids:
-                raise ValueError(f"job_id {job_id} already exists")
+                raise SessionInputError(f"job_id {job_id} already exists")
             self._starting_job_ids.add(job_id)
             self._starting_params[job_id] = params
 
@@ -360,7 +373,7 @@ class KeepGPUServer:
             Dict with "stopped", "timed_out", "failed", and "errors" fields.
             If a specific job_id was not found, a "message" field explains the miss.
         """
-        job_id = validate_job_id(job_id)
+        job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is not None:
             with self._sessions_lock:
                 while job_id in self._starting_job_ids:
@@ -480,7 +493,7 @@ class KeepGPUServer:
         return self._finalize_stop_result(result)
 
     def status(self, job_id: Optional[str] = None) -> Dict[str, Any]:
-        job_id = validate_job_id(job_id)
+        job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is not None:
             with self._sessions_lock:
                 session = self._sessions.get(job_id)
@@ -550,17 +563,42 @@ def _jsonrpc_error(req_id: Any, code: int, message: str) -> Dict[str, Any]:
     }
 
 
+_DIRECT_METHOD_PARAMS = {
+    "start_keep": {"gpu_ids", "vram", "interval", "busy_threshold", "job_id"},
+    "stop_keep": {"job_id"},
+    "status": {"job_id"},
+    "list_gpus": set(),
+}
+
+
+def _validate_direct_method_params(method: str, params: Dict[str, Any]) -> None:
+    allowed = _DIRECT_METHOD_PARAMS.get(method)
+    if allowed is None:
+        return
+    unknown = sorted(set(params) - allowed)
+    if unknown:
+        joined = ", ".join(unknown)
+        raise JSONRPCError(
+            JSONRPC_INVALID_PARAMS,
+            f"Unknown params for {method}: {joined}",
+        )
+
+
 def _call_keepgpu_method(
     server: KeepGPUServer, method: str, params: Dict[str, Any]
 ) -> Dict[str, Any]:
-    if method == "start_keep":
-        return server.start_keep(**params)
-    if method == "stop_keep":
-        return server.stop_keep(**params)
-    if method == "status":
-        return server.status(**params)
-    if method == "list_gpus":
-        return server.list_gpus()
+    _validate_direct_method_params(method, params)
+    try:
+        if method == "start_keep":
+            return server.start_keep(**params)
+        if method == "stop_keep":
+            return server.stop_keep(**params)
+        if method == "status":
+            return server.status(**params)
+        if method == "list_gpus":
+            return server.list_gpus()
+    except SessionInputError as exc:
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, str(exc)) from exc
     raise JSONRPCError(JSONRPC_METHOD_NOT_FOUND, f"Unknown method: {method}")
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -10,7 +10,12 @@ from typing import Any, cast
 
 import pytest
 
-from keep_gpu.mcp.server import KeepGPUServer, _handle_request
+from keep_gpu.mcp.server import (
+    JSONRPC_INTERNAL_ERROR,
+    JSONRPC_INVALID_PARAMS,
+    KeepGPUServer,
+    _handle_request,
+)
 
 
 class DummyController:
@@ -202,6 +207,7 @@ def test_jsonrpc_rejects_empty_gpu_ids():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "gpu_ids must select at least one GPU" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
@@ -217,6 +223,7 @@ def test_jsonrpc_rejects_duplicate_gpu_ids():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "gpu_ids must not contain duplicate values" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
@@ -232,6 +239,7 @@ def test_jsonrpc_rejects_non_positive_interval():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "interval must be positive" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
@@ -247,6 +255,7 @@ def test_jsonrpc_rejects_nan_interval_without_creating_session():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "interval must be finite and positive" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
@@ -262,10 +271,61 @@ def test_jsonrpc_rejects_busy_threshold_above_percent_range():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert (
         "busy_threshold must be -1 or an integer between 0 and 100"
         in resp["error"]["message"]
     )
+    assert server.status()["active_jobs"] == []
+
+
+def test_jsonrpc_rejects_invalid_vram_type_without_creating_session():
+    server = make_server()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"gpu_ids": [0], "vram": []},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert "vram_to_keep must be str or int bytes" in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
+def test_jsonrpc_rejects_unknown_direct_method_param_without_internal_error():
+    server = make_server()
+    req = {
+        "id": 1,
+        "method": "status",
+        "params": {"unexpected": True},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert "Unknown params for status" in resp["error"]["message"]
+
+
+def test_jsonrpc_start_keep_runtime_value_error_remains_internal_error():
+    def failing_factory(**kwargs):
+        raise ValueError("controller startup failed")
+
+    server = KeepGPUServer(controller_factory=cast(Any, failing_factory))
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"gpu_ids": [0]},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INTERNAL_ERROR
+    assert "controller startup failed" in resp["error"]["message"]
     assert server.status()["active_jobs"] == []
 
 
@@ -337,6 +397,7 @@ def test_jsonrpc_stop_keep_rejects_empty_job_id_without_stopping_sessions():
     resp = _handle_request(server, req)
 
     assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
     assert "job_id" in resp["error"]["message"]
     assert server.status(active_job_id)["active"] is True
     assert controller.released is False


### PR DESCRIPTION
## Summary
- map direct JSON-RPC public validation failures and unknown direct params to `-32602 Invalid params`
- keep unknown methods at `-32601` and internal/runtime failures at `-32603`
- document the direct JSON-RPC error-code contract in AGENTS and MCP docs

## Test Plan
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` (`71 passed`)
- [x] `PYTHONPATH=$PWD/src pytest tests -q` (`252 passed, 11 skipped`)
- [x] `PYTHONPATH=$PWD/src mkdocs build` (passed; existing Material for MkDocs and docs-nav warnings)
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Local Review
- [x] Local subagent review found and fixed the initial broad `ValueError` mapping issue.
- [x] Local subagent re-review passed with no critical, important, or minor findings.
