### PR TITLE
[controllers] fix: align python global vram default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ This file defines how coding agents should work in this repository.
   handler exceptions drop the HTTP connection.
 - Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
+- Keep omitted public VRAM defaults aligned and low-power: CLI, Python global controller, service, REST, JSON-RPC, and MCP should default to `1GiB` per GPU unless a user explicitly asks for a different reservation.
 - `GlobalGPUController` must validate local constructor inputs (`gpu_ids`,
   `interval`, `busy_threshold`, `vram_to_keep`) before calling
   `get_platform()` or other hardware/backend probes. Visible-count checks for

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -71,6 +71,9 @@ with GlobalGPUController(
 - Local constructor inputs (`gpu_ids`, `interval`, `busy_threshold`, and
   `vram_to_keep`) are validated before platform/backend discovery. Visible-count
   checks for explicit IDs still require device discovery.
+- `vram_to_keep` defaults to the shared low-power public default, `1GiB`, when
+  omitted. Pass an explicit smaller or larger value when your scheduler needs a
+  different reservation signal.
 - `busy_threshold` defaults to `25` and accepts `-1` or a percentage in
   `0..100`. Non-negative thresholds throttle the keep-alive loop when
   utilization spikes. When utilization telemetry is unavailable, non-negative

--- a/docs/plans/global-python-vram-default-1gib.md
+++ b/docs/plans/global-python-vram-default-1gib.md
@@ -1,0 +1,39 @@
+# Global Python VRAM Default Plan
+
+## Background
+
+`GlobalGPUController` defaulted `vram_to_keep` to `10 * (2**30)` bytes, while
+the CLI, service, JSON-RPC, REST, and MCP public surfaces default to `1GiB`.
+Direct Python users who omitted `vram_to_keep` therefore reserved ten times more
+VRAM per GPU than the rest of KeepGPU.
+
+## Goal
+
+Align the Python global controller with the low-power public default so omitted
+VRAM settings reserve `1GiB` per GPU by default.
+
+## Solution
+
+- Add a signature-level contract test for `GlobalGPUController.vram_to_keep`.
+- Change the default to `"1GiB"` while preserving explicit integer-byte and
+  human-readable string support.
+- Document the shared low-power default in API docs, Python recipes, and
+  `AGENTS.md`.
+
+## Todo
+
+- [x] Run the global-controller baseline.
+- [x] Add the failing default-contract test.
+- [x] Verify the new test fails on current behavior.
+- [x] Implement the one-line default change.
+- [x] Verify the focused test and global contract shard pass.
+- [x] Run broader tests, docs build, pre-commit, and local subagent review.
+- [ ] Open a PR, resolve review comments, squash merge, and clean up the branch.
+
+## Verification
+
+- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py -q`
+- `PYTHONPATH=$PWD/src pytest tests/global_controller -q`
+- `PYTHONPATH=$PWD/src pytest tests -q`
+- `PYTHONPATH=$PWD/src mkdocs build`
+- `pre-commit run --all-files`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,7 +14,9 @@ IDs.
 `GlobalGPUController` validates local constructor inputs (`gpu_ids`, `interval`,
 `busy_threshold`, and `vram_to_keep`) before platform or hardware probing.
 Visible-count checks for explicit IDs still run after backend discovery because
-they depend on the current visible device count.
+they depend on the current visible device count. Its omitted `vram_to_keep`
+default is the shared low-power public default, `1GiB`, matching the CLI and
+service APIs.
 
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
 querying NVML; duplicate or ambiguous masks report unavailable utilization.
@@ -23,10 +25,11 @@ matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying
 ROCm SMI. Unresolved mappings report unavailable utilization instead of falling
 back to a possibly wrong physical device.
 
-Public controller, CLI, REST, JSON-RPC, and MCP defaults use
-`busy_threshold=25`, so busy or unavailable telemetry sleeps before allocating
-keep tensors or running compute. Pass `busy_threshold=-1` only when you
-intentionally want unconditional keepalive compute without utilization backoff.
+Public controller, CLI, REST, JSON-RPC, and MCP defaults use `vram_to_keep`/`vram`
+`1GiB` and `busy_threshold=25`, so omitted settings reserve a modest VRAM signal
+and busy or unavailable telemetry sleeps before allocating keep tensors or
+running compute. Pass `busy_threshold=-1` only when you intentionally want
+unconditional keepalive compute without utilization backoff.
 
 Single-GPU workload iteration controls must be positive integers. CUDA exposes
 `relu_iterations`; ROCm and Mac M expose `iterations`. Non-integer values raise

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -34,7 +34,7 @@ class GlobalGPUController:
         self,
         gpu_ids: Optional[List[int]] = None,
         interval: int = 300,
-        vram_to_keep: Union[int, str] = 10 * (2**30),
+        vram_to_keep: Union[int, str] = "1GiB",
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
     ):
         self.interval = validate_interval(interval)

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -7,6 +7,25 @@ from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUContro
 from keep_gpu.utilities import platform_manager as pm
 
 
+def test_global_controller_propagates_default_vram_to_child_controller(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    captured = {}
+
+    class DummyController:
+        def __init__(self, *, rank, interval, vram_to_keep, busy_threshold):
+            captured["vram_to_keep"] = vram_to_keep
+
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module, "CudaGPUController", DummyController)
+
+    GlobalGPUController(gpu_ids=[0])
+
+    assert captured["vram_to_keep"] == "1GiB"
+
+
 def test_global_keep_rolls_back_started_controllers(monkeypatch):
     monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -23,6 +23,11 @@ def test_python_controller_defaults_use_eco_safe_busy_threshold():
         assert inspect.signature(controller).parameters["busy_threshold"].default == 25
 
 
+def test_global_controller_default_vram_matches_public_low_power_default():
+    default = inspect.signature(GlobalGPUController).parameters["vram_to_keep"].default
+    assert default == "1GiB"
+
+
 @pytest.mark.parametrize("iterations", [1.5, True, "5000"])
 @pytest.mark.parametrize(
     ("controller", "parameter", "message"),


### PR DESCRIPTION
## Summary
- Align `GlobalGPUController()` omitted `vram_to_keep` with the shared low-power public default, `1GiB`.
- Add no-GPU contract and propagation coverage for the Python global controller default.
- Update `AGENTS.md`, Python guide, API reference, and the plan document.

## Verification
- Local subagent code review: no critical or important issues; minor plan checkbox cleanup addressed.
- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py tests/global_controller/global_keep_test.py tests/global_controller -q` -> 33 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 306 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> exit 0, known MkDocs/Material and unnav'd plan notices
- `pre-commit run --all-files` -> passed