### PR TITLE
[controllers,docs] fix: align single-gpu VRAM default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ This file defines how coding agents should work in this repository.
   handler exceptions drop the HTTP connection.
 - Public `interval` values must be finite positive seconds capped by the Python runtime wait limit; reject `NaN`, `Infinity`, and oversized values before creating or mutating session state so keep loops cannot spin, crash, or wedge.
 - Keep human VRAM parsing centralized in `src/keep_gpu/utilities/humanized_input.py`; public integer values and digit-only strings mean bytes, public VRAM byte-equivalent values must be no more than 1 PiB, and controllers may convert valid inputs to internal tensor element counts.
-- Keep omitted public VRAM defaults aligned and low-power: CLI, Python global controller, service, REST, JSON-RPC, and MCP should default to `1GiB` per GPU unless a user explicitly asks for a different reservation.
+- Keep omitted public VRAM defaults aligned and low-power: CLI, Python global controller, Python single-GPU controllers, service, REST, JSON-RPC, and MCP should default to `1GiB` per GPU unless a user explicitly asks for a different reservation.
 - `GlobalGPUController` must validate local constructor inputs (`gpu_ids`,
   `interval`, `busy_threshold`, `vram_to_keep`) before calling
   `get_platform()` or other hardware/backend probes. Visible-count checks for

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -29,6 +29,9 @@ train_model()                     # GPU memory is released automatically
   background thread, capped by the Python runtime wait limit.
 - `vram_to_keep` accepts integer bytes or human-readable strings (`parse_size`
   handles it). Byte-equivalent values above 1 PiB are rejected.
+- When omitted, direct `CudaGPUController`, `RocmGPUController`, and
+  `MacMGPUController` constructors default `vram_to_keep` to the shared
+  low-power public default, `1GiB`.
 - Platform-specific keep workload iteration counts must be positive integers.
   CUDA uses `relu_iterations`; ROCm and Mac M use `iterations`. Rejecting
   non-integer and non-positive values prevents a keep session from starting

--- a/docs/plans/single-gpu-default-1gib.md
+++ b/docs/plans/single-gpu-default-1gib.md
@@ -1,0 +1,37 @@
+# Single-GPU Default 1GiB Plan
+
+## Background
+
+KeepGPU documents omitted public VRAM settings as the low-power `1GiB` default,
+and `GlobalGPUController` already follows that contract. Direct Python
+single-GPU controllers still defaulted `vram_to_keep` to `"1000 MB"`, creating a
+small but visible mismatch for users who instantiate CUDA, ROCm, or Mac M
+controllers directly.
+
+## Goal
+
+Make omitted VRAM defaults consistent across `GlobalGPUController`,
+`CudaGPUController`, `RocmGPUController`, and `MacMGPUController`.
+
+## Solution
+
+- Extend the Python controller contract test to inspect all four constructor
+  signatures for `vram_to_keep="1GiB"`.
+- Change only the direct single-GPU controller defaults from `"1000 MB"` to
+  `"1GiB"`.
+- Document that direct single-GPU Python controllers share the same low-power
+  omitted VRAM default.
+
+## Tasks
+
+- [x] Add the failing default-contract test.
+- [x] Verify the new test fails on current CUDA, ROCm, and Mac M defaults.
+- [x] Update the three direct single-GPU controller defaults.
+- [x] Update `AGENTS.md`, API reference, and Python guide wording.
+- [x] Run targeted verification and `git diff --check`.
+
+## Validation
+
+- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_python_controller_default_vram_matches_public_low_power_default -q`
+- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py tests/single_gpu_controller -q`
+- `git diff --check`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,8 +16,10 @@ IDs.
 Visible-count checks for explicit IDs still run after backend discovery because
 they depend on the current visible device count. Its omitted `vram_to_keep`
 default is the shared low-power public default, `1GiB`, matching the CLI and
