### PR TITLE
[validation,mcp] fix: reject oversized numeric session inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,8 @@ This file defines how coding agents should work in this repository.
 - Supported REST API routes/methods must return structured JSON error objects
   for validation, unknown-endpoint, and unexpected runtime failures; do not let
   handler exceptions drop the HTTP connection.
-- Public `interval` values must be finite positive seconds; reject `NaN`/`Infinity` before creating or mutating session state so keep loops cannot spin, crash, or wedge.
-- Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, while controllers may convert to internal tensor element counts.
+- Public `interval` values must be finite positive seconds capped by the Python runtime wait limit; reject `NaN`, `Infinity`, and oversized values before creating or mutating session state so keep loops cannot spin, crash, or wedge.
+- Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, public VRAM byte-equivalent values must be no more than 1 PiB, and controllers may convert valid inputs to internal tensor element counts.
 - Keep omitted public VRAM defaults aligned and low-power: CLI, Python global controller, service, REST, JSON-RPC, and MCP should default to `1GiB` per GPU unless a user explicitly asks for a different reservation.
 - `GlobalGPUController` must validate local constructor inputs (`gpu_ids`,
   `interval`, `busy_threshold`, `vram_to_keep`) before calling

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Flags that matter:
 
 - Blocking mode knobs:
   - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
+    Public VRAM byte-equivalent values are capped at 1 PiB so absurd requests
+    fail as validation errors instead of overflow failures.
   - `--interval` (finite positive seconds): sleep between keep-alive bursts.
+    Values above the Python runtime wait limit are rejected.
   - `--busy-threshold`: defaults to `25`; `0..100` skips work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
   - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm); otherwise all visible GPUs are guarded. Empty, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
 - Service mode commands:
@@ -159,7 +162,7 @@ to zero devices.
   curl http://127.0.0.1:8765/health
   curl http://127.0.0.1:8765/api/sessions
   ```
-- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
+- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Public numeric session inputs must stay finite and bounded: interval values are positive seconds capped by the runtime wait limit, and VRAM byte-equivalent values are capped at 1 PiB. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
 - Supported REST route/method failures remain machine-readable: validation
   errors use JSON `400` responses, unknown API routes use JSON `404`, and
   unexpected service/runtime failures use JSON `500` instead of closing the

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -60,9 +60,11 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
 5. If utilization exceeds `busy_threshold`, or if utilization is unavailable
    while `busy_threshold` is non-negative, the worker just sleeps for one more
    `interval` before allocating or running ops. Otherwise it allocates the keep
-   tensor when needed and runs a batch. Public defaults use `busy_threshold=25`.
-   Valid thresholds are `-1` or `0..100`; `busy_threshold=-1` is the explicit
-   unconditional mode.
+   tensor when needed and runs a batch. Public intervals must be finite positive
+   seconds within the Python runtime wait limit, and public VRAM
+   byte-equivalent inputs are capped at 1 PiB before conversion to tensor
+   elements. Public defaults use `busy_threshold=25`. Valid thresholds are `-1`
+   or `0..100`; `busy_threshold=-1` is the explicit unconditional mode.
 6. When you call `release()` (or exit the context), every worker sets a stop
    event, joins the thread, and clears the device cache. Release attempts every
    worker and then raises a summary if any worker failed to stop.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,14 +96,15 @@ drivers/toolkit can allocate VRAM outside KeepGPU.
 keep-gpu --interval 120 --gpu-ids 0 --vram 1GiB
 ```
 
-- `--interval` controls the finite positive sleep between utilization checks (seconds).
+- `--interval` controls the finite positive sleep between utilization checks
+  (seconds). Values above the Python runtime wait limit are rejected.
 - `--gpu-ids` limits the job to a subset of visible device ordinals. Set
   `CUDA_VISIBLE_DEVICES` before starting KeepGPU if you need physical-device
   filtering. In service mode, `keep-gpu list-gpus` and the dashboard show these
   same start-compatible visible ordinals as GPU IDs; physical metadata is only
   informational.
 - `--vram` accepts human-readable sizes or bare bytes; KeepGPU allocates one
-  tensor of that size.
+  tensor of that size. Byte-equivalent values above 1 PiB are rejected.
 
 Leave the command running while you prepare data or review notebooks. When you are
 ready to hand the GPU back, hit `Ctrl+C`—controllers will release VRAM and exit.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -31,6 +31,9 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
 fail without creating daemon runtime files or issuing RPC.
+`--interval` must be finite, positive, and within the Python runtime wait
+limit. `--vram` keeps integer and digit-only values as bytes, accepts human
+units, and rejects byte-equivalent requests above 1 PiB.
 
 ### Check status
 
@@ -98,8 +101,8 @@ The dashboard provides:
 | Option | Meaning | Default |
 | --- | --- | --- |
 | `--gpu-ids` | Comma-separated unique non-negative visible device ordinals. Omit to use all visible devices; startup fails if that resolves to none or if an explicit ordinal is out of range. | all |
