### PR TITLE
[mcp] fix: return JSON errors for REST failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,9 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
+- Supported REST API routes/methods must return structured JSON error objects
+  for validation, unknown-endpoint, and unexpected runtime failures; do not let
+  handler exceptions drop the HTTP connection.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ to zero devices.
   curl http://127.0.0.1:8765/api/sessions
   ```
 - Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
+- Supported REST route/method failures remain machine-readable: validation
+  errors use JSON `400` responses, unknown API routes use JSON `404`, and
+  unexpected service/runtime failures use JSON `500` instead of closing the
+  connection without a response.
 - Stop responses distinguish completed cleanup from partial cleanup:
   `stopped` means released, while `timed_out` sessions remain visible as
   `stopping` until background cleanup completes and `failed` sessions remain

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -79,6 +79,11 @@ For direct JSON-RPC calls, public validation failures and unknown parameters
 return JSON-RPC `-32602 Invalid params`. Unexpected server failures use
 `-32603 Internal error`.
 
+For supported REST route/method calls, service errors stay parseable. Public
+validation failures return JSON `400` responses, unknown API routes return JSON
+`404`, and unexpected runtime failures return JSON `500` responses with an
+`error` object.
+
 REST session creation accepts a JSON object body, not arrays or scalar values.
 Omitting `gpu_ids` means all GPUs visible to the service process. Omitting
 `busy_threshold` uses the eco-safe default `25`. Explicit GPU values are visible

--- a/docs/plans/rest-json-errors-get-delete.md
+++ b/docs/plans/rest-json-errors-get-delete.md
@@ -1,0 +1,104 @@
+# REST JSON Errors for GET and DELETE Plan
+
+## Background
+
+The HTTP service already returned JSON error objects for most `POST` failures,
+but `GET` and `DELETE` route handlers could raise out of `BaseHTTPRequestHandler`
+and close the socket before writing a response. Local agents, scripts, and
+dashboards then had to handle a transport failure instead of a normal JSON error.
+
+## Goal
+
+Keep supported REST route/method failures machine-readable by returning
+structured JSON `500` responses for unexpected handler/runtime errors while
+preserving existing JSON `400` validation responses and JSON `404`
+unknown-endpoint responses.
+
+## Solution
+
+- Add RED HTTP tests proving `GET /api/gpus` and `DELETE /api/sessions`
+  backend failures return JSON `500` error objects instead of disconnecting.
+- Add RED setup regressions proving missing handler server wiring returns JSON
+  `500` for `GET`, `POST`, and `DELETE`.
+- Add POST runtime regressions proving unexpected startup `TypeError` and
+  `ValueError` failures return JSON `500` rather than client-validation `400`.
+- Add a GitHub-review regression proving unknown POST routes return JSON `404`
+  before reading missing or malformed request bodies.
+- Add a GitHub-review regression proving explicit REST `gpu_ids` are rejected
+  when `/api/gpus` lists no visible IDs.
+- Centralize defensive runtime error formatting in `_json_runtime_error()`.
+- Wrap `GET`, `POST`, and `DELETE` server dispatch setup and route bodies in the
+  defensive JSON response path without changing public validation behavior.
+- Document the REST error contract in `AGENTS.md`, README, and service docs.
+
+## Tasks
+
+- [x] Add RED runtime-failure tests for `GET` and `DELETE`.
+- [x] Implement shared JSON `500` handling for unexpected REST runtime errors.
+- [x] Add RED setup-failure tests for `GET`, `POST`, and `DELETE`.
+- [x] Move server dispatch setup inside each verb's defensive error guard.
+- [x] Narrow the POST `400` path to request parsing, public validation, and
+      explicit `SessionInputError` failures.
+- [x] Move POST unknown-endpoint handling before body parsing.
+- [x] Reject explicit REST `gpu_ids` when the current visible ID set is empty.
+- [x] Update `AGENTS.md`, README, MCP guide, CLI reference, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+Completed so far:
+
+- Baseline `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q`:
+  `29 passed`.
+- RED runtime regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_delete_sessions_runtime_error_returns_json_500 -q`
+  failed with `RemoteDisconnected` and server tracebacks.
+- GREEN runtime regression after shared JSON `500` handling: same command,
+  `2 passed`.
+- RED setup regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_get_setup_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_delete_setup_runtime_error_returns_json_500 -q`
+  failed with `RemoteDisconnected` while looking up `keepgpu_server` before the
+  defensive block.
+- GREEN focused regressions:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_delete_sessions_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_get_setup_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_delete_setup_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_setup_runtime_error_returns_json_500 -q`:
+  `5 passed`.
+- Local review RED POST runtime regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 -q`
+  failed because unexpected startup `TypeError` still returned HTTP `400`.
+- Local review GREEN POST runtime regressions:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_value_error_returns_json_500 -q`:
+  `2 passed`.
+- GitHub review RED unknown-route regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_unknown_api_route_returns_json_404_before_body_parse -q`
+  failed because unknown POST routes with missing or malformed bodies returned
+  HTTP `400`.
+- GitHub review GREEN focused shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_unknown_api_route_returns_json_404_before_body_parse tests/mcp/test_http_api.py::test_http_post_setup_runtime_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_value_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_rejects_non_object_json_without_creating_session tests/mcp/test_http_api.py::test_http_post_rejects_unknown_fields -q`:
+  `10 passed`.
+- GitHub review RED no-visible-ID regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids -q`
+  failed because `gpu_ids=[0]` started despite an empty visible ID set.
+- GitHub review GREEN GPU-ID focused shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids tests/mcp/test_http_api.py::test_http_session_lifecycle tests/mcp/test_http_api.py::test_http_session_start_defaults_to_eco_safe_busy_threshold tests/mcp/test_http_api.py::test_http_session_start_preserves_explicit_unconditional_busy_threshold tests/mcp/test_http_api.py::test_http_start_validates_gpu_ids_against_listed_visible_ids -q`:
+  `5 passed`.
+- HTTP API shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q`: `39 passed`.
+- Targeted MCP/GPU-info shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp tests/utilities/test_gpu_info.py -q`:
+  `126 passed, 1 skipped`.
+- Full test suite: `PYTHONPATH=$PWD/src pytest tests -q`:
+  `278 passed, 11 skipped`.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed. Existing Material for MkDocs
+  warning and unnav'd plan notices were emitted.
+- `pre-commit run --all-files`: passed.
+- `git diff --check`: passed.
+- Local subagent code review: initial reviews found POST runtime error
+  misclassification and docs wording that overpromised unsupported HTTP methods;
+  both were fixed and re-review reported no Critical or Important findings.
+- GitHub review comments: moved POST unknown-endpoint handling before body
+  parsing and added explicit `BLE001` suppressions for the intentional
+  GET/POST/DELETE runtime-boundary catches. Explicit REST `gpu_ids` are now
+  rejected when no visible IDs are listed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -105,6 +105,9 @@ Stops the ownership-verified local daemon process created by auto-start logic.
 Only omitted/`null` `job_id` values mean generated IDs or all-sessions, depending
 on the method. Custom IDs must be non-empty strings containing only letters,
 digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