-service APIs. Public interval values must be finite positive seconds capped by
-the Python runtime wait limit, and public VRAM byte-equivalent values must be no
+service APIs. Direct `CudaGPUController`, `RocmGPUController`, and
+`MacMGPUController` constructors use the same omitted `vram_to_keep="1GiB"`
+default. Public interval values must be finite positive seconds capped by the
+Python runtime wait limit, and public VRAM byte-equivalent values must be no
 more than 1 PiB.
 
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
@@ -27,11 +29,12 @@ matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying
 ROCm SMI. Unresolved mappings report unavailable utilization instead of falling
 back to a possibly wrong physical device.
 
-Public controller, CLI, REST, JSON-RPC, and MCP defaults use `vram_to_keep`/`vram`
-`1GiB` and `busy_threshold=25`, so omitted settings reserve a modest VRAM signal
-and busy or unavailable telemetry sleeps before allocating keep tensors or
-running compute. Pass `busy_threshold=-1` only when you intentionally want
-unconditional keepalive compute without utilization backoff.
+Public Python controller, CLI, REST, JSON-RPC, and MCP defaults use
+`vram_to_keep`/`vram` `1GiB` and `busy_threshold=25`, so omitted settings
+reserve a modest VRAM signal and busy or unavailable telemetry sleeps before
+allocating keep tensors or running compute. Pass `busy_threshold=-1` only when
+you intentionally want unconditional keepalive compute without utilization
+backoff.
 
 CUDA and ROCm `keep()` calls wait for fatal backend startup setup to succeed
 before reporting success. Startup failures such as device-selection errors are

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -49,7 +49,7 @@ class CudaGPUController(BaseGPUController):
         interval: float = 1.0,
         relu_iterations: int = 5000,
         matmul_iterations: Optional[int] = None,
-        vram_to_keep: str | int = "1000 MB",
+        vram_to_keep: str | int = "1GiB",
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
     ):
         """
@@ -62,7 +62,7 @@ class CudaGPUController(BaseGPUController):
             matmul_iterations (int, optional): Legacy alias for
                 `relu_iterations`. When set, it overrides `relu_iterations`.
             vram_to_keep (int or str, optional): Amount of VRAM to keep busy,
-                e.g. `"1000 MB"`, `"20 GB"`, or an integer like `1000 * 1000`.
+                e.g. `"1GiB"`, `"20 GB"`, or an integer like `1000 * 1000`.
                 This represents the total size of the matrix allocated to
                 occupy the GPU.
             busy_threshold (int, optional): Defaults to 25. If current

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -23,7 +23,7 @@ class MacMGPUController(BaseGPUController):
         *,
         rank: int = 0,
         interval: float = 1.0,
-        vram_to_keep: str | int = "1000 MB",
+        vram_to_keep: str | int = "1GiB",
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
         iterations: int = 5000,
     ):

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -27,7 +27,7 @@ class RocmGPUController(BaseGPUController):
         *,
         rank: int,
         interval: float = 1.0,
-        vram_to_keep: str | int = "1000 MB",
+        vram_to_keep: str | int = "1GiB",
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
         iterations: int = 5000,
         max_allocation_retries: Optional[int] = None,

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -23,8 +23,17 @@ def test_python_controller_defaults_use_eco_safe_busy_threshold():
         assert inspect.signature(controller).parameters["busy_threshold"].default == 25
 
 
-def test_global_controller_default_vram_matches_public_low_power_default():
-    default = inspect.signature(GlobalGPUController).parameters["vram_to_keep"].default
+@pytest.mark.parametrize(
+    "controller",
+    [
+        GlobalGPUController,
+        CudaGPUController,
+        RocmGPUController,
+        MacMGPUController,
+    ],
+)
+def test_python_controller_default_vram_matches_public_low_power_default(controller):
+    default = inspect.signature(controller).parameters["vram_to_keep"].default
     assert default == "1GiB"
 
 


### PR DESCRIPTION
## Summary
- Align direct CUDA, ROCm, and Mac M controller `vram_to_keep` defaults with the shared public `1GiB` default.
- Extend the Python controller contract test across global and single-GPU controllers.
- Update AGENTS, Python/API docs, and add the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_python_controller_default_vram_matches_public_low_power_default -q`
- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py tests/single_gpu_controller -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check`

## Local Review
- Local subagent review completed. One finding: plan file was untracked. Fixed by staging and committing `docs/plans/single-gpu-default-1gib.md`.