-| `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes). | `1GiB` |
-| `--interval` | Finite positive seconds between keep-alive cycles. | `300` |
+| `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes), capped at 1 PiB byte-equivalent. | `1GiB` |
+| `--interval` | Finite positive seconds between keep-alive cycles, capped by the Python runtime wait limit. | `300` |
 | `--busy-threshold` / `--util-threshold` | `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
 | `--job-id` | Optional URL-path-safe session id. Invalid IDs are rejected before service auto-start. | auto |
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -93,7 +93,10 @@ Omitting `gpu_ids` means all GPUs visible to the service process. Omitting
 device ordinals in that same process environment. Empty, duplicate, or
 out-of-range lists are invalid, and startup returns an error if the resolved
 selection contains zero devices. `interval` must be a finite positive number of
-seconds; `NaN` and infinities are rejected before session creation.
+seconds within the Python runtime wait limit; `NaN`, infinities, and oversized
+values are rejected before session creation. `vram` accepts human-readable
+sizes or bytes, but byte-equivalent requests above 1 PiB are rejected as public
+validation errors.
 Cheap local fields (`vram`, `interval`, `busy_threshold`, `job_id`, duplicate
 custom `job_id`, and `gpu_ids` shape) are rejected before `/api/sessions` asks
 the service to list visible GPUs, so bad requests do not spend telemetry work.

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -25,8 +25,10 @@ train_model()                     # GPU memory is released automatically
   resolves `ROCR_VISIBLE_DEVICES` as the base mask and one matching
   `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm
   SMI. If a mapping cannot be resolved, utilization is treated as unavailable.
-- `interval` is the finite positive pause between keep-alive bursts inside the background thread.
-- `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size` handles it).
+- `interval` is the finite positive pause between keep-alive bursts inside the
+  background thread, capped by the Python runtime wait limit.
+- `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size`
+  handles it). Byte-equivalent values above 1 PiB are rejected.
 - Platform-specific keep workload iteration counts must be positive integers.
   CUDA uses `relu_iterations`; ROCm and Mac M use `iterations`. Rejecting
   non-integer and non-positive values prevents a keep session from starting

--- a/docs/plans/mcp-finite-numeric-validation.md
+++ b/docs/plans/mcp-finite-numeric-validation.md
@@ -113,6 +113,7 @@ validation lane.
 - Modify: `README.md`
 - Modify: `docs/guides/cli.md`
 - Modify: `docs/guides/mcp.md`
+- Modify: `docs/guides/python.md`
 - Modify: `docs/reference/cli.md`
 - Modify: `docs/getting-started.md`
 - Modify: `docs/concepts/architecture.md`

