### PR TITLE
[mcp] fix: validate REST session input before telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
+- REST session creation must validate cheap local fields (`vram`, `interval`,
+  `busy_threshold`, `job_id`, duplicate custom `job_id`, and `gpu_ids` shape)
+  before telemetry/list_gpus probing. Valid explicit `gpu_ids` are still checked
+  against listed visible IDs before startup.
 - Supported REST API routes/methods must return structured JSON error objects
   for validation, unknown-endpoint, and unexpected runtime failures; do not let
   handler exceptions drop the HTTP connection.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -91,6 +91,9 @@ device ordinals in that same process environment. Empty, duplicate, or
 out-of-range lists are invalid, and startup returns an error if the resolved
 selection contains zero devices. `interval` must be a finite positive number of
 seconds; `NaN` and infinities are rejected before session creation.
+Cheap local fields (`vram`, `interval`, `busy_threshold`, `job_id`, duplicate
+custom `job_id`, and `gpu_ids` shape) are rejected before `/api/sessions` asks
+the service to list visible GPUs, so bad requests do not spend telemetry work.
 CUDA telemetry resolves `CUDA_VISIBLE_DEVICES` for the service process and
 treats duplicate or ambiguous masks as unavailable utilization rather than
 guessing a physical GPU.

--- a/docs/plans/rest-prevalidate-session-input.md
+++ b/docs/plans/rest-prevalidate-session-input.md
@@ -1,0 +1,72 @@
+# REST Session Prevalidation Plan
+
+## Background
+
+`POST /api/sessions` validates `gpu_ids` shape before checking visible GPU IDs,
+but when `gpu_ids` is present it calls `list_gpus()` before validating other
+cheap public inputs such as `vram`, `interval`, `busy_threshold`, `job_id`, or
+duplicate `job_id`. That means clearly invalid REST requests can still trigger
+GPU telemetry probing before returning a user-correctable `400`.
+
+## Goal
+
+Reject invalid REST session creation inputs before telemetry or session state
+work, while preserving visible-ID validation for otherwise valid explicit
+`gpu_ids`.
+
+## Solution
+
+- Add RED HTTP tests proving invalid REST payload fields return JSON `400`
+  without calling `list_gpus()`.
+- Validate the full REST session payload with shared public validators before
+  visible-GPU telemetry checks.
+- Check existing/starting custom `job_id` values before visible-GPU telemetry,
+  then keep the existing atomic duplicate reservation in `start_keep()`.
+- Keep successful explicit `gpu_ids` behavior unchanged: valid IDs are still
+  checked against `/api/gpus`-compatible visible IDs before starting.
+- Document the validation-before-telemetry contract in `AGENTS.md`, MCP guide,
+  and this plan.
+
+## Tasks
+
+- [x] Add RED tests for invalid `vram`, `job_id`, `interval`,
+      `busy_threshold`, and duplicate `job_id` before `list_gpus()`.
+- [x] Implement REST payload prevalidation before visible-GPU telemetry.
+- [x] Preserve current valid explicit `gpu_ids` listing behavior.
+- [x] Update `AGENTS.md`, MCP docs, and this plan.
+- [x] Run focused MCP/HTTP tests, broader tests, docs build, and pre-commit.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
+      and clean the worktree.
+
+## Verification
+
+Completed so far:
+
+- Focused MCP/HTTP baseline before edits:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py -q`,
+  `111 passed`.
+- RED replay in a disposable worktree with tests only:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'invalid_fields_before_listing_gpus or duplicate_job_id_before_listing_gpus'`,
+  `5 failed` because `list_gpus()` ran before cheap validation and returned
+  HTTP `500` instead of `400`.
+- GREEN focused regressions:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'invalid_fields_before_listing_gpus or duplicate_job_id_before_listing_gpus'`,
+  `5 passed`.
+- HTTP API shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q`, `44 passed`.
+- MCP/HTTP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py -q`,
+  `116 passed`.
+- Full test suite:
+  `PYTHONPATH=$PWD/src pytest tests -q`, `317 passed, 11 skipped`.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build`, passed with the known
+  Material/MkDocs warning and unnav'd plan notices.
+- Pre-commit:
+  `pre-commit run --all-files`, passed.
+- Diff whitespace:
+  `git diff --check`, passed.
+- Local subagent review:
+  spec compliance and code-quality reviewers reported no critical, important,
+  or minor findings and marked the branch ready for PR.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -569,6 +569,7 @@ _DIRECT_METHOD_PARAMS = {
     "status": {"job_id"},
     "list_gpus": set(),
 }
+_REST_SESSION_FIELDS = _DIRECT_METHOD_PARAMS["start_keep"]
 
 
 def _validate_direct_method_params(method: str, params: Dict[str, Any]) -> None:
