### PR TITLE
[telemetry] fix: prefer ROCm GPU listings for HIP torch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,10 @@ This file defines how coding agents should work in this repository.
 - Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` numeric/UUID tokens to the correct NVML handle. If that mapping is duplicate, ambiguous, or unsupported, return `None` rather than falling back to a possibly wrong physical index.
 - Keep ROCm telemetry aligned with visible ROCm ordinals: resolve `ROCR_VISIBLE_DEVICES` as the base mask and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. If the mapping is malformed, conflicting, unsupported, or out of range, return unavailable utilization rather than querying a guessed SMI index.
 - Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus` must expose `id` as the visible ordinal users can pass as `gpu_ids`; physical/vendor identifiers belong in explicit metadata fields such as `physical_id` and must not be accepted implicitly as selection IDs.
+- Keep GPU listing platform precedence aligned with controller platform
+  detection: HIP/ROCm torch builds must prefer ROCm listing over NVML CUDA
+  listing, and must not fall back to NVML CUDA records when torch's active
+  runtime is HIP.
 - Global controller startup must fail clearly when GPU selection resolves to zero or duplicate devices; do not create silent no-op or duplicate-worker keep sessions.
 - Avoid scattering platform-specific branching across unrelated modules; prefer one clear decision path then platform-specific controller classes.
 - Preserve simple controller flow: global controller orchestrates per-GPU controllers; single-GPU controllers handle device-level keep/release loops.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -102,3 +102,8 @@ Vendor detection probes initialize and then shut down their telemetry libraries
 immediately, so detection does not leave NVML or ROCm SMI handles open. A PyTorch
 build with a truthy `torch.version.hip` is treated as ROCm before any NVML-based
 CUDA fallback, even if NVML is available on the host.
+
+GPU listing follows the same precedence. On HIP/ROCm torch builds, `list_gpus`
+prefers ROCm records and ROCm SMI metadata instead of returning NVML CUDA records
+first on mixed hosts. If ROCm SMI is unavailable, listing falls back to
+torch's HIP-backed device records rather than NVML CUDA records.