--- a/docs/plans/mcp-finite-numeric-validation.md
+++ b/docs/plans/mcp-finite-numeric-validation.md
@@ -1,0 +1,205 @@
+# Finite Numeric Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject oversized public numeric values as validation errors before they can overflow interval or VRAM parsing paths.
+
+**Architecture:** Keep public interval validation centralized in `src/keep_gpu/utilities/session_config.py` and public VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`. JSON-RPC, REST, MCP tools, CLI, and Python controllers should inherit the same finite, bounded contract through those shared helpers instead of each surface handling overflow differently.
+
+**Tech Stack:** Python, pytest, KeepGPU MCP/JSON-RPC/REST service, MkDocs.
+
+---
+
+## Background
+
+The previous non-finite interval fix rejects `NaN` and infinity, but some huge
+finite-looking public values still fail before they can become normal validation
+errors:
+
+- `validate_interval(10**1000)` can raise `OverflowError` while calling
+  `math.isfinite()`.
+- `parse_vram_to_elements(10**1000)` can raise `OverflowError` while converting
+  public byte counts through `float(value)`.
+- Oversized digit strings such as `"999...GiB"` can also overflow during
+  `float(value)` conversion.
+
+Because `_validate_public_session_input()` maps only `TypeError` and
+`ValueError` into `SessionInputError`, those overflows can surface as JSON-RPC
+`-32603`, HTTP `500`, or MCP tool execution errors that look like internal
+failures. They are user-correctable input errors and should stay in the public
+validation lane.
+
+## Solution
+
+- Add RED tests for oversized interval and VRAM inputs at the shared utility
+  layer, direct JSON-RPC layer, and REST prevalidation layer.
+- Add explicit public bounds for interval seconds and VRAM byte-equivalent
+  requests. Intervals are capped by Python's runtime wait limit, VRAM
+  byte-equivalent requests are capped at 1 PiB, and oversized values raise
+  `ValueError`.
+- Avoid unchecked `float()` conversion for public integer byte counts. Integer
+  byte counts can be converted to float32 element counts with integer division.
+- Catch numeric conversion `OverflowError` inside `humanized_input.py` and raise
+  `ValueError` with a user-facing message.
+- Parse decimal VRAM strings exactly enough to enforce the 1 PiB ceiling before
+  conversion to tensor elements.
+- Add a narrow `_validate_public_session_input()` defense-in-depth catch for
+  `OverflowError` so public validators cannot leak overflow as internal server
+  failures if a future helper regresses.
+- Update `AGENTS.md` and user docs to state that public numeric session inputs
+  must be finite, positive, and bounded.
+
+## Tasks
+
+### Task 1: Add RED utility tests
+
+**Files:**
+- Modify: `tests/utilities/test_session_config.py`
+- Modify: `tests/utilities/test_humanized_input.py`
+
+- [x] Add a test proving `validate_interval(10**1000)` raises `ValueError`
+      with a public validation message instead of `OverflowError`.
+- [x] Add tests proving huge integer and huge digit-string VRAM inputs raise
+      `ValueError` from `parse_vram_to_elements()`/`parse_size()`.
+- [x] Run:
+      `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py -q`
+      and record the expected RED failures.
+
+### Task 2: Add RED service boundary tests
+
+**Files:**
+- Modify: `tests/mcp/test_server.py`
+- Modify: `tests/mcp/test_http_api.py`
+
+- [x] Add JSON-RPC tests proving huge `interval`, huge integer `vram`, and huge
+      string `vram` return `-32602 Invalid params` without creating sessions.
+- [x] Add REST tests proving the same oversized values return HTTP `400` before
+      `list_gpus()` or controller startup.
+- [x] Run:
+      `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q -k 'huge or oversized'`
+      and record the expected RED failures.
+
+### Task 3: Implement shared validation
+
+**Files:**
+- Modify: `src/keep_gpu/utilities/session_config.py`
+- Modify: `src/keep_gpu/utilities/humanized_input.py`
+- Modify: `src/keep_gpu/mcp/server.py`
+
+- [x] Define an explicit maximum public interval and reject values above it with
+      `ValueError`.
+- [x] Define an explicit maximum public VRAM byte-equivalent request and reject
+      values above it with `ValueError`.
+- [x] Convert public integer byte counts to element counts with integer
+      arithmetic.
+- [x] Validate digit-only byte strings before `int()` conversion so Python's
+      integer digit limit cannot leak into user-facing errors.
+- [x] Validate decimal VRAM strings against the 1 PiB ceiling before element
+      conversion.
+- [x] Validate unit-suffixed decimal VRAM strings against the per-unit ceiling
+      before multiplication can round just-over-limit values back to the cap.
+- [x] Validate blocking CLI VRAM before torch import, telemetry probing, or
+      controller startup.
+- [x] Widen MCP `tools/list` schema so `vram` accepts strings or integer bytes
+      and advertises the 1 PiB cap.
+- [x] Wrap string numeric conversion overflow in `ValueError`.
+- [x] Map public `OverflowError` through `SessionInputError` as a final guard.
+- [x] Run targeted utility and MCP/HTTP tests until green.
+
+### Task 4: Update documentation
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `docs/guides/cli.md`
+- Modify: `docs/guides/mcp.md`
+- Modify: `docs/reference/cli.md`
+- Modify: `docs/getting-started.md`
+- Modify: `docs/concepts/architecture.md`
+- Modify: this plan
+
+- [x] Document that public `interval` values are finite positive seconds capped
+      to a reasonable keep-loop bound.
+- [x] Document that public `vram` values remain bytes for integers and
+      digit-only strings, but must be finite and bounded.
+- [x] Keep wording consistent across CLI, REST, JSON-RPC, MCP, and Python API
+      references.
+
+### Task 5: Verify, review, PR, and merge
+
+- [x] Run targeted tests:
+      `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py tests/global_controller/test_contract.py -q`
+- [x] Run full tests:
+      `PYTHONPATH=$PWD/src pytest tests -q`
+- [x] Run docs build:
+      `PYTHONPATH=$PWD/src mkdocs build`
+- [x] Run pre-commit:
+      `pre-commit run --all-files`
+- [x] Run `git diff --check`.
+- [x] Run local subagent spec and code-quality review; resolve all must-fix
+      findings.
+- [ ] Commit with `fix(validation): reject oversized numeric session inputs`.
+- [ ] Push, open a PR titled
+      `[validation,mcp] fix: reject oversized numeric session inputs`.
+- [ ] Resolve all GitHub and local review comments, wait for green checks, squash
+      merge, pull `main`, and clean the branch/worktree.
+
+## Verification
+
+- Baseline before edits:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q`,
+  `150 passed`.
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py tests/global_controller/test_contract.py -q -k 'oversized or huge or local_inputs_before_auto_start or validates_local_inputs_before_platform_probe'`,
+  `14 failed, 12 passed, 222 deselected`; failures showed `OverflowError`,
+  JSON-RPC `-32603`, HTTP `500`, and uncaught CLI/controller overflows.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py tests/global_controller/test_contract.py -q -k 'oversized or huge or local_inputs_before_auto_start or validates_local_inputs_before_platform_probe'`,
+  `26 passed, 222 deselected`.
+- Touched-module shard:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py tests/global_controller/test_contract.py -q`,
+  `248 passed` before review fixes, then `258 passed` after addressing local
+  review findings for blocking CLI, MCP schema, digit-only string limits, and
+  exact decimal VRAM caps, then `259 passed` after the final unit-suffixed
+  decimal cap fix.
+- Utility rerun after Black formatting:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_humanized_input.py tests/utilities/test_session_config.py -q`,
+  `41 passed`.
+- Review-fix RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_blocking_mode_rejects_invalid_vram_without_raw_exception tests/mcp/test_server.py::test_mcp_tools_list_exposes_keepgpu_actions tests/mcp/test_server.py::test_mcp_tools_call_rejects_oversized_integer_vram_as_tool_error tests/utilities/test_humanized_input.py tests/utilities/test_session_config.py -q`,
+  `5 failed, 47 passed`; failures showed blocking CLI raw VRAM errors, MCP
+  string-only `vram` schema, and decimal strings just over 1 PiB passing.
+- Review-fix GREEN:
+  Same command, `52 passed`.
+- Unit-decimal RED:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_humanized_input.py::test_parse_size_rejects_unit_decimal_string_above_public_maximum -q`,
+  `1 failed`; `1048576.0000000000000000000000001GiB` rounded to the 1 PiB cap.
+- Unit-decimal GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_humanized_input.py -q`,
+  `11 passed`.
+- Manual review probes:
+  `parse_size(str(PUBLIC_VRAM_MAX_BYTES))` accepted the max,
+  `parse_size(str(PUBLIC_VRAM_MAX_BYTES + 1))`,
+  `parse_size(f"{PUBLIC_VRAM_MAX_BYTES}.1")`, and `parse_size("9" * 4301)`
+  raised `ValueError: vram must be no more than 1 PiB`; MCP `tools/list`
+  exposed `vram` as `["string", "integer"]` with the 1 PiB maximum; blocking
+  CLI printed `Error: vram must be no more than 1 PiB`.
+- Local subagent review:
+  initial spec review found blocking CLI VRAM validation, MCP schema parity,
+  Decimal precision, and docs table gaps; code-quality review found the
+  4301-digit string message edge. All findings were fixed with tests.
+  Final spec and code-quality re-reviews reported no remaining issues and
+  marked the branch ready to PR.
+- Full suite after all edits:
+  `PYTHONPATH=$PWD/src pytest tests -q`,
+  `349 passed, 11 skipped` before review fixes; `359 passed, 11 skipped` after
+  blocking CLI, MCP schema, exact decimal cap, and digit-limit cleanup; `360
+  passed, 11 skipped` after the final unit-suffixed decimal cap fix.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build`, passed on final post-review rerun with
+  the known Material/MkDocs notice and unlisted-plan warnings.
+- Pre-commit:
+  `pre-commit run --all-files`, passed on final post-review rerun after Black
+  reformatted `src/keep_gpu/utilities/humanized_input.py` in the first run.
+- Diff whitespace:
+  `git diff --check`, passed on final post-review rerun.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,7 +16,9 @@ IDs.
 Visible-count checks for explicit IDs still run after backend discovery because
 they depend on the current visible device count. Its omitted `vram_to_keep`
 default is the shared low-power public default, `1GiB`, matching the CLI and
