### PR TITLE
[platform] fix: prefer rocm torch over nvml cuda

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ This file defines how coding agents should work in this repository.
   `get_platform()` or other hardware/backend probes. Visible-count checks for
   explicit IDs still happen after platform/device discovery.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
+- ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -96,4 +96,6 @@ Elementwise keep-alive batches:
 `get_platform()` inspects the system and enables the CUDA, ROCm, or Mac M series
 (MPS) path. Detection order: CUDA → ROCm → Mac M → CPU fallback.
 Vendor detection probes initialize and then shut down their telemetry libraries
-immediately, so detection does not leave NVML or ROCm SMI handles open.
+immediately, so detection does not leave NVML or ROCm SMI handles open. A PyTorch
+build with a truthy `torch.version.hip` is treated as ROCm before any NVML-based
+CUDA fallback, even if NVML is available on the host.

--- a/docs/plans/rocm-platform-precedence.md
+++ b/docs/plans/rocm-platform-precedence.md
@@ -1,0 +1,42 @@
+# ROCm Platform Precedence Plan
+
+## Background
+
+ROCm PyTorch builds can report `torch.cuda.is_available()` while also exposing a
+truthy `torch.version.hip`. KeepGPU already avoided the torch-CUDA path in that
+case, but `_check_cuda()` still fell through to NVML. On a mixed host where NVML
+initializes, platform detection selected CUDA before ROCm and cached the wrong
+controller family.
+
+## Goal
+
+Prefer the active HIP/ROCm PyTorch runtime over NVML-based CUDA fallback so
+KeepGPU selects ROCm controllers on ROCm torch builds.
+
+## Solution
+
+- Add a no-GPU regression test for `get_platform()` with HIP torch and working
+  NVML.
+- Update `_check_cuda()` to return `False` immediately when `torch.version.hip`
+  is truthy, skipping the NVML fallback.
+- Keep a direct `_check_cuda()` test proving HIP builds do not probe NVML.
+- Document the detection invariant in `AGENTS.md` and the architecture guide.
+
+## Todo
+
+- [x] Run the platform-manager baseline.
+- [x] Add the failing ROCm-over-NVML platform detection test.
+- [x] Verify the new test fails on current behavior.
+- [x] Implement the minimal CUDA probe guard.
+- [x] Update stale platform-manager test expectations.
+- [x] Run the platform-manager shard.
+- [x] Run broader tests, docs build, pre-commit, and local subagent review.
+- [ ] Open a PR, resolve review comments, squash merge, and clean up the branch.
+
+## Verification
+
+- `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py -q`
+- `PYTHONPATH=$PWD/src pytest tests/utilities -q`
+- `PYTHONPATH=$PWD/src pytest tests -q`
+- `PYTHONPATH=$PWD/src mkdocs build`
+- `pre-commit run --all-files`

--- a/src/keep_gpu/utilities/platform_manager.py
+++ b/src/keep_gpu/utilities/platform_manager.py
@@ -27,7 +27,9 @@ def _check_cuda():
     """
     try:
         # ROCm builds set torch.version.hip; treat those as non-CUDA.
-        if torch.cuda.is_available() and torch.version.hip is None:
+        if getattr(torch.version, "hip", None):
+            return False
+        if torch.cuda.is_available():
             return True
     except Exception as exc:  # pragma: no cover - torch edge cases
         logger.debug("torch.cuda.is_available() failed: %s", exc)

--- a/tests/utilities/test_platform_manager.py
+++ b/tests/utilities/test_platform_manager.py
@@ -77,9 +77,9 @@ def test_rocm_detects_hip(monkeypatch):
     assert pm._check_rocm() is True
 
 
-def test_cuda_detection_falls_back_to_nvml(monkeypatch):
-    _reset_cache(monkeypatch)
-    # Force torch to look like ROCm build to ensure NVML takes precedence
+def test_get_platform_prefers_rocm_torch_over_nvml(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", None)
+    monkeypatch.delenv("KEEP_GPU_PLATFORM", raising=False)
     monkeypatch.setattr(pm.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(pm.torch, "version", type("v", (), {"hip": "6.0"}))
 
@@ -88,8 +88,62 @@ def test_cuda_detection_falls_back_to_nvml(monkeypatch):
         def nvmlInit():
             return None
 
+        @staticmethod
+        def nvmlShutdown():
+            return None
+
     monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
+
+    assert pm.get_platform() == pm.ComputingPlatform.ROCM
+
+
+def test_cuda_detection_skips_nvml_for_rocm_torch_build(monkeypatch):
+    _reset_cache(monkeypatch)
+
+    def fail_cuda_probe():
+        raise AssertionError("CUDA availability should not be probed for HIP builds")
+
+    monkeypatch.setattr(pm.torch.cuda, "is_available", fail_cuda_probe)
+    monkeypatch.setattr(pm.torch, "version", type("v", (), {"hip": "6.0"}))
+
+    class DummyNVML:
+        init_calls = 0
+
+        @staticmethod
+        def nvmlInit():
+            DummyNVML.init_calls += 1
+            return None
+
+    monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
+    assert pm._check_cuda() is False
+    assert DummyNVML.init_calls == 0
+
+
+def test_cuda_detection_uses_torch_when_hip_attr_missing(monkeypatch):
+    _reset_cache(monkeypatch)
+    cuda_calls = 0
+
+    def cuda_available():
+        nonlocal cuda_calls
+        cuda_calls += 1
+        return True
+
+    monkeypatch.setattr(pm.torch.cuda, "is_available", cuda_available)
+    monkeypatch.delattr(pm.torch.version, "hip", raising=False)
+
+    class DummyNVML:
+        init_calls = 0
+
+        @staticmethod
+        def nvmlInit():
+            DummyNVML.init_calls += 1
+            raise RuntimeError("NVML should not be needed when torch sees CUDA")
+
+    monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
+
     assert pm._check_cuda() is True
+    assert cuda_calls == 1
+    assert DummyNVML.init_calls == 0
 
 
 def test_cuda_detection_shuts_down_nvml_probe(monkeypatch):


### PR DESCRIPTION
## Summary
- prefer HIP/ROCm PyTorch detection over NVML-based CUDA fallback
- avoid probing NVML from `_check_cuda()` when `torch.version.hip` is truthy
- add no-GPU regression tests for mixed HIP torch + NVML hosts
- document the platform precedence invariant in AGENTS.md, architecture docs, and a plan file

## Verification
- Baseline before edits: `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py -q` -> 8 passed
- RED: `test_get_platform_prefers_rocm_torch_over_nvml` failed with CUDA instead of ROCM
- Focused GREEN: `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py::test_get_platform_prefers_rocm_torch_over_nvml -q` -> 1 passed
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py -q` -> 9 passed
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py tests/utilities -q` -> 9 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 303 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> exit 0; known Material/MkDocs warning and unnav'd plan notices
- `pre-commit run --all-files` -> passed

## Local Review
- Local subagent review completed; no critical or important issues found. Minor plan checklist/test-order hardening suggestions were applied before this PR.