@@ -644,6 +645,40 @@ def _mcp_call_tool(server: KeepGPUServer, params: Dict[str, Any]) -> Dict[str, A
         return _mcp_tool_result(_call_keepgpu_method(server, name, arguments))
     except Exception as exc:
         return _mcp_tool_result(str(exc), True)
+
+
+def _prevalidate_rest_session_payload(
+    server: KeepGPUServer, payload: Any
+) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("JSON body must be an object")
+    unknown_fields = set(payload) - _REST_SESSION_FIELDS
+    if unknown_fields:
+        raise ValueError(f"Unknown request fields: {sorted(unknown_fields)}")
+
+    safe_payload = dict(payload)
+    if "gpu_ids" in safe_payload:
+        safe_payload["gpu_ids"] = _validate_public_session_input(
+            validate_gpu_ids, safe_payload["gpu_ids"]
+        )
+    if "interval" in safe_payload:
+        safe_payload["interval"] = _validate_public_session_input(
+            validate_interval, safe_payload["interval"]
+        )
+    if "busy_threshold" in safe_payload:
+        safe_payload["busy_threshold"] = _validate_public_session_input(
+            validate_busy_threshold, safe_payload["busy_threshold"]
+        )
+    if "vram" in safe_payload:
+        _validate_public_session_input(parse_vram_to_elements, safe_payload["vram"])
+    if "job_id" in safe_payload:
+        job_id = _validate_public_session_input(validate_job_id, safe_payload["job_id"])
+        safe_payload["job_id"] = job_id
+        if job_id is not None:
+            with server._sessions_lock:
+                if job_id in server._sessions or job_id in server._starting_job_ids:
+                    raise SessionInputError(f"job_id {job_id} already exists")
+    return safe_payload
 
 
 def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, Any]]:
@@ -857,29 +892,10 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
 
             if path == "/api/sessions":
                 try:
-                    if not isinstance(payload, dict):
-                        raise ValueError("JSON body must be an object")
-                    allowed_fields = {
-                        "gpu_ids",
-                        "vram",
-                        "interval",
-                        "busy_threshold",
-                        "job_id",
-                    }
-                    unknown_fields = set(payload) - allowed_fields
-                    if unknown_fields:
-                        raise ValueError(
-                            f"Unknown request fields: {sorted(unknown_fields)}"
-                        )
-
-                    safe_payload = {
-                        key: value
-                        for key, value in payload.items()
-                        if key in allowed_fields
-                    }
+                    safe_payload = _prevalidate_rest_session_payload(
+                        server_ref, payload
+                    )
                     gpu_ids = safe_payload.get("gpu_ids")
-                    if gpu_ids is not None:
-                        validate_gpu_ids(gpu_ids)
                 except (ValueError, TypeError) as exc:
                     self._json_response(
                         400, {"error": {"message": f"Bad request: {exc}"}}

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -308,6 +308,133 @@ def test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids(monkeypatch):
     assert controllers == []
 
 
+@pytest.mark.parametrize(
+    ("request_payload", "message"),
+    [
+        (
+            {
+                "gpu_ids": [0],
+                "vram": [],
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+            "vram_to_keep must be str or int bytes",
+        ),
+        (
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 0,
+                "busy_threshold": 5,
+            },
+            "interval must be positive",
+        ),
+        (
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 20,
+                "busy_threshold": 101,
+            },
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 20,
+                "busy_threshold": 5,
+                "job_id": "",
+            },
+            "job_id must be a URL-path-safe non-empty string",
+        ),
+    ],
+)
+def test_http_start_rejects_invalid_fields_before_listing_gpus(
+    request_payload, message
+):
+    controllers = []
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            controllers.append(self)
+            super().__init__(**kwargs)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+    list_calls = []
+
+    def fail_list_gpus():
+        list_calls.append(True)
+        raise AssertionError("list_gpus should not run for invalid input")
+
+    server.list_gpus = fail_list_gpus  # type: ignore[method-assign]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            request_payload,
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 400
+    assert message in payload["error"]["message"]
+    assert list_calls == []
+    assert controllers == []
+
+
+def test_http_start_rejects_duplicate_job_id_before_listing_gpus():
+    controllers = []
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            controllers.append(self)
+            super().__init__(**kwargs)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+    server.start_keep(job_id="existing-job", gpu_ids=[0])
+    list_calls = []
+
+    def fail_list_gpus():
+        list_calls.append(True)
+        raise AssertionError("list_gpus should not run for duplicate job_id")
+
+    server.list_gpus = fail_list_gpus  # type: ignore[method-assign]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 20,
+                "busy_threshold": 5,
+                "job_id": "existing-job",
+            },
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 400
+    assert "job_id existing-job already exists" in payload["error"]["message"]
+    assert list_calls == []
+    assert len(controllers) == 1
+
+
 def test_http_status_reports_starting_session_during_controller_keep():
     keep_started = threading.Event()
     keep_release = threading.Event()


### PR DESCRIPTION
## Summary
- Prevalidate REST `/api/sessions` payload fields before visible-GPU telemetry/listing.
- Preserve visible-ID validation for otherwise valid explicit `gpu_ids`.
- Document the REST validation-before-telemetry contract in `AGENTS.md`, MCP docs, and the branch plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'invalid_fields_before_listing_gpus or duplicate_job_id_before_listing_gpus'` -> 5 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` -> 44 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py -q` -> 116 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 116 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 317 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with known Material/MkDocs and unnav'd plan warnings
- `pre-commit run --all-files` -> passed
- local subagent spec and code-quality reviews -> no findings, ready for PR