-service APIs.
+service APIs. Public interval values must be finite positive seconds capped by
+the Python runtime wait limit, and public VRAM byte-equivalent values must be no
+more than 1 PiB.
 
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
 querying NVML; duplicate or ambiguous masks report unavailable utilization.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,9 +20,9 @@ These options apply when you run `keep-gpu` without subcommands.
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `--interval INTEGER` | seconds | Finite positive sleep duration between utilization checks and keep-alive batches. |
+| `--interval INTEGER` | seconds | Finite positive sleep duration between utilization checks and keep-alive batches; values above the Python runtime wait limit are rejected. |
 | `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to use all visible GPUs; startup fails if that resolves to none or if an explicit ordinal is out of range. |
-| `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`). |
+| `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`); byte-equivalent values above 1 PiB are rejected. |
 | `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | `0..100` backs off before allocation/compute when utilization is above this value or unavailable; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
 
@@ -48,8 +48,8 @@ daemon startup or RPC.
 | Option | Default | Description |
 | --- | --- | --- |
 | `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. |
-| `--vram` | `1GiB` | Per-GPU keep memory target. |
-| `--interval` | `300` | Finite positive keep cycle interval in seconds. |
+| `--vram` | `1GiB` | Per-GPU keep memory target; byte-equivalent values above 1 PiB are rejected. |
+| `--interval` | `300` | Finite positive keep cycle interval in seconds, capped by the Python runtime wait limit. |
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact. |
@@ -118,7 +118,7 @@ return `500` instead of dropping the connection.
 | `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unsupported fields are `null`). |
 | `/api/sessions` | GET | Tracked keep sessions, including `state="starting"` during startup and `state`/`last_error` for in-progress or failed stops. |
 | `/api/sessions/{job_id}` | GET | One session status, including `state` and `last_error` when active or starting. |
-| `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive `interval`, `busy_threshold`, `job_id`); omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |
+| `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |
 | `/api/sessions` | DELETE | Stop all sessions; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/api/sessions/{job_id}` | DELETE | Stop one session; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/rpc` | POST | JSON-RPC compatibility endpoint. |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -245,6 +245,14 @@ def _validate_cli_interval(interval: int) -> int:
         raise typer.BadParameter(str(exc)) from exc
 
 
