### PR TITLE
[cli] fix: reject empty GPU ID selections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
+- For CLI `--gpu-ids`, only omission means all visible GPUs; explicit empty or
+  whitespace-only values are invalid and must not silently expand to all GPUs.
 - Destructive or broad stop surfaces must reject ambiguous inputs such as `--job-id` with `--all` before any RPC, stop-all fallback, or daemon stop side effect.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - REST session creation must validate cheap local fields (`vram`, `interval`,

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Flags that matter:
   - `--interval` (finite positive seconds): sleep between keep-alive bursts.
     Values above the Python runtime wait limit are rejected.
   - `--busy-threshold`: defaults to `25`; `0..100` skips work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
-  - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm); otherwise all visible GPUs are guarded. Empty, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
+  - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm). Omit the option to guard all visible GPUs. Empty, whitespace-only, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
 - Service mode commands:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
   - `keep-gpu start`: create keep session and return immediately.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -31,6 +31,8 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
 fail without creating daemon runtime files or issuing RPC.
+Omit `--gpu-ids` to use all visible GPUs; an explicit empty or whitespace-only
+value is invalid.
 `--interval` must be finite, positive, and within the Python runtime wait
 limit. `--vram` keeps integer and digit-only values as bytes, accepts human
 units, and rejects byte-equivalent requests above 1 PiB.
@@ -104,7 +106,7 @@ The dashboard provides:
 
 | Option | Meaning | Default |
 | --- | --- | --- |
-| `--gpu-ids` | Comma-separated unique non-negative visible device ordinals. Omit to use all visible devices; startup fails if that resolves to none or if an explicit ordinal is out of range. | all |
+| `--gpu-ids` | Comma-separated unique non-negative visible device ordinals. Omit to use all visible devices; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. | all |
 | `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes), capped at 1 PiB byte-equivalent. | `1GiB` |
 | `--interval` | Finite positive seconds between keep-alive cycles, capped by the Python runtime wait limit. | `300` |
 | `--busy-threshold` / `--util-threshold` | `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
@@ -124,7 +126,7 @@ of `keep-gpu status`.
 
 ## Troubleshooting
 
-- **`--gpu-ids` parse error**: use only comma-separated visible ordinals (`0,1`).
+- **`--gpu-ids` parse error**: use only comma-separated visible ordinals (`0,1`). Omit the option to use all visible GPUs; do not pass an empty string.
 - **Unexpected GPU selection**: set `CUDA_VISIBLE_DEVICES` before starting
   KeepGPU on CUDA, or `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES` before
   starting KeepGPU on ROCm, then pass visible ordinals by way of `--gpu-ids`.

--- a/docs/plans/reject-empty-cli-gpu-ids.md
+++ b/docs/plans/reject-empty-cli-gpu-ids.md
@@ -1,0 +1,31 @@
+# Reject Empty CLI GPU IDs Plan
+
+## Root Cause
+
+`src/keep_gpu/cli.py` treats any falsy `gpu_ids` value as omitted. That makes an explicit empty CLI value such as `--gpu-ids ""` resolve to `None`, which means all visible GPUs.
+
+## Goal
+
+Keep omitted `--gpu-ids` as "all visible GPUs", but reject explicit empty or whitespace-only values before service auto-start/RPC or blocking controller creation.
+
+## Scope
+
+- Update CLI parsing in `src/keep_gpu/cli.py`.
+- Add CLI regression tests for service and blocking mode.
+- Document the public contract in CLI docs, README, and `AGENTS.md`.
+
+## Tasks
+
+- [x] Add failing tests for `keep-gpu start --gpu-ids ""` and whitespace-only values rejecting before service startup/RPC.
+- [x] Add a failing blocking-mode test for `keep-gpu --gpu-ids ""` rejecting before `_run_blocking`.
+- [x] Add or update direct `_parse_gpu_ids` coverage for omitted versus explicit empty values.
+- [x] Implement the minimal parser change that distinguishes `None` from explicit empty/whitespace strings.
+- [x] Update user-facing docs and repository guidance.
+- [x] Run targeted tests and `git diff --check`.
+- [x] Commit with `fix(cli): reject empty gpu id selections`.
+
+## Verification Checklist
+
+- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` failed for the new empty-selection tests before implementation.
+- [x] GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed after implementation.
+- [x] `git diff --check` passes.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@ These options apply when you run `keep-gpu` without subcommands.
 | Option | Type | Description |
 | --- | --- | --- |
 | `--interval INTEGER` | seconds | Finite positive sleep duration between utilization checks and keep-alive batches; values above the Python runtime wait limit are rejected. |
-| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to use all visible GPUs; startup fails if that resolves to none or if an explicit ordinal is out of range. |
+| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to use all visible GPUs; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. |
 | `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`); byte-equivalent values above 1 PiB are rejected. |
 | `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | `0..100` backs off before allocation/compute when utilization is above this value or unavailable; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
@@ -43,11 +43,12 @@ Starts a keep session and returns immediately with `job_id`.
 
 Local input validation runs before service auto-start. Invalid `--vram`,
 `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values fail before
-daemon startup or RPC.
+daemon startup or RPC. Omit `--gpu-ids` to use all visible GPUs; explicit empty
+or whitespace-only values are invalid.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. |
+| `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. Omit for all visible GPUs; empty or whitespace-only values are invalid. |
 | `--vram` | `1GiB` | Per-GPU keep memory target; byte-equivalent values above 1 PiB are rejected. |
 | `--interval` | `300` | Finite positive keep cycle interval in seconds, capped by the Python runtime wait limit. |
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -223,8 +223,12 @@ def _apply_legacy_threshold(
 
 
 def _parse_gpu_ids(gpu_ids: Optional[str]) -> Optional[List[int]]:
-    if not gpu_ids:
+    if gpu_ids is None:
         return None
+    if gpu_ids.strip() == "":
+        raise typer.BadParameter(
+            "gpu_ids must not be empty; omit --gpu-ids to use all visible GPUs"
+        )
     try:
         parsed = [int(i.strip()) for i in gpu_ids.split(",")]
     except ValueError as exc:
@@ -602,6 +606,7 @@ def main(
         return
     try:
         interval = _validate_cli_interval(interval)
+        _parse_gpu_ids(gpu_ids)
         _run_blocking(interval, gpu_ids, vram, legacy_threshold, busy_threshold)
     except typer.BadParameter as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -118,6 +118,29 @@ def test_start_command_rejects_negative_gpu_ids(monkeypatch):
     assert "non-negative integers" in result.output
 
 
+@pytest.mark.parametrize("gpu_ids", ["", "   "])
+def test_start_command_rejects_empty_gpu_ids_before_auto_start(monkeypatch, gpu_ids):
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be started")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("RPC should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["start", "--gpu-ids", gpu_ids])
+
+    assert result.exit_code == 1
+    assert "gpu_ids must not be empty" in result.output
+
+
 def test_start_command_rejects_non_positive_interval(monkeypatch):
     monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: None)
     monkeypatch.setattr(

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -2,8 +2,21 @@ import os
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
 from keep_gpu import cli
+
+runner = CliRunner()
+
+
+def test_parse_gpu_ids_treats_omitted_as_all_visible():
+    assert cli._parse_gpu_ids(None) is None
+
+
+@pytest.mark.parametrize("gpu_ids", ["", "   "])
+def test_parse_gpu_ids_rejects_empty_values(gpu_ids):
+    with pytest.raises(typer.BadParameter, match="gpu_ids must not be empty"):
+        cli._parse_gpu_ids(gpu_ids)
 
 
 def test_parse_gpu_ids_rejects_negative_values():
@@ -48,6 +61,21 @@ def test_validate_cli_busy_threshold_rejects_legacy_value_above_percent_range():
         match="busy_threshold must be -1 or an integer between 0 and 100",
     ):
         cli._validate_cli_busy_threshold(threshold)
+
+
+def test_blocking_command_rejects_empty_gpu_ids_before_run_blocking(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_run_blocking",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("blocking mode should not start")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["--gpu-ids", ""])
+
+    assert result.exit_code == 1
+    assert "gpu_ids must not be empty" in result.output
 
 
 def test_run_blocking_preserves_cuda_visible_devices_for_gpu_ids(monkeypatch):


### PR DESCRIPTION
## Summary
- Reject explicit empty or whitespace-only CLI `--gpu-ids` values instead of treating them as omitted/all-visible.
- Preserve omitted `--gpu-ids` as the all-visible default for both blocking mode and service `start`.
- Update CLI docs, README, AGENTS.md, and the implementation plan for the public contract.

## Test Plan
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
- [x] `PYTHONPATH=$PWD/src pytest tests -q`
- [x] `PYTHONPATH=$PWD/src mkdocs build`
- [x] `pre-commit run --all-files`
- [x] `git diff --check origin/main...HEAD`

## Local Review
- [x] Local subagent review completed with no must-fix findings.
