### PR TITLE
[cli] fix: validate start inputs before service startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ This file defines how coding agents should work in this repository.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
+- `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -28,6 +28,10 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 - follow-up status/stop command hints,
 - daemon shutdown hint (`keep-gpu service-stop`).
 
+Local `start` inputs are validated before auto-starting the service. Invalid
+`--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
+fail without creating daemon runtime files or issuing RPC.
+
 ### Check status
 
 ```bash
@@ -95,6 +99,7 @@ The dashboard provides:
 | `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes). | `1GiB` |
 | `--interval` | Finite positive seconds between keep-alive cycles. | `300` |
 | `--busy-threshold` / `--util-threshold` | `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
+| `--job-id` | Optional URL-path-safe session id. Invalid IDs are rejected before service auto-start. | auto |
 
 ## Remote sessions
 

--- a/docs/plans/cli-local-validation-before-service.md
+++ b/docs/plans/cli-local-validation-before-service.md
@@ -1,0 +1,56 @@
+# CLI Local Validation Before Service Plan
+
+## Background
+
+`keep-gpu start` validates `interval`, `busy_threshold`, and `gpu_ids` before
+crossing the service boundary, but it forwards `vram` and `job_id` to the
+daemon without local validation. When the service is unavailable, invalid
+`--vram` or `--job-id` can auto-start the daemon, create runtime files, or
+report service-unavailable before the user sees the local input error.
+
+## Goal
+
+Reject invalid `keep-gpu start` local inputs before service auto-start or RPC,
+so bad user input has no daemon side effects.
+
+## Solution
+
+- Add RED CLI tests proving invalid `--vram` and `--job-id` do not call
+  `_ensure_service_running()` or `_rpc_call()`.
+- Reuse the shared public validators for `vram` and `job_id` in the CLI start
+  path before service startup.
+- Document the no-side-effect validation contract for service-mode `start`.
+
+## Tasks
+
+- [x] Add RED CLI regression tests for invalid `--vram` and `--job-id`.
+- [x] Implement local validation before `_ensure_service_running()`.
+- [x] Update `AGENTS.md`, CLI docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'rejects_local_inputs_before_auto_start'`
+  failed because both invalid cases called `_ensure_service_running()`.
+- GREEN focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'rejects_local_inputs_before_auto_start'`,
+  `2 passed`.
+- GREEN CLI service-command shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
+  `41 passed`.
+
+Final branch gate before local review:
+
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`:
+  `41 passed` after implementation and again after local review follow-up.
+- `PYTHONPATH=$PWD/src pytest tests -q`: `254 passed, 11 skipped`.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed. Existing Material for MkDocs
+  version warning and docs-nav notices were emitted.
+- `pre-commit run --all-files`: passed.
+- `git diff --check`: passed.
+- Local subagent code review: passed with no critical or important findings.
+  Review follow-up added explicit valid-path `--job-id` forwarding coverage.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,13 +41,17 @@ Starts local KeepGPU service (HTTP + JSON-RPC + dashboard).
 
 Starts a keep session and returns immediately with `job_id`.
 
+Local input validation runs before service auto-start. Invalid `--vram`,
+`--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values fail before
+daemon startup or RPC.
+
 | Option | Default | Description |
 | --- | --- | --- |
 | `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. |
 | `--vram` | `1GiB` | Per-GPU keep memory target. |
 | `--interval` | `300` | Finite positive keep cycle interval in seconds. |
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
-| `--job-id` | auto | Optional custom id. Must be unique across active and starting sessions. |
+| `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact. |
 | `--port` | `8765` | Service port to contact. |
 | `--auto-start/--no-auto-start` | `--auto-start` | Auto-start local service if unavailable. |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -17,12 +17,14 @@ from urllib.request import Request, urlopen
 import typer
 from rich.console import Console
 
+from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
+    validate_job_id,
 )
 
 DEFAULT_SERVICE_HOST = "127.0.0.1"
@@ -636,6 +638,14 @@ def start(
         interval = _validate_cli_interval(interval)
         busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         parsed_gpu_ids = _parse_gpu_ids(gpu_ids)
+        try:
+            parse_vram_to_elements(vram)
+        except (TypeError, ValueError) as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        try:
+            validate_job_id(job_id)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
         auto_started = _ensure_service_running(host, port, auto_start=auto_start)
         result = _rpc_call(
             "start_keep",

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from keep_gpu import cli
@@ -38,6 +39,8 @@ def test_start_command_uses_rpc(monkeypatch):
             "60",
             "--busy-threshold",
             "30",
+            "--job-id",
+            "custom-job",
         ],
     )
 
@@ -54,6 +57,7 @@ def test_start_command_uses_rpc(monkeypatch):
     assert params["vram"] == "2GiB"
     assert params["interval"] == 60
     assert params["busy_threshold"] == 30
+    assert params["job_id"] == "custom-job"
     assert host == cli.DEFAULT_SERVICE_HOST
     assert port == cli.DEFAULT_SERVICE_PORT
 
@@ -150,6 +154,37 @@ def test_start_command_rejects_busy_threshold_above_percent_range(monkeypatch):
 
     assert result.exit_code == 1
     assert "busy_threshold must be -1 or an integer between 0 and 100" in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--job-id", "bad/id"], "job_id must be a URL-path-safe non-empty string"),
+        (["--vram", "not-a-size"], "invalid format"),
+    ],
+)
+def test_start_command_rejects_local_inputs_before_auto_start(
+    monkeypatch, args, message
+):
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be started")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("RPC should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["start", *args])
+
+    assert result.exit_code == 1
+    assert message in result.output
 
 
 def test_stop_requires_job_id_or_all():


### PR DESCRIPTION
## Summary
- validate `keep-gpu start --vram` and `--job-id` before service auto-start or RPC
- keep valid starts forwarding the original `vram` and `job_id` values to the service
- document the no-daemon-side-effect validation contract in AGENTS and CLI docs

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'rejects_local_inputs_before_auto_start'` failed before the fix because invalid inputs reached `_ensure_service_running()`
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` (`41 passed`)
- [x] `PYTHONPATH=$PWD/src pytest tests -q` (`254 passed, 11 skipped`)
- [x] `PYTHONPATH=$PWD/src mkdocs build` (passed; existing Material for MkDocs and docs-nav warnings)
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Local Review
- [x] Local subagent review passed with no critical or important findings.
- [x] Review follow-up added explicit valid-path `--job-id` forwarding coverage.