+def _validate_cli_vram(vram: str) -> str:
+    try:
+        parse_vram_to_elements(vram)
+    except (TypeError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    return vram
+
+
 def _validate_cli_busy_threshold(busy_threshold: int) -> int:
     try:
         return validate_busy_threshold(busy_threshold)
@@ -507,14 +515,11 @@ def _run_blocking(
     legacy_threshold: Optional[str],
     busy_threshold: int,
 ) -> None:
-    import torch
-
-    from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
-
     vram, busy_threshold, legacy_mode = _apply_legacy_threshold(
         vram, legacy_threshold, busy_threshold
     )
     interval = _validate_cli_interval(interval)
+    vram = _validate_cli_vram(vram)
     if legacy_mode == "vram":
         console.print(
             "[yellow]`--threshold` for VRAM is deprecated; use `--vram`.[/yellow]"
@@ -526,6 +531,11 @@ def _run_blocking(
     busy_threshold = _validate_cli_busy_threshold(busy_threshold)
 
     gpu_id_list = _parse_gpu_ids(gpu_ids)
+
+    import torch
+
+    from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+
     if gpu_id_list is not None:
         logger.info("Using specified visible GPU ordinals: %s", gpu_id_list)
         gpu_count = len(gpu_id_list)
@@ -665,10 +675,7 @@ def start(
         interval = _validate_cli_interval(interval)
         busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         parsed_gpu_ids = _parse_gpu_ids(gpu_ids)
-        try:
-            parse_vram_to_elements(vram)
-        except (TypeError, ValueError) as exc:
-            raise typer.BadParameter(str(exc)) from exc
+        _validate_cli_vram(vram)
         try:
             validate_job_id(job_id)
         except ValueError as exc:

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -43,11 +43,15 @@ from urllib.parse import unquote, urlparse
 
 from keep_gpu import __version__
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
-from keep_gpu.utilities.humanized_input import parse_vram_to_elements
+from keep_gpu.utilities.humanized_input import (
+    PUBLIC_VRAM_MAX_BYTES,
+    parse_vram_to_elements,
+)
 from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
+    PUBLIC_INTERVAL_MAX_SECONDS,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
@@ -80,13 +84,16 @@ MCP_TOOLS: List[Dict[str, Any]] = [
                     "description": "Visible GPU ordinals; null or omitted uses all.",
                 },
                 "vram": {
-                    "type": "string",
+                    "type": ["string", "integer"],
+                    "minimum": 4,
+                    "maximum": PUBLIC_VRAM_MAX_BYTES,
                     "default": "1GiB",
-                    "description": "Human-readable VRAM amount to keep.",
+                    "description": "Human-readable VRAM amount or integer bytes to keep; byte-equivalent values must be no more than 1 PiB.",
                 },
                 "interval": {
                     "type": "integer",
                     "minimum": 1,
+                    "maximum": PUBLIC_INTERVAL_MAX_SECONDS,
                     "default": 300,
                     "description": "Seconds between keep-alive checks.",
                 },
@@ -170,7 +177,7 @@ class SessionInputError(ValueError):
 def _validate_public_session_input(validator: Callable[..., Any], *args: Any) -> Any:
     try:
         return validator(*args)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise SessionInputError(str(exc)) from exc
 
 

--- a/src/keep_gpu/utilities/humanized_input.py
+++ b/src/keep_gpu/utilities/humanized_input.py
@@ -1,5 +1,11 @@
+import math
 import re
+from decimal import Decimal, InvalidOperation
 from typing import Union
+
+PUBLIC_VRAM_MAX_BYTES = 1 << 50
+_PUBLIC_VRAM_MAX_BYTES_TEXT = str(PUBLIC_VRAM_MAX_BYTES)
+_PUBLIC_VRAM_MAX_LABEL = "1 PiB"
 
 _UNITS = {
     "KB": 1000,
@@ -17,8 +23,44 @@ _UNITS = {
 }
 
 
-def _bytes_to_float32_elements(byte_count: float) -> int:
-    elements = int(byte_count / 4)
+def _vram_too_large_message() -> str:
+    return f"vram must be no more than {_PUBLIC_VRAM_MAX_LABEL}"
+
+
+def _parse_public_number(value: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except InvalidOperation as exc:
+        raise ValueError(f"invalid format: {value}, should be like '1000 MB'") from exc
+    except ValueError as exc:
+        raise ValueError(_vram_too_large_message()) from exc
+
+
+def _parse_public_byte_count(value: str) -> int:
+    normalized = value.lstrip("0") or "0"
+    if len(normalized) > len(_PUBLIC_VRAM_MAX_BYTES_TEXT) or (
+        len(normalized) == len(_PUBLIC_VRAM_MAX_BYTES_TEXT)
+        and normalized > _PUBLIC_VRAM_MAX_BYTES_TEXT
+    ):
+        raise ValueError(_vram_too_large_message())
+    return int(normalized)
+
+
+def _unit_factor(unit: str) -> Decimal:
+    return Decimal(str(_UNITS[unit]))
+
+
+def _bytes_to_float32_elements(byte_count: Union[int, float, Decimal]) -> int:
+    if isinstance(byte_count, float) and not math.isfinite(byte_count):
+        raise ValueError(_vram_too_large_message())
+    if byte_count > PUBLIC_VRAM_MAX_BYTES:
+        raise ValueError(_vram_too_large_message())
+    if isinstance(byte_count, int):
+        elements = byte_count // 4
+    elif isinstance(byte_count, Decimal):
+        elements = int(byte_count // Decimal(4))
+    else:
+        elements = int(byte_count / 4)
     if elements <= 0:
         raise ValueError("memory size must be at least 4 bytes")
     return elements
@@ -38,14 +80,20 @@ def parse_size(text: str) -> int:
         raise ValueError(f"invalid format: {text}, should be like '1000 MB'")
     value, unit = m.groups()
     if not unit:
-        return _bytes_to_float32_elements(float(value))
+        if value.isdigit():
+            return _bytes_to_float32_elements(_parse_public_byte_count(value))
+        return _bytes_to_float32_elements(_parse_public_number(value))
     if len(unit) > 1:
         # Treat all-lowercase units as byte units ("gb" -> "GB", "gib" -> "GIB")
         # while preserving explicit mixed-case bit forms ("Gb", "GIb").
         unit = unit.upper() if unit.islower() else unit[:-1].upper() + unit[-1]
     if unit not in _UNITS:
         raise ValueError(f"unknown unit: {unit}, should be one of {_UNITS.keys()}")
-    return _bytes_to_float32_elements(float(value) * _UNITS[unit])
+    number = _parse_public_number(value)
+    factor = _unit_factor(unit)
+    if number > Decimal(PUBLIC_VRAM_MAX_BYTES) / factor:
+        raise ValueError(_vram_too_large_message())
+    return _bytes_to_float32_elements(number * factor)
 
 
 def parse_vram_to_elements(value: Union[int, str]) -> int:
@@ -53,5 +101,5 @@ def parse_vram_to_elements(value: Union[int, str]) -> int:
     if isinstance(value, str):
         return parse_size(value)
     if isinstance(value, int) and not isinstance(value, bool):
-        return _bytes_to_float32_elements(float(value))
+        return _bytes_to_float32_elements(value)
     raise TypeError(f"vram_to_keep must be str or int bytes, got {type(value)}")

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -1,9 +1,11 @@
 import math
 import re
+import threading
 from typing import Any, List, Optional, Union
 
 _JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9._~-]+$")
 DEFAULT_BUSY_THRESHOLD = 25
+PUBLIC_INTERVAL_MAX_SECONDS = int(threading.TIMEOUT_MAX)
 
 
 def _is_plain_int(value: Any) -> bool:
@@ -33,10 +35,16 @@ def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
 
 def validate_interval(interval: Any) -> Union[int, float]:
     """Validate public interval input in seconds."""
-    if not _is_plain_number(interval) or not math.isfinite(interval):
+    if not _is_plain_number(interval):
+        raise ValueError("interval must be finite and positive")
+    if isinstance(interval, float) and not math.isfinite(interval):
         raise ValueError("interval must be finite and positive")
     if interval <= 0:
         raise ValueError("interval must be positive")
+    if interval > PUBLIC_INTERVAL_MAX_SECONDS:
+        raise ValueError(
+            f"interval must be no more than {PUBLIC_INTERVAL_MAX_SECONDS} seconds"
+        )
     return interval
 
 

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -80,6 +80,7 @@ def test_global_controller_rejects_empty_gpu_ids(monkeypatch):
         ({"gpu_ids": [-1]}, "gpu_ids must contain non-negative integers"),
         ({"interval": 0}, "interval must be positive"),
         ({"interval": math.nan}, "interval must be finite and positive"),
+        ({"interval": 10**1000}, "interval must be no more than"),
         (
             {"busy_threshold": -2},
             "busy_threshold must be -1 or an integer between 0 and 100",
@@ -91,6 +92,7 @@ def test_global_controller_rejects_empty_gpu_ids(monkeypatch):
         ({"vram_to_keep": []}, "vram_to_keep must be str or int bytes"),
         ({"vram_to_keep": "not-a-size"}, "invalid format"),
         ({"vram_to_keep": 1}, "memory size must be at least 4 bytes"),
+        ({"vram_to_keep": 10**1000}, "vram must be no more than"),
     ],
 )
 def test_global_controller_validates_local_inputs_before_platform_probe(

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -390,6 +390,78 @@ def test_http_start_rejects_invalid_fields_before_listing_gpus(
     assert controllers == []
 
 
+@pytest.mark.parametrize(
+    ("request_payload", "message"),
+    [
+        (
+            {
+                "gpu_ids": [0],
+                "vram": "256MB",
+                "interval": 10**1000,
+                "busy_threshold": 5,
+            },
+            "interval must be no more than",
+        ),
+        (
+            {
+                "gpu_ids": [0],
+                "vram": 10**1000,
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+            "vram must be no more than",
+        ),
+        (
+            {
+                "gpu_ids": [0],
+                "vram": ("9" * 500) + "GiB",
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+            "vram must be no more than",
+        ),
+    ],
+)
+def test_http_start_rejects_oversized_numeric_inputs_before_listing_gpus(
+    request_payload, message
+):
+    controllers = []
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            controllers.append(self)
+            super().__init__(**kwargs)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+    list_calls = []
+
+    def fail_list_gpus():
+        list_calls.append(True)
+        raise AssertionError("list_gpus should not run for invalid input")
+
+    server.list_gpus = fail_list_gpus  # type: ignore[method-assign]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            request_payload,
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 400
+    assert message in payload["error"]["message"]
+    assert list_calls == []
+    assert controllers == []
+
+
 def test_http_start_rejects_duplicate_job_id_before_listing_gpus():
     controllers = []
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -16,6 +16,7 @@ from keep_gpu.mcp.server import (
     KeepGPUServer,
     _handle_request,
 )
+from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
 from keep_gpu.utilities import platform_manager as pm
 
 
@@ -261,6 +262,31 @@ def test_jsonrpc_rejects_nan_interval_without_creating_session():
     assert server.status()["active_jobs"] == []
 
 
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"gpu_ids": [0], "interval": 10**1000}, "interval must be no more than"),
+        ({"gpu_ids": [0], "vram": 10**1000}, "vram must be no more than"),
+        (
+            {"gpu_ids": [0], "vram": ("9" * 500) + "GiB"},
+            "vram must be no more than",
+        ),
+    ],
+)
+def test_jsonrpc_rejects_oversized_numeric_session_inputs_without_internal_error(
+    params, message
+):
+    server = make_server()
+    req = {"id": 1, "method": "start_keep", "params": params}
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert message in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
 def test_jsonrpc_rejects_busy_threshold_above_percent_range():
     server = make_server()
     req = {
@@ -499,6 +525,9 @@ def test_mcp_tools_list_exposes_keepgpu_actions():
     start_schema = tools["start_keep"]["inputSchema"]
     assert start_schema["type"] == "object"
     assert start_schema["properties"]["gpu_ids"]["items"]["type"] == "integer"
+    assert start_schema["properties"]["vram"]["type"] == ["string", "integer"]
+    assert start_schema["properties"]["vram"]["maximum"] == PUBLIC_VRAM_MAX_BYTES
+    assert "1 PiB" in start_schema["properties"]["vram"]["description"]
     assert start_schema["properties"]["busy_threshold"]["default"] == 25
     assert tools["status"]["inputSchema"]["properties"]["job_id"]["type"] == [
         "string",
@@ -527,6 +556,29 @@ def test_mcp_tools_call_routes_to_existing_status_method():
     assert payload["active"] is True
     assert payload["job_id"] == "mcp-job"
     assert payload["params"]["gpu_ids"] == [0]
+
+
+def test_mcp_tools_call_rejects_oversized_integer_vram_as_tool_error():
+    server = make_server()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "start_keep",
+            "arguments": {"gpu_ids": [0], "vram": 10**1000},
+        },
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 4
+    assert "result" in resp
+    result = resp["result"]
+    assert result["isError"] is True
+    assert "vram must be no more than" in result["content"][0]["text"]
+    assert server.status()["active_jobs"] == []
 
 
 def test_mcp_tools_call_unknown_tool_returns_protocol_error():

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -525,7 +525,7 @@ def test_mcp_tools_list_exposes_keepgpu_actions():
     start_schema = tools["start_keep"]["inputSchema"]
     assert start_schema["type"] == "object"
     assert start_schema["properties"]["gpu_ids"]["items"]["type"] == "integer"
-    assert start_schema["properties"]["vram"]["type"] == ["string", "integer"]
+    assert set(start_schema["properties"]["vram"]["type"]) == {"string", "integer"}
     assert start_schema["properties"]["vram"]["maximum"] == PUBLIC_VRAM_MAX_BYTES
     assert "1 PiB" in start_schema["properties"]["vram"]["description"]
     assert start_schema["properties"]["busy_threshold"]["default"] == 25

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -161,6 +161,8 @@ def test_start_command_rejects_busy_threshold_above_percent_range(monkeypatch):
     [
         (["--job-id", "bad/id"], "job_id must be a URL-path-safe non-empty string"),
         (["--vram", "not-a-size"], "invalid format"),
+        (["--vram", ("9" * 500) + "GiB"], "vram must be no more than"),
+        (["--interval", str(10**1000)], "interval must be no more than"),
     ],
 )
 def test_start_command_rejects_local_inputs_before_auto_start(
@@ -531,6 +533,22 @@ def test_blocking_mode_rejects_non_positive_interval(monkeypatch):
 
     assert result.exit_code == 1
     assert "interval must be positive" in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--vram", ("9" * 500) + "GiB"], "vram must be no more than"),
+        (["--vram", "not-a-size"], "invalid format"),
+        (["--threshold", ("9" * 500) + "GiB"], "vram must be no more than"),
+    ],
+)
+def test_blocking_mode_rejects_invalid_vram_without_raw_exception(args, message):
+    result = runner.invoke(cli.app, args)
+
+    assert result.exit_code == 1
+    assert result.exception is not None
+    assert message in result.output
 
 
 def test_blocking_mode_rejects_duplicate_gpu_ids():

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -547,7 +547,6 @@ def test_blocking_mode_rejects_invalid_vram_without_raw_exception(args, message)
     result = runner.invoke(cli.app, args)
 
     assert result.exit_code == 1
-    assert result.exception is not None
     assert message in result.output
 
 

--- a/tests/utilities/test_humanized_input.py
+++ b/tests/utilities/test_humanized_input.py
@@ -1,4 +1,10 @@
-from keep_gpu.utilities.humanized_input import parse_size, parse_vram_to_elements
+import pytest
+
+from keep_gpu.utilities.humanized_input import (
+    PUBLIC_VRAM_MAX_BYTES,
+    parse_size,
+    parse_vram_to_elements,
+)
 
 
 def test_parse_size_digit_only_string_means_bytes():
@@ -12,3 +18,45 @@ def test_parse_size_human_units_still_mean_bytes():
 
 def test_parse_vram_integer_means_bytes():
     assert parse_vram_to_elements(1_073_741_824) == 268_435_456
+
+
+def test_parse_vram_accepts_public_maximum_bytes():
+    assert parse_vram_to_elements(PUBLIC_VRAM_MAX_BYTES) == PUBLIC_VRAM_MAX_BYTES // 4
+    assert parse_size(str(PUBLIC_VRAM_MAX_BYTES)) == PUBLIC_VRAM_MAX_BYTES // 4
+
+
+def test_parse_vram_rejects_values_above_public_maximum():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_vram_to_elements(PUBLIC_VRAM_MAX_BYTES + 1)
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size(str(PUBLIC_VRAM_MAX_BYTES + 1))
+
+
+def test_parse_size_rejects_decimal_string_above_public_maximum():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size(f"{PUBLIC_VRAM_MAX_BYTES}.1")
+
+
+def test_parse_size_rejects_unit_decimal_string_above_public_maximum():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size("1048576.0000000000000000000000001GiB")
+
+
+def test_parse_vram_rejects_oversized_integer_without_overflow():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_vram_to_elements(10**1000)
+
+
+def test_parse_size_rejects_oversized_digit_only_string_without_overflow():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size("9" * 500)
+
+
+def test_parse_size_rejects_digit_string_above_python_int_limit_cleanly():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size("9" * 4301)
+
+
+def test_parse_size_rejects_oversized_human_unit_string_without_overflow():
+    with pytest.raises(ValueError, match="vram must be no more than"):
+        parse_size(("9" * 500) + "GiB")

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from keep_gpu.utilities import session_config
 from keep_gpu.utilities.session_config import (
+    PUBLIC_INTERVAL_MAX_SECONDS,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
@@ -26,6 +27,20 @@ def test_validate_interval_rejects_non_positive_values():
 def test_validate_interval_rejects_non_finite_values(value):
     with pytest.raises(ValueError, match="interval must be finite and positive"):
         validate_interval(value)
+
+
+def test_validate_interval_accepts_public_maximum_seconds():
+    assert validate_interval(PUBLIC_INTERVAL_MAX_SECONDS) == PUBLIC_INTERVAL_MAX_SECONDS
+
+
+def test_validate_interval_rejects_above_public_maximum_seconds():
+    with pytest.raises(ValueError, match="interval must be no more than"):
+        validate_interval(PUBLIC_INTERVAL_MAX_SECONDS + 1)
+
+
+def test_validate_interval_rejects_oversized_integer_without_overflow():
+    with pytest.raises(ValueError, match="interval must be no more than"):
+        validate_interval(10**1000)
 
 
 def test_validate_gpu_ids_rejects_empty_list():


### PR DESCRIPTION
## Summary
- Reject oversized public interval and VRAM values as validation errors instead of overflow/internal failures.
- Validate blocking CLI VRAM before torch import/probing, widen MCP vram schema to string or integer bytes, and keep REST/JSON-RPC/MCP/Python behavior aligned.
- Document the bounded public contract and add plan/test coverage for huge ints, digit strings, decimal caps, and service boundary behavior.

## Verification
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_humanized_input.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/test_cli_service_commands.py tests/global_controller/test_contract.py -q` -> 259 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 360 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with known Material/MkDocs and unlisted-plan warnings
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed

## Local Review
- Local spec review and code-quality re-review completed with no remaining issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer limits for public numeric inputs across the CLI, service API, and MCP interfaces.
  - `--interval` values now have an explicit maximum, and VRAM values are capped at 1 PiB equivalent.

- **Bug Fixes**
  - Oversized or invalid numeric inputs are now rejected with user-friendly validation errors instead of runtime overflow failures.
  - Validation is applied earlier in request handling, reducing the chance of partial session setup.

- **Documentation**
  - Updated guides and reference docs to reflect the new input limits and response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->