### PR TITLE
[controllers] fix: validate inputs before platform probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@ This file defines how coding agents should work in this repository.
   handler exceptions drop the HTTP connection.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
+- `GlobalGPUController` must validate local constructor inputs (`gpu_ids`,
+  `interval`, `busy_threshold`, `vram_to_keep`) before calling
+  `get_platform()` or other hardware/backend probes. Visible-count checks for
+  explicit IDs still happen after platform/device discovery.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -7,9 +7,10 @@ schedulers that the GPU is still busy, without burning a full training workload.
 ## Components
 
 1. **CLI (Typer/Rich)** – Parses options, validates visible GPU ordinals, and configures the logger.
-2. **`GlobalGPUController`** – Detects the current platform (CUDA, ROCm,
-   or Mac M series), validates selected visible ordinals against the current
-   device count, and instantiates one single-GPU controller per selected device.
+2. **`GlobalGPUController`** – Validates local constructor inputs before
+   platform probes, detects the current platform (CUDA, ROCm, or Mac M series),
+   validates selected visible ordinals against the current device count, and
+   instantiates one single-GPU controller per selected device.
 3. **`CudaGPUController`** / **`RocmGPUController`** / **`MacMGPUController`** –
    Platform-specific implementations for per-GPU keep-alive loops.
 4. **GPU monitor (NVML/ROCm/MPS)** – Wraps `nvidia-ml-py` (the `pynvml`
@@ -33,7 +34,8 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
 
 ## Lifecycle
 
-1. The CLI (or your Python code) instantiates `GlobalGPUController`.
+1. The CLI (or your Python code) instantiates `GlobalGPUController`; invalid
+   local inputs fail before backend discovery.
 2. During `keep()` / `__enter__`, `GlobalGPUController` starts each worker.
    If a later worker fails to start, already-started workers are released before
    the original start error is re-raised.

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -64,6 +64,9 @@ with GlobalGPUController(
   ordinals after CUDA or ROCm visibility filtering. Empty, duplicate, or
   out-of-range lists are invalid, and startup raises `ValueError` if the
   resolved selection contains zero devices.
+- Local constructor inputs (`gpu_ids`, `interval`, `busy_threshold`, and
+  `vram_to_keep`) are validated before platform/backend discovery. Visible-count
+  checks for explicit IDs still require device discovery.
 - `busy_threshold` defaults to `25` and accepts `-1` or a percentage in
   `0..100`. Non-negative thresholds throttle the keep-alive loop when
   utilization spikes. When utilization telemetry is unavailable, non-negative

--- a/docs/plans/validate-global-input-before-platform.md
+++ b/docs/plans/validate-global-input-before-platform.md
@@ -1,0 +1,64 @@
+# Validate Global Inputs Before Platform Probe Plan
+
+## Background
+
+`GlobalGPUController.__init__()` called `get_platform()` before validating local
+constructor inputs. That means obviously invalid Python API values such as empty
+or duplicate `gpu_ids`, non-positive intervals, invalid busy thresholds, and bad
+VRAM values could trigger backend/platform probes first. On GPU hosts, those
+probes may initialize NVML, ROCm SMI, torch CUDA, or MPS before returning a
+user-correctable input error.
+
+## Goal
+
+Reject invalid local `GlobalGPUController` inputs before platform or hardware
+probing, keeping visible-count validation after discovery because it depends on
+the current backend/device count.
+
+## Solution
+
+- Add RED constructor tests that monkeypatch `get_platform()` to fail and prove
+  invalid local inputs should raise their own validation errors first.
+- Reuse existing shared validators for `gpu_ids`, `interval`, and
+  `busy_threshold`.
+- Reuse `parse_vram_to_elements()` only as a validation step, preserving the
+  raw public `vram_to_keep` value that child controllers already normalize.
+- Leave CUDA/ROCm/MACM visible-count and platform-specific ID validation after
+  backend discovery.
+- Document the validation-before-probe contract in `AGENTS.md`, Python/API docs,
+  architecture docs, and this plan.
+
+## Tasks
+
+- [x] Add RED test coverage for invalid local inputs before `get_platform()`.
+- [x] Move local validation ahead of platform detection.
+- [x] Keep visible-count checks after platform/device discovery.
+- [x] Update `AGENTS.md`, Python/API/architecture docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and local
+      subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+Completed so far:
+
+- Baseline `PYTHONPATH=$PWD/src pytest tests/global_controller -q`:
+  `9 passed, 1 skipped`.
+- RED focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_global_controller_validates_local_inputs_before_platform_probe -q`
+  failed because all invalid-input cases reached `get_platform()` first.
+- GREEN focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_global_controller_validates_local_inputs_before_platform_probe -q`:
+  `10 passed`.
+- Global-controller shard: `PYTHONPATH=$PWD/src pytest tests/global_controller -q`:
+  `17 passed, 1 skipped`.
+- Targeted controller/platform shard:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py -q`:
+  `34 passed, 6 skipped`.
+- Full test suite: `PYTHONPATH=$PWD/src pytest tests -q`:
+  `288 passed, 11 skipped`.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed. Existing Material for MkDocs
+  warning and unnav'd plan notices were emitted.
+- `pre-commit run --all-files`: passed.
+- `git diff --check && git diff --cached --check`: passed.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,6 +11,11 @@ empty, duplicate, or out-of-range list is invalid, and startup raises
 metadata such as `physical_id`, but those fields are not accepted as selection
 IDs.
 
+`GlobalGPUController` validates local constructor inputs (`gpu_ids`, `interval`,
+`busy_threshold`, and `vram_to_keep`) before platform or hardware probing.
+Visible-count checks for explicit IDs still run after backend discovery because
+they depend on the current visible device count.
+
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
 querying NVML; duplicate or ambiguous masks report unavailable utilization.
 ROCm telemetry resolves `ROCR_VISIBLE_DEVICES` as the base mask and one

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 import torch
 
-from keep_gpu.utilities.humanized_input import parse_size
+from keep_gpu.utilities.humanized_input import parse_size, parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
@@ -37,11 +37,12 @@ class GlobalGPUController:
         vram_to_keep: Union[int, str] = 10 * (2**30),
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
     ):
-        self.computing_platform = get_platform()
         self.interval = validate_interval(interval)
         self.busy_threshold = validate_busy_threshold(busy_threshold)
+        parse_vram_to_elements(vram_to_keep)
         self.vram_to_keep = vram_to_keep
         gpu_ids = validate_gpu_ids(gpu_ids)
+        self.computing_platform = get_platform()
         if self.computing_platform == ComputingPlatform.CUDA:
             from keep_gpu.single_gpu_controller.cuda_gpu_controller import (
                 CudaGPUController,

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -1,7 +1,9 @@
 import inspect
+import math
 
 import pytest
 
+from keep_gpu.global_gpu_controller import global_gpu_controller as global_module
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
 from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
 from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
@@ -35,3 +37,36 @@ def test_global_controller_rejects_empty_gpu_ids(monkeypatch):
 
     with pytest.raises(ValueError, match="gpu_ids must select at least one GPU"):
         GlobalGPUController(gpu_ids=[])
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"gpu_ids": []}, "gpu_ids must select at least one GPU"),
+        ({"gpu_ids": [0, 0]}, "gpu_ids must not contain duplicate values"),
+        ({"gpu_ids": [-1]}, "gpu_ids must contain non-negative integers"),
+        ({"interval": 0}, "interval must be positive"),
+        ({"interval": math.nan}, "interval must be finite and positive"),
+        (
+            {"busy_threshold": -2},
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
+            {"busy_threshold": 101},
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        ({"vram_to_keep": []}, "vram_to_keep must be str or int bytes"),
+        ({"vram_to_keep": "not-a-size"}, "invalid format"),
+        ({"vram_to_keep": 1}, "memory size must be at least 4 bytes"),
+    ],
+)
+def test_global_controller_validates_local_inputs_before_platform_probe(
+    monkeypatch, kwargs, message
+):
+    def fail_platform_probe():
+        raise AssertionError("platform probe should not run for invalid inputs")
+
+    monkeypatch.setattr(global_module, "get_platform", fail_platform_probe)
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        GlobalGPUController(**kwargs)


### PR DESCRIPTION
## Summary
- Validate `GlobalGPUController` local constructor inputs before `get_platform()` or hardware/backend probing.
- Keep visible-count validation after backend discovery, and preserve raw `vram_to_keep` semantics for child controllers while dry-run validating it up front.
- Document the validation-before-probe contract in AGENTS, Python/API/architecture docs, and the branch plan.

## Test Plan
- [x] PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_global_controller_validates_local_inputs_before_platform_probe -q
- [x] PYTHONPATH=$PWD/src pytest tests/global_controller -q
- [x] PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py -q
- [x] PYTHONPATH=$PWD/src pytest tests -q
- [x] PYTHONPATH=$PWD/src mkdocs build
- [x] pre-commit run --all-files
- [x] git diff --check && git diff --cached --check
- [x] Local subagent code review; no Critical or Important findings

## Notes
- `mkdocs build` still emits the existing Material for MkDocs warning and unnav'd plan notices, but exits 0.