### PR TITLE
[cli] fix: validate JSON-RPC service envelopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ This file defines how coding agents should work in this repository.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
+- CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - REST session creation must validate cheap local fields (`vram`, `interval`,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Flags that matter:
     `physical_id`/`uuid` fields are metadata only.
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
-    that tools such as `jq` can parse directly.
+    that tools such as `jq` can parse directly. Malformed JSON-RPC service
+    envelopes are reported as those JSON error objects instead of empty success
+    results.
 
 ## Embed in Python
 
@@ -149,6 +151,9 @@ to zero devices.
 - HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
   same JSON-RPC messages at `/rpc`, but it is not a Streamable HTTP MCP
   endpoint.
+- Successful legacy direct JSON-RPC responses use a KeepGPU direct-method
+  envelope with `jsonrpc: "2.0"`, the matching request `id`, and an object
+  `result`.
 - REST examples:
   ```bash
   curl http://127.0.0.1:8765/health

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -66,6 +66,8 @@ The `id` field in this output is the visible ordinal to pass to `--gpu-ids`.
 `status`, `stop`, and `list-gpus` print JSON objects, including
 `{"error": "..."}` for service/runtime errors after CLI parsing succeeds, that
 can be parsed directly with `jq` or a single `json.loads()` call.
+Malformed JSON-RPC service envelopes are reported as JSON error objects instead
+of empty success results.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -75,6 +75,9 @@ Methods:
 - `status(job_id?)`
 - `list_gpus()`
 
+Successful direct-method responses are KeepGPU JSON-RPC envelopes with
+`jsonrpc: "2.0"`, the matching request `id`, and an object `result`.
+
 For direct JSON-RPC calls, public validation failures and unknown parameters
 return JSON-RPC `-32602 Invalid params`. Unexpected server failures use
 `-32603 Internal error`.

--- a/docs/plans/cli-jsonrpc-envelope-validation.md
+++ b/docs/plans/cli-jsonrpc-envelope-validation.md
@@ -1,0 +1,99 @@
+# CLI JSON-RPC Envelope Validation Plan
+
+## Background
+
+`keep-gpu status`, `keep-gpu stop`, and `keep-gpu list-gpus` rely on
+`_rpc_call()` for local service requests. `_rpc_call()` checks for an `"error"`
+field, but otherwise returns `response.get("result", {})`. A malformed success
+envelope that omits `"result"` can therefore be treated as an empty successful
+response, which hides service/proxy bugs from users and downstream automation.
+
+## Goal
+
+Reject malformed JSON-RPC service envelopes as structured CLI errors instead of
+accepting them as successful empty results or leaking tracebacks.
+
+## Solution
+
+- Add RED CLI tests proving malformed service envelopes exit nonzero
+  and print a single-decode `{"error": "..."}` JSON object.
+- Add focused `_rpc_call()` coverage for malformed response shapes.
+- Validate the local service JSON-RPC envelope at the client boundary before
+  returning a result.
+- Update `AGENTS.md` and CLI docs so future CLI service changes keep the
+  response-envelope contract.
+
+## Tasks
+
+- [x] Create an isolated worktree branch from latest `main`.
+- [x] Run the focused CLI service-command baseline.
+- [x] Add RED malformed-envelope tests.
+- [x] Implement minimal `_rpc_call()` response-envelope validation.
+- [x] Update `AGENTS.md`, docs, and this plan.
+- [x] Run targeted tests, broader tests, docs build, and pre-commit.
+- [ ] Run local subagent review.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+Completed so far:
+
+- Baseline:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
+  `41 passed`.
+- RED missing-result regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_without_result tests/test_cli_service_commands.py::test_status_outputs_json_error_for_malformed_rpc_success_envelope -q`,
+  `2 failed` because `_rpc_call()` did not raise and `keep-gpu status` exited
+  successfully.
+- GREEN missing-result regression:
+  the same targeted command passed with `2 passed`.
+- RED non-object result regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_non_object_result -q`,
+  `1 failed` because list results were accepted.
+- RED `jsonrpc`/`id` regressions:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_invalid_jsonrpc_version tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_mismatched_id -q`,
+  `3 failed` because wrong or missing `jsonrpc` and mismatched `id` were
+  accepted.
+- RED non-object error regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_non_object_error -q`,
+  `1 failed` because a malformed error envelope leaked as `AttributeError`.
+- GREEN malformed-envelope group:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_without_result tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_non_object_result tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_invalid_jsonrpc_version tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_mismatched_id tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_non_object_error tests/test_cli_service_commands.py::test_status_outputs_json_error_for_malformed_rpc_success_envelope -q`,
+  `7 passed`.
+- Local review follow-up RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_non_object_jsonrpc_response tests/test_cli_service_commands.py::test_service_json_commands_output_json_error_for_non_object_rpc_response -q`,
+  `4 failed` because a top-level JSON array leaked as `AttributeError` and
+  `status`/`stop`/`list-gpus` printed no JSON error object.
+- Local review follow-up GREEN:
+  the same command passed with `4 passed` after adding a top-level response
+  object guard. The expanded malformed-envelope group passed with `11 passed`.
+- Gemini review follow-up RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_both_error_and_result -q`,
+  `2 failed` because protocol-level errors with `id: null` were masked as
+  mismatched ids and envelopes containing both `error` and `result` propagated
+  as application errors.
+- Gemini review follow-up GREEN:
+  the same command passed with `2 passed` after checking mutual exclusion before
+  error/result handling and allowing `id: null` for JSON-RPC error envelopes.
+  The expanded malformed-envelope group passed with `13 passed`.
+- Local review after Gemini follow-up RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_without_id_member -q`,
+  `1 failed` because an omitted error-envelope `id` was treated the same as an
+  explicit `id: null`.
+- Local review after Gemini follow-up GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_without_id_member tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_both_error_and_result tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_mismatched_id -q`,
+  `4 passed` after requiring the `id` member on error envelopes.
+- GREEN CLI service-command shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
+  `55 passed`.
+- Targeted CLI + MCP/service shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py -q`,
+  `127 passed`.
+- Full test suite:
+  `PYTHONPATH=$PWD/src pytest tests -q`, `335 passed, 11 skipped`.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build`, passed with the known Material/MkDocs
+  warning and unnav'd plan notices.
+- Pre-commit:
+  `pre-commit run --all-files`, passed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,7 +64,8 @@ daemon startup or RPC.
 | `--host`, `--port` | Service host/port. |
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
-service/runtime errors after CLI parsing succeeds.
+service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
+envelopes are reported as JSON error objects instead of empty success results.
 
 ### `keep-gpu stop`
 
@@ -81,7 +82,8 @@ stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
 The output is a directly parseable JSON object, including `{"error": "..."}` for
-service/runtime errors after CLI parsing succeeds.
+service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
+envelopes are reported as JSON error objects instead of empty success results.
 
 ### `keep-gpu list-gpus`
 
@@ -89,7 +91,8 @@ Returns GPU telemetry from service. `id` and `visible_id` are the visible
 ordinals accepted by `--gpu-ids` and service `gpu_ids`; optional `physical_id`
 or `uuid` fields are metadata only. The output is a directly parseable JSON
 object, including `{"error": "..."}` for service/runtime errors after CLI
-parsing succeeds.
+parsing succeeds. Malformed JSON-RPC service envelopes are reported as JSON
+error objects instead of empty success results.
 
 ### `keep-gpu service-stop`
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -431,10 +431,37 @@ def _rpc_call(
     response = _http_json_request(
         "POST", f"{_service_base_url(host, port)}/rpc", payload, timeout=timeout
     )
+    if not isinstance(response, dict):
+        raise ServiceResponseError(
+            "Malformed JSON-RPC response: response must be an object"
+        )
+    if response.get("jsonrpc") != "2.0":
+        raise ServiceResponseError("Malformed JSON-RPC response: jsonrpc must be 2.0")
+    if "error" in response and "result" in response:
+        raise ServiceResponseError(
+            "Malformed JSON-RPC response: both error and result members are present"
+        )
     if "error" in response:
         error = response["error"]
+        if not isinstance(error, dict):
+            raise ServiceResponseError(
+                "Malformed JSON-RPC response: error must be an object"
+            )
+        if "id" not in response:
+            raise ServiceResponseError("Malformed JSON-RPC response: missing id")
+        if response.get("id") not in (payload["id"], None):
+            raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
         raise ServiceRPCError(error.get("message", str(error)))
-    return response.get("result", {})
+    if response.get("id") != payload["id"]:
+        raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
+    if "result" not in response:
+        raise ServiceResponseError("Malformed JSON-RPC response: missing result")
+    result = response["result"]
+    if not isinstance(result, dict):
+        raise ServiceResponseError(
+            "Malformed JSON-RPC response: result must be an object"
+        )
+    return result
 
 
 def _is_service_unreachable_error(exc: RuntimeError) -> bool:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -314,6 +314,169 @@ def test_list_gpus_error_outputs_single_decoded_json_object(monkeypatch):
     assert payload["error"] == "telemetry service unavailable"
 
 
+def test_rpc_call_rejects_success_envelope_without_result(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+
+    def fake_http_json_request(method, url, payload, timeout=8.0):
+        assert method == "POST"
+        assert url == "http://127.0.0.1:8765/rpc"
+        assert payload["id"] == 1000
+        return {"jsonrpc": "2.0", "id": 1000}
+
+    monkeypatch.setattr(cli, "_http_json_request", fake_http_json_request)
+
+    with pytest.raises(cli.ServiceResponseError, match="missing result"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_success_envelope_with_non_object_result(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1000, "result": []},
+    )
+
+    with pytest.raises(cli.ServiceResponseError, match="result must be an object"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+@pytest.mark.parametrize("version", [None, "1.0"])
+def test_rpc_call_rejects_success_envelope_with_invalid_jsonrpc_version(
+    monkeypatch, version
+):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    response = {"id": 1000, "result": {}}
+    if version is not None:
+        response["jsonrpc"] = version
+    monkeypatch.setattr(cli, "_http_json_request", lambda *args, **kwargs: response)
+
+    with pytest.raises(cli.ServiceResponseError, match="jsonrpc must be 2.0"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_success_envelope_with_mismatched_id(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 999, "result": {}},
+    )
+
+    with pytest.raises(cli.ServiceResponseError, match="mismatched id"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_error_envelope_with_non_object_error(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1000, "error": "bad"},
+    )
+
+    with pytest.raises(cli.ServiceResponseError, match="error must be an object"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_propagates_error_envelope_with_null_id(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32700, "message": "Parse error"},
+        },
+    )
+
+    with pytest.raises(cli.ServiceRPCError, match="Parse error"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_error_envelope_without_id_member(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {
+            "jsonrpc": "2.0",
+            "error": {"code": -32600, "message": "Requests must include an id."},
+        },
+    )
+
+    with pytest.raises(cli.ServiceResponseError, match="missing id"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_envelope_with_both_error_and_result(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {
+            "jsonrpc": "2.0",
+            "id": 1000,
+            "error": {"code": -32000, "message": "service failed"},
+            "result": {},
+        },
+    )
+
+    with pytest.raises(
+        cli.ServiceResponseError, match="both error and result members are present"
+    ):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+def test_rpc_call_rejects_non_object_jsonrpc_response(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(cli, "_http_json_request", lambda *args, **kwargs: [])
+
+    with pytest.raises(cli.ServiceResponseError, match="response must be an object"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
+@pytest.mark.parametrize(
+    ("command", "method", "params"),
+    [
+        (["status"], "status", {}),
+        (["stop", "--job-id", "job-1"], "stop_keep", {"job_id": "job-1"}),
+        (["list-gpus"], "list_gpus", {}),
+    ],
+)
+def test_service_json_commands_output_json_error_for_non_object_rpc_response(
+    monkeypatch, command, method, params
+):
+    def fake_http_json_request(http_method, url, payload, timeout=8.0):
+        assert payload["method"] == method
+        assert payload["params"] == params
+        return []
+
+    monkeypatch.setattr(cli, "_http_json_request", fake_http_json_request)
+
+    result = runner.invoke(cli.app, command)
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert "response must be an object" in payload["error"]
+
+
+def test_status_outputs_json_error_for_malformed_rpc_success_envelope(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1000},
+    )
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert "missing result" in payload["error"]
+
+
 def test_blocking_mode_defaults_to_eco_safe_busy_threshold(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- Reject malformed CLI service JSON-RPC envelopes before treating responses as successful results.
- Preserve one-decode JSON error output for `status`, `stop`, and `list-gpus` when the service returns malformed JSON-RPC responses.
- Document the KeepGPU direct-method response-envelope contract in AGENTS, README, and CLI/MCP docs.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`

## Local Review
- Spec compliance subagent: no must-fix findings after top-level non-object response guard.
- Code-quality/reliability subagent: no findings; verified CLI and MCP shards.