--- a/docs/plans/rocm-list-gpus-precedence.md
+++ b/docs/plans/rocm-list-gpus-precedence.md
@@ -1,0 +1,80 @@
+# ROCm GPU Listing Precedence Plan
+
+## Background
+
+Platform detection already treats a PyTorch build with truthy `torch.version.hip`
+as ROCm before NVML-based CUDA fallback. `get_gpu_info()`, however, still tries
+NVML first for `list_gpus`/`/api/gpus`. On mixed hosts with ROCm torch and
+working NVML, GPU listing can expose CUDA/NVML records instead of ROCm-visible
+ordinals and ROCm SMI metadata.
+
+## Goal
+
+Keep GPU listing aligned with the active HIP/ROCm runtime: when
+`torch.version.hip` is truthy, `get_gpu_info()` should prefer ROCm telemetry and
+skip NVML CUDA listing, using torch's HIP-backed listing when ROCm SMI is
+unavailable.
+
+## Solution
+
+- Add a RED GPU-info regression with HIP torch, working ROCm SMI, and working
+  NVML; it must return ROCm records and avoid NVML queries.
+- Teach `get_gpu_info()` to try ROCm SMI, then torch's HIP-backed listing, when
+  the active torch runtime is HIP/ROCm.
+- Preserve existing CUDA/NVML-first behavior for non-HIP torch builds.
+- Update agent/docs guidance to keep `list_gpus` platform precedence aligned
+  with controller platform detection.
+
+## Tasks
+
+- [x] Run focused telemetry baseline.
+- [x] Add RED HIP-over-NVML GPU listing regressions.
+- [x] Implement minimal `get_gpu_info()` precedence fix.
+- [x] Update `AGENTS.md`, docs, and this plan.
+- [x] Run focused telemetry tests, full tests, docs build, and pre-commit.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
+      and clean the worktree.
+
+## Verification
+
+Completed so far:
+
+- Focused telemetry baseline:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/utilities/test_platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py -q`,
+  `54 passed, 1 skipped`.
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_prefers_rocm_when_hip_torch_and_nvml_are_both_available -q`,
+  `1 failed` because `get_gpu_info()` returned NVML CUDA records before ROCm.
+- RED ROCm-SMI-unavailable regression:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_hip_torch_skips_nvml_when_rocm_smi_unavailable -q`,
+  `1 failed` because HIP torch still fell through to NVML CUDA records.
+- GREEN regression:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_prefers_rocm_when_hip_torch_and_nvml_are_both_available tests/utilities/test_gpu_info.py::test_get_gpu_info_hip_torch_skips_nvml_when_rocm_smi_unavailable -q`,
+  `2 passed`.
+- GPU-info shard:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py -q`,
+  `20 passed, 1 skipped` after adding the review-followup missing
+  `torch.version` regression.
+- Telemetry shard:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/utilities/test_platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py -q`,
+  `58 passed, 1 skipped` after the review-followup regression.
+- Full test suite:
+  `PYTHONPATH=$PWD/src pytest tests -q`, `321 passed, 11 skipped`.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build`, passed with the known
+  Material/MkDocs warning and unnav'd plan notices.
+- Pre-commit:
+  `pre-commit run --all-files`, passed.
+- Review follow-up:
+  Gemini suggested guarding missing `torch.version`; updated the HIP check to
+  use nested `getattr` and added
+  `test_get_gpu_info_allows_torch_without_version_attribute`.
+- Local subagent review:
+  code-quality reviewer reported no findings. Spec reviewer reported no
+  blockers but noted `_query_torch()` still read `torch.version.hip` directly
+  on fallback; added a RED regression
+  `test_get_gpu_info_torch_fallback_allows_missing_version_attribute`, observed
+  `1 failed` because the torch fallback returned no GPU records, then guarded
+  `_query_torch()` with nested `getattr` and confirmed the targeted follow-up
+  group passed with `4 passed`.

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -239,7 +239,11 @@ def _query_torch() -> List[Dict[str, Any]]:
                 {
                     "id": idx,
                     "visible_id": idx,
-                    "platform": "cuda" if torch.version.hip is None else "rocm",
+                    "platform": (
+                        "cuda"
+                        if getattr(getattr(torch, "version", None), "hip", None) is None
+                        else "rocm"
+                    ),
                     "name": name,
                     "memory_total": int(total) if total is not None else None,
                     "memory_used": int(used) if used is not None else None,
@@ -302,8 +306,24 @@ def get_gpu_info() -> List[Dict[str, Any]]:
     memory_used, and utilization. Backends may add physical_id or uuid metadata
     when the underlying vendor identity is known.
 
-    Tries NVML first (CUDA), then ROCm SMI, then torch.cuda, then MPS data.
+    Tries ROCm first for HIP torch builds, otherwise NVML first (CUDA), then
+    ROCm SMI, then torch.cuda, then MPS data.
     """
+    if getattr(getattr(torch, "version", None), "hip", None):
+        try:
+            infos = _query_rocm()
+            if infos:
+                return infos
+        except Exception as exc:
+            logger.debug("ROCm info failed: %s", exc)
+        try:
+            infos = _query_torch()
+            if infos:
+                return infos
+        except Exception as exc:
+            logger.debug("Torch GPU info failed: %s", exc)
+        return _query_mps()
+
     try:
         infos = _query_nvml()
         if infos:

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -366,6 +366,127 @@ def test_get_gpu_info_rocm_unresolved_mask_keeps_visible_records_without_utiliza
     assert dummy_rocm.shutdown_calls == 1
 
 
+def test_get_gpu_info_prefers_rocm_when_hip_torch_and_nvml_are_both_available(
+    monkeypatch,
+):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_nvml = MultiGPUDummyNVML(count=2)
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        count=1,
+        util_by_index={0: 71},
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "rocm"
+    assert infos[0]["visible_id"] == 0
+    assert infos[0]["physical_id"] == 0
+    assert infos[0]["name"] == "ROCm 0"
+    assert infos[0]["utilization"] == 71
+    assert dummy_rocm.queried_indexes == [0]
+    assert dummy_rocm.shutdown_calls == 1
+    assert dummy_nvml.queried_indexes == []
+    assert dummy_nvml.shutdown_calls == 0
+
+
+def test_get_gpu_info_hip_torch_skips_nvml_when_rocm_smi_unavailable(monkeypatch):
+    dummy_nvml = MultiGPUDummyNVML(count=2)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+    dummy_cuda = DummyTorchCudaROCm(count=1)
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": dummy_cuda,
+            "version": type("V", (), {"hip": "6.0"}),
+            "backends": type(
+                "Backends",
+                (),
+                {
+                    "mps": type(
+                        "MPSBackend", (), {"is_available": staticmethod(lambda: False)}
+                    )
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "rocm"
+    assert infos[0]["visible_id"] == 0
+    assert infos[0]["utilization"] is None
+    assert dummy_nvml.queried_indexes == []
+    assert dummy_nvml.shutdown_calls == 0
+
+
+def test_get_gpu_info_allows_torch_without_version_attribute(monkeypatch):
+    dummy_nvml = MultiGPUDummyNVML(count=1)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": type("Cuda", (), {"is_available": staticmethod(lambda: False)}),
+            "backends": type(
+                "Backends",
+                (),
+                {
+                    "mps": type(
+                        "MPSBackend", (), {"is_available": staticmethod(lambda: False)}
+                    )
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "cuda"
+    assert dummy_nvml.queried_indexes == [0]
+    assert dummy_nvml.shutdown_calls == 1
+
+
+def test_get_gpu_info_torch_fallback_allows_missing_version_attribute(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+    dummy_cuda = DummyTorchCudaROCm(count=1)
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": dummy_cuda,
+            "backends": type(
+                "Backends",
+                (),
+                {
+                    "mps": type(
+                        "MPSBackend", (), {"is_available": staticmethod(lambda: False)}
+                    )
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["platform"] == "cuda"
+    assert infos[0]["visible_id"] == 0
+    assert dummy_cuda.set_devices == [0, 0]
+
+
 @pytest.mark.rocm
 def test_get_gpu_info_rocm(monkeypatch):
     # remove nvml so ROCm path is used


### PR DESCRIPTION
## Summary
- Make `get_gpu_info()`/`list_gpus` follow ROCm/HIP platform precedence before NVML CUDA listing.
- On HIP torch builds, try ROCm SMI first, then torch's HIP-backed records; do not fall back to NVML CUDA records for the active HIP runtime.
- Add mocked regressions for mixed ROCm+NVML hosts and ROCm-SMI-unavailable HIP fallback, plus AGENTS/docs/plan updates.

## Test Plan
- RED: `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_prefers_rocm_when_hip_torch_and_nvml_are_both_available -q` -> 1 failed on old NVML-first behavior
- RED: `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_hip_torch_skips_nvml_when_rocm_smi_unavailable -q` -> 1 failed on old NVML fallback behavior
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py -q` -> 18 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/utilities/test_platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py -q` -> 56 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 319 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with known Material/MkDocs and unnav'd plan warnings
- `pre-commit run --all-files` -> passed
- local subagent spec and code-quality reviews -> no findings, ready for PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU listing now prefers ROCm/HIP data on compatible builds, avoiding CUDA/NVML results when the active runtime is HIP.
  * Added a new planning note documenting the expected GPU listing precedence for ROCm systems.

* **Bug Fixes**
  * Improved GPU detection on mixed ROCm and CUDA hosts so listed devices and metadata match the active runtime.

* **Documentation**
  * Clarified platform-detection guidance and architecture boundaries for GPU listing behavior.

* **Tests**
  * Added coverage for ROCm-first discovery and fallback behavior when ROCm SMI is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->