+Supported REST route/method errors are JSON objects: validation errors return
+`400`, unknown API routes return `404`, and unexpected service/runtime failures
+return `500` instead of dropping the connection.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -717,6 +717,18 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
+    def _json_runtime_error(self, method: str, path: str, exc: Exception) -> None:
+        logger.exception("%s request failed for path %s", method, path)
+        self._json_response(
+            500,
+            {
+                "error": {
+                    "message": str(exc),
+                    "type": exc.__class__.__name__,
+                }
+            },
+        )
+
     def _read_json_body(self) -> Any:
         length = int(self.headers.get("content-length", "0"))
         if length > MAX_JSON_BODY_BYTES:
@@ -780,35 +792,37 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
         parsed = urlparse(self.path)
         path = parsed.path
-        server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
-
-        if path == "/health":
-            self._json_response(200, {"ok": True})
-            return
-        if path == "/api/gpus":
-            self._json_response(200, server_ref.list_gpus())
-            return
-        if path == "/api/sessions":
-            if self._reject_session_route_components(parsed):
+        try:
+            server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
+            if path == "/health":
+                self._json_response(200, {"ok": True})
                 return
-            self._json_response(200, server_ref.status())
-            return
-        if path.startswith("/api/sessions/"):
-            if self._reject_session_route_components(parsed):
+            if path == "/api/gpus":
+                self._json_response(200, server_ref.list_gpus())
                 return
-            try:
-                job_id = self._job_id_from_session_path(path)
-            except ValueError as exc:
-                self._json_response(400, {"error": {"message": str(exc)}})
+            if path == "/api/sessions":
+                if self._reject_session_route_components(parsed):
+                    return
+                self._json_response(200, server_ref.status())
                 return
-            self._json_response(200, server_ref.status(job_id=job_id))
-            return
+            if path.startswith("/api/sessions/"):
+                if self._reject_session_route_components(parsed):
+                    return
+                try:
+                    job_id = self._job_id_from_session_path(path)
+                except ValueError as exc:
+                    self._json_response(400, {"error": {"message": str(exc)}})
+                    return
+                self._json_response(200, server_ref.status(job_id=job_id))
+                return
 
-        if path.startswith("/api/"):
-            self._json_response(404, {"error": {"message": "Unknown endpoint"}})
-            return
+            if path.startswith("/api/"):
+                self._json_response(404, {"error": {"message": "Unknown endpoint"}})
+                return
 
-        self._serve_static(path)
+            self._serve_static(path)
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - defensive
+            self._json_runtime_error("GET", path, exc)
 
     def do_POST(self):  # noqa: N802
         """
@@ -819,35 +833,60 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         """
         parsed = urlparse(self.path)
         path = parsed.path
-        server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
         try:
-            payload = self._read_json_body()
-            if path == "/api/sessions":
-                if self._reject_session_route_components(parsed):
-                    return
-                if not isinstance(payload, dict):
-                    raise ValueError("JSON body must be an object")
-                allowed_fields = {
-                    "gpu_ids",
-                    "vram",
-                    "interval",
-                    "busy_threshold",
-                    "job_id",
-                }
-                unknown_fields = set(payload) - allowed_fields
-                if unknown_fields:
-                    raise ValueError(
-                        f"Unknown request fields: {sorted(unknown_fields)}"
-                    )
+            if path not in ("/api/sessions", "/", "/rpc"):
+                self._json_response(404, {"error": {"message": "Unknown endpoint"}})
+                return
 
-                safe_payload = {
-                    key: value
-                    for key, value in payload.items()
-                    if key in allowed_fields
-                }
-                gpu_ids = safe_payload.get("gpu_ids")
+            server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
+            if path == "/api/sessions" and self._reject_session_route_components(
+                parsed
+            ):
+                return
+
+            try:
+                payload = self._read_json_body()
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                UnicodeDecodeError,
+                TypeError,
+            ) as exc:
+                self._json_response(400, {"error": {"message": f"Bad request: {exc}"}})
+                return
+
+            if path == "/api/sessions":
+                try:
+                    if not isinstance(payload, dict):
+                        raise ValueError("JSON body must be an object")
+                    allowed_fields = {
+                        "gpu_ids",
+                        "vram",
+                        "interval",
+                        "busy_threshold",
+                        "job_id",
+                    }
+                    unknown_fields = set(payload) - allowed_fields
+                    if unknown_fields:
+                        raise ValueError(
+                            f"Unknown request fields: {sorted(unknown_fields)}"
+                        )
+
+                    safe_payload = {
+                        key: value
+                        for key, value in payload.items()
+                        if key in allowed_fields
+                    }
+                    gpu_ids = safe_payload.get("gpu_ids")
+                    if gpu_ids is not None:
+                        validate_gpu_ids(gpu_ids)
+                except (ValueError, TypeError) as exc:
+                    self._json_response(
+                        400, {"error": {"message": f"Bad request: {exc}"}}
+                    )
+                    return
+
                 if gpu_ids is not None:
-                    validate_gpu_ids(gpu_ids)
                     visible_gpus = server_ref.list_gpus().get("gpus", [])
                     listed_ids = {
                         gpu["id"]
@@ -857,16 +896,32 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     invalid_ids = [
                         gpu_id for gpu_id in gpu_ids if gpu_id not in listed_ids
                     ]
-                    if visible_gpus and invalid_ids:
-                        allowed_ids = ", ".join(
-                            str(gpu_id) for gpu_id in sorted(listed_ids)
+                    if invalid_ids:
+                        allowed_ids = (
+                            ", ".join(str(gpu_id) for gpu_id in sorted(listed_ids))
+                            or "none"
                         )
-                        raise ValueError(
-                            "gpu_ids must match listed visible GPU IDs"
-                            f" ({allowed_ids}); got {invalid_ids}"
+                        self._json_response(
+                            400,
+                            {
+                                "error": {
+                                    "message": (
+                                        "Bad request: gpu_ids must match listed "
+                                        f"visible GPU IDs ({allowed_ids}); got "
+                                        f"{invalid_ids}"
+                                    )
+                                }
+                            },
                         )
+                        return
 
-                result = server_ref.start_keep(**safe_payload)
+                try:
+                    result = server_ref.start_keep(**safe_payload)
+                except SessionInputError as exc:
+                    self._json_response(
+                        400, {"error": {"message": f"Bad request: {exc}"}}
+                    )
+                    return
                 self._json_response(200, result)
                 return
 
@@ -878,43 +933,32 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     return
                 self._json_response(200, response)
                 return
-
-            self._json_response(404, {"error": {"message": "Unknown endpoint"}})
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, TypeError) as exc:
-            self._json_response(400, {"error": {"message": f"Bad request: {exc}"}})
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.exception("POST request failed for path %s", path)
-            self._json_response(
-                500,
-                {
-                    "error": {
-                        "message": str(exc),
-                        "type": exc.__class__.__name__,
-                    }
-                },
-            )
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - defensive
+            self._json_runtime_error("POST", path, exc)
 
     def do_DELETE(self):  # noqa: N802
         parsed = urlparse(self.path)
         path = parsed.path
-        server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
-
-        if path == "/api/sessions":
-            if self._reject_session_route_components(parsed):
+        try:
+            server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
+            if path == "/api/sessions":
+                if self._reject_session_route_components(parsed):
+                    return
+                self._json_response(200, server_ref.stop_keep(job_id=None))
                 return
-            self._json_response(200, server_ref.stop_keep(job_id=None))
-            return
-        if path.startswith("/api/sessions/"):
-            if self._reject_session_route_components(parsed):
+            if path.startswith("/api/sessions/"):
+                if self._reject_session_route_components(parsed):
+                    return
+                try:
+                    job_id = self._job_id_from_session_path(path)
+                except ValueError as exc:
+                    self._json_response(400, {"error": {"message": str(exc)}})
+                    return
+                self._json_response(200, server_ref.stop_keep(job_id=job_id))
                 return
-            try:
-                job_id = self._job_id_from_session_path(path)
-            except ValueError as exc:
-                self._json_response(400, {"error": {"message": str(exc)}})
-                return
-            self._json_response(200, server_ref.stop_keep(job_id=job_id))
-            return
-        self._json_response(404, {"error": {"message": "Unknown endpoint"}})
+            self._json_response(404, {"error": {"message": "Unknown endpoint"}})
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - defensive
+            self._json_runtime_error("DELETE", path, exc)
 
     def log_message(self, format, *args):  # noqa: A003
         """Suppress default request logging."""

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -31,8 +31,13 @@ def dummy_factory(**kwargs):
     return DummyController(**kwargs)
 
 
+class DummyKeepGPUServer(KeepGPUServer):
+    def list_gpus(self):
+        return {"gpus": [{"id": 0, "name": "GPU 0"}]}
+
+
 def make_server() -> KeepGPUServer:
-    return KeepGPUServer(controller_factory=cast(Any, dummy_factory))
+    return DummyKeepGPUServer(controller_factory=cast(Any, dummy_factory))
 
 
 def _start_http_server(server: KeepGPUServer):
@@ -41,6 +46,17 @@ def _start_http_server(server: KeepGPUServer):
 
     httpd = _Server(("127.0.0.1", 0), _JSONRPCHandler)
     httpd.keepgpu_server = server  # type: ignore[attr-defined]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    return httpd, thread, base
+
+
+def _start_bare_http_server():
+    class _Server(TCPServer):
+        allow_reuse_address = True
+
+    httpd = _Server(("127.0.0.1", 0), _JSONRPCHandler)
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     thread.start()
     base = f"http://127.0.0.1:{httpd.server_address[1]}"
@@ -64,6 +80,18 @@ def _request_json(method, url, payload=None):
     data = None
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
+    request = Request(url=url, data=data, method=method)
+    request.add_header("content-type", "application/json")
+    try:
+        with urlopen(request, timeout=2.0) as response:  # nosec B310
+            body = response.read().decode("utf-8")
+            return response.status, json.loads(body) if body else {}
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        return exc.code, json.loads(body) if body else {}
+
+
+def _request_raw(method, url, data=None):
     request = Request(url=url, data=data, method=method)
     request.add_header("content-type", "application/json")
     try:
@@ -244,6 +272,42 @@ def test_http_start_validates_gpu_ids_against_listed_visible_ids(monkeypatch):
     assert controllers == []
 
 
+def test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids(monkeypatch):
+    controllers = []
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            controllers.append(self)
+            super().__init__(**kwargs)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+    monkeypatch.setattr(server, "list_gpus", lambda: {"gpus": []})
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 400
+    assert "listed visible GPU IDs (none)" in payload["error"]["message"]
+    assert controllers == []
+
+
 def test_http_status_reports_starting_session_during_controller_keep():
     keep_started = threading.Event()
     keep_release = threading.Event()
@@ -255,7 +319,7 @@ def test_http_status_reports_starting_session_during_controller_keep():
             keep_started.set()
             keep_release.wait(timeout=1.0)
 
-    server = KeepGPUServer(
+    server = DummyKeepGPUServer(
         controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
     )
     httpd, thread, base = _start_threaded_http_server(server)
@@ -418,6 +482,153 @@ def test_http_unknown_api_route_returns_json_404():
         httpd.server_close()
         server.shutdown()
         thread.join(timeout=2)
+
+
+@pytest.mark.parametrize("data", [None, b"{bad json"])
+def test_http_post_unknown_api_route_returns_json_404_before_body_parse(data):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_raw("POST", f"{base}/api/unknown", data)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 404
+    assert payload["error"]["message"] == "Unknown endpoint"
+
+
+def test_http_get_api_gpus_runtime_error_returns_json_500(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "list_gpus",
+        lambda: (_ for _ in ()).throw(RuntimeError("telemetry exploded")),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}/api/gpus")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["message"] == "telemetry exploded"
+    assert payload["error"]["type"] == "RuntimeError"
+
+
+def test_http_delete_sessions_runtime_error_returns_json_500(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "stop_keep",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("release exploded")),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("DELETE", f"{base}/api/sessions")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["message"] == "release exploded"
+    assert payload["error"]["type"] == "RuntimeError"
+
+
+def test_http_post_sessions_runtime_type_error_returns_json_500(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "start_keep",
+        lambda **_: (_ for _ in ()).throw(TypeError("internal type exploded")),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("POST", f"{base}/api/sessions", {})
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["message"] == "internal type exploded"
+    assert payload["error"]["type"] == "TypeError"
+
+
+def test_http_post_sessions_runtime_value_error_returns_json_500(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "start_keep",
+        lambda **_: (_ for _ in ()).throw(ValueError("startup invariant broke")),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("POST", f"{base}/api/sessions", {})
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["message"] == "startup invariant broke"
+    assert payload["error"]["type"] == "ValueError"
+
+
+def test_http_get_setup_runtime_error_returns_json_500():
+    httpd, thread, base = _start_bare_http_server()
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}/api/gpus")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["type"] == "AttributeError"
+
+
+def test_http_delete_setup_runtime_error_returns_json_500():
+    httpd, thread, base = _start_bare_http_server()
+
+    try:
+        status_code, payload = _request_json("DELETE", f"{base}/api/sessions")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["type"] == "AttributeError"
+
+
+def test_http_post_setup_runtime_error_returns_json_500():
+    httpd, thread, base = _start_bare_http_server()
+
+    try:
+        status_code, payload = _request_json("POST", f"{base}/api/sessions", {})
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+    assert status_code == 500
+    assert payload["error"]["type"] == "AttributeError"
 
 
 def test_http_post_rejects_unknown_fields():


### PR DESCRIPTION
## Summary
- Return structured JSON 500 responses for supported REST GET/POST/DELETE runtime/setup failures instead of dropping HTTP connections.
- Keep validation 400s and unknown API 404s machine-readable; narrow POST validation handling so unexpected startup ValueError/TypeError become runtime 500s while SessionInputError remains 400.
- Document the supported REST route/method error contract in AGENTS, README, MCP guide, CLI reference, and the branch plan.

## Test Plan
- [x] PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q
- [x] PYTHONPATH=$PWD/src pytest tests/mcp tests/utilities/test_gpu_info.py -q
- [x] PYTHONPATH=$PWD/src pytest tests -q
- [x] PYTHONPATH=$PWD/src mkdocs build
- [x] pre-commit run --all-files
- [x] git diff --check && git diff --cached --check
- [x] Local subagent code review, then re-review after fixes; no Critical or Important findings remain

## Notes
- `mkdocs build` still emits the existing Material for MkDocs warning and unnav'd plan notices, but exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * REST API errors now return structured JSON responses instead of dropping the connection.
  * Validation issues, unknown endpoints, and unexpected failures consistently return appropriate HTTP error codes with an error body.
  * Session requests now reject invalid inputs more clearly, including unsupported fields and mismatched GPU selections.

* **Documentation**
  * Updated guides and references to describe the new REST error response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->