### PR TITLE
[cli] fix: reject conflicting stop targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
+- Destructive or broad stop surfaces must reject ambiguous inputs such as `--job-id` with `--all` before any RPC, stop-all fallback, or daemon stop side effect.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - REST session creation must validate cheap local fields (`vram`, `interval`,
   `busy_threshold`, `job_id`, duplicate custom `job_id`, and `gpu_ids` shape)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Flags that matter:
   - `keep-gpu start`: create keep session and return immediately.
   - `keep-gpu status`: inspect tracked sessions, including in-progress or failed releases.
   - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
+    The two stop targets are mutually exclusive; passing both returns a JSON
+    error before contacting the service.
   - `keep-gpu service-stop`: stop the ownership-verified auto-started local daemon.
   - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
     `id` is the visible ordinal accepted by `--gpu-ids`; optional

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -49,6 +49,10 @@ keep-gpu stop --job-id <job_id>
 keep-gpu stop --all
 ```
 
+Use exactly one stop target. `--job-id` and `--all` are mutually exclusive, and
+passing both returns a JSON error before contacting the service or running the
+stop-all fallback.
+
 ### Stop local daemon
 
 ```bash

--- a/docs/plans/stop-conflicting-flags.md
+++ b/docs/plans/stop-conflicting-flags.md
@@ -1,0 +1,44 @@
+# Stop Conflicting Flags Plan
+
+## Background
+
+`keep-gpu stop --job-id X --all` currently follows the stop-all path because
+the CLI checks `--all` before the single-session stop branch. That makes a typo
+dangerous: a command that names one job can release every tracked keep session.
+
+## Goal
+
+Reject ambiguous stop targets before any RPC, stop-all fallback, or daemon stop
+side effect.
+
+## Solution
+
+- Add a CLI regression test for `stop --job-id job-1 --all`.
+- In `src/keep_gpu/cli.py`, check for both `job_id is not None` and
+  `all_sessions` before the existing missing-target validation.
+- Return the same structured JSON error shape used by other service commands.
+- Document the mutual-exclusion rule in agent guidance and user CLI docs.
+
+## Tasks
+
+- [x] Add the RED regression test in `tests/test_cli_service_commands.py`.
+- [x] Confirm the test fails on the existing stop-all behavior.
+- [x] Implement the minimal early CLI validation guard.
+- [x] Update `AGENTS.md`, `README.md`, `docs/reference/cli.md`, and
+      `docs/guides/cli.md`.
+- [x] Run targeted verification and record the results.
+
+## Validation
+
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_rejects_job_id_with_all_before_rpc -q`
+  failed with `assert 0 == 1`, confirming the command still took the stop-all
+  path.
+- GREEN focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_rejects_job_id_with_all_before_rpc -q`
+  passed with `1 passed in 0.15s`.
+- CLI service-command shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+  passed with `61 passed in 1.07s`.
+- Diff hygiene:
+  `git diff --check` passed with no output.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -75,6 +75,8 @@ envelopes are reported as JSON error objects instead of empty success results.
 | `--all` | Stop all sessions. |
 | `--host`, `--port` | Service host/port. |
 
+`--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
+error before any RPC or stop-all fallback runs.
 Stop waits for in-progress starts to settle before returning `not found` or
 taking the stop-all snapshot, so starting sessions are not silently skipped.
 For `--all`, starts that begin after that command's initial snapshot are not

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -748,6 +748,8 @@ def stop(
 ):
     """Stop one session or all sessions."""
     try:
+        if job_id is not None and all_sessions:
+            raise RuntimeError("Use either --job-id or --all, not both.")
         if job_id is None and not all_sessions:
             raise RuntimeError("Provide --job-id or use --all.")
         if all_sessions:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -196,6 +196,29 @@ def test_stop_requires_job_id_or_all():
     assert payload["error"] == "Provide --job-id or use --all."
 
 
+def test_stop_rejects_job_id_with_all_before_rpc(monkeypatch):
+    called = {"rpc": False, "stop_all": False}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        called["rpc"] = True
+        return {"stopped": ["job-1"], "timed_out": [], "failed": [], "errors": {}}
+
+    def fake_stop_all(host, port):
+        called["stop_all"] = True
+        return {"stopped": ["job-1"], "timed_out": [], "failed": [], "errors": {}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_all_sessions_with_fallback", fake_stop_all)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1", "--all"])
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert "Use either --job-id or --all" in payload["error"]
+    assert called["rpc"] is False
+    assert called["stop_all"] is False
+
+
 def test_status_forwards_explicit_empty_job_id_to_service(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- Reject `keep-gpu stop --job-id <id> --all` before RPC or stop-all fallback.
- Add regression coverage proving the ambiguous stop command returns a structured JSON error and has no stop side effects.
- Update AGENTS, README, CLI guide/reference docs, and add the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_rejects_job_id_with_all_before_rpc -q`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check`

## Local Review
- Local subagent review completed. One finding: plan file was untracked. Fixed by staging and committing `docs/plans/stop-conflicting-flags.md`.
