### PR TITLE
[cli] fix: validate status and stop job ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
+- `keep-gpu status --job-id` and `keep-gpu stop --job-id` must validate
+  explicit custom IDs locally before service RPC, stop-all fallback, or daemon
+  side effects. Only omitting the option means all-session status or no stop
+  target was chosen.
 - For CLI `--gpu-ids`, only omission means all visible GPUs; explicit empty or
   whitespace-only values are invalid and must not silently expand to all GPUs.
 - Destructive or broad stop surfaces must reject ambiguous inputs such as `--job-id` with `--all` before any RPC, stop-all fallback, or daemon stop side effect.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Flags that matter:
   - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
     The two stop targets are mutually exclusive; passing both returns a JSON
     error before contacting the service.
+    Explicit `--job-id` values for `status` and `stop` must be non-empty
+    URL-path-safe IDs; invalid values return JSON errors before any RPC or
+    stop-all fallback.
   - `keep-gpu service-stop`: stop the ownership-verified auto-started local daemon.
   - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
     `id` is the visible ordinal accepted by `--gpu-ids`; optional

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -44,6 +44,10 @@ keep-gpu status
 keep-gpu status --job-id <job_id>
 ```
 
+Explicit `--job-id` values use the shared session-id rules: non-empty strings
+containing only letters, digits, `.`, `_`, `-`, or `~`. Invalid IDs return a
+JSON error before contacting the service.
+
 ### Stop sessions
 
 ```bash
@@ -54,6 +58,8 @@ keep-gpu stop --all
 Use exactly one stop target. `--job-id` and `--all` are mutually exclusive, and
 passing both returns a JSON error before contacting the service or running the
 stop-all fallback.
+Explicit `--job-id` values use the same non-empty URL-path-safe validation as
+`status`; invalid IDs return a JSON error before any RPC or stop-all fallback.
 
 ### Stop local daemon
 

--- a/docs/plans/cli-status-stop-job-id-validation.md
+++ b/docs/plans/cli-status-stop-job-id-validation.md
@@ -1,0 +1,64 @@
+# CLI Status/Stop Job ID Validation Plan
+
+## Background
+
+`keep-gpu start` already validates custom `--job-id` values locally, but
+`keep-gpu status --job-id` and `keep-gpu stop --job-id` passed explicit values
+directly into the JSON-RPC service client. Empty, whitespace-only, or
+non-URL-path-safe values therefore crossed the service boundary and could
+produce service errors after unnecessary RPC attempts.
+
+## Goal
+
+Use the shared public `job_id` validator for CLI `status` and `stop` before any
+service RPC, stop-all fallback, or daemon side effect. Omitted `--job-id`
+continues to mean all-session status for `status`, and `stop` still requires
+either `--job-id` or `--all`.
+
+## Solution
+
+- Add RED CLI tests proving invalid explicit `--job-id` values for `status` and
+  `stop` do not call `_rpc_call()` or `_stop_all_sessions_with_fallback()`.
+- Add one CLI helper around `session_config.validate_job_id()` and reuse it from
+  `start`, `status`, and `stop`.
+- Keep service-command failures as structured JSON error objects.
+- Update CLI documentation and `AGENTS.md` with the local validation contract.
+
+## Tasks
+
+- [x] Add RED CLI regression tests for invalid `status`/`stop --job-id` values.
+- [x] Implement shared CLI job-id validation before service calls.
+- [x] Update `AGENTS.md`, README, CLI guide, reference docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, and pre-commit.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- Baseline before edits:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with `74 passed`.
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_job_id_before'`
+  failed with six cases because the commands still reached the monkeypatched RPC
+  path instead of emitting a local JSON validation error.
+- GREEN focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_job_id_before'`
+  passed with `6 passed, 61 deselected`.
+- Review follow-up:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_job_id_before or status_job_outputs'`
+  passed with `7 passed, 61 deselected` after adding valid `status --job-id`
+  forwarding coverage.
+- GREEN CLI service-command file:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed
+  with `68 passed`.
+- GREEN CLI service-command shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with `78 passed`.
+- Full branch gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `386 passed, 11 skipped`;
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's existing
+  Material warning and unnav'd plan notices; `pre-commit run --all-files`
+  passed; and `git diff --check` passed.
+- Local subagent code review: passed with no critical or important findings.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,7 +61,7 @@ or whitespace-only values are invalid.
 
 | Option | Description |
 | --- | --- |
-| `--job-id` | Optional session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. |
+| `--job-id` | Optional non-empty URL-path-safe session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. Invalid explicit IDs are rejected locally before RPC. |
 | `--host`, `--port` | Service host/port. |
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
@@ -76,7 +76,7 @@ runtime failure.
 
 | Option | Description |
 | --- | --- |
-| `--job-id` | Stop one session. |
+| `--job-id` | Stop one non-empty URL-path-safe session id. Invalid explicit IDs are rejected locally before RPC or stop-all fallback. |
 | `--all` | Stop all sessions. |
 | `--host`, `--port` | Service host/port. |
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -264,6 +264,13 @@ def _validate_cli_busy_threshold(busy_threshold: int) -> int:
         raise typer.BadParameter(str(exc)) from exc
 
 
+def _validate_cli_job_id(job_id: Optional[str]) -> Optional[str]:
+    try:
+        return validate_job_id(job_id)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
 def _service_base_url(host: str, port: int) -> str:
     return f"http://{host}:{port}"
 
@@ -681,10 +688,7 @@ def start(
         busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         parsed_gpu_ids = _parse_gpu_ids(gpu_ids)
         _validate_cli_vram(vram)
-        try:
-            validate_job_id(job_id)
-        except ValueError as exc:
-            raise typer.BadParameter(str(exc)) from exc
+        job_id = _validate_cli_job_id(job_id)
         auto_started = _ensure_service_running(host, port, auto_start=auto_start)
         result = _rpc_call(
             "start_keep",
@@ -725,6 +729,7 @@ def status(
 ):
     """Show session status from KeepGPU local service."""
     try:
+        job_id = _validate_cli_job_id(job_id)
         result = _rpc_call(
             "status",
             {} if job_id is None else {"job_id": job_id},
@@ -732,7 +737,7 @@ def status(
             port,
         )
         console.print_json(data=result)
-    except RuntimeError as exc:
+    except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
@@ -757,6 +762,7 @@ def stop(
             raise RuntimeError("Use either --job-id or --all, not both.")
         if job_id is None and not all_sessions:
             raise RuntimeError("Provide --job-id or use --all.")
+        job_id = _validate_cli_job_id(job_id)
         if all_sessions:
             result = _stop_all_sessions_with_fallback(host, port)
         else:
@@ -768,7 +774,7 @@ def stop(
                 timeout=45.0,
             )
         console.print_json(data=result)
-    except RuntimeError as exc:
+    except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -242,43 +242,36 @@ def test_stop_rejects_job_id_with_all_before_rpc(monkeypatch):
     assert called["stop_all"] is False
 
 
-def test_status_forwards_explicit_empty_job_id_to_service(monkeypatch):
-    called = {}
-
-    def fake_rpc(method, params, host, port):
-        called["rpc"] = (method, params, host, port)
-        raise RuntimeError("job_id must be a URL-path-safe non-empty string")
+@pytest.mark.parametrize("job_id", ["", "   ", "bad/id"])
+def test_status_rejects_invalid_job_id_before_rpc(monkeypatch, job_id):
+    def fake_rpc(*args, **kwargs):
+        raise AssertionError("RPC should not be called")
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
 
-    result = runner.invoke(cli.app, ["status", "--job-id", ""])
+    result = runner.invoke(cli.app, ["status", "--job-id", job_id])
 
     assert result.exit_code == 1
     payload = _single_decoded_json_object(result.output)
     assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
-    method, params, _host, _port = called["rpc"]
-    assert method == "status"
-    assert params == {"job_id": ""}
 
 
-def test_stop_forwards_explicit_empty_job_id_to_service(monkeypatch):
-    called = {}
+@pytest.mark.parametrize("job_id", ["", "   ", "bad/id"])
+def test_stop_rejects_invalid_job_id_before_rpc_or_fallback(monkeypatch, job_id):
+    def fake_rpc(*args, **kwargs):
+        raise AssertionError("RPC should not be called")
 
-    def fake_rpc(method, params, host, port, timeout=8.0):
-        called["rpc"] = (method, params, host, port, timeout)
-        raise RuntimeError("job_id must be a URL-path-safe non-empty string")
+    def fake_stop_all(*args, **kwargs):
+        raise AssertionError("stop-all fallback should not be called")
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_all_sessions_with_fallback", fake_stop_all)
 
-    result = runner.invoke(cli.app, ["stop", "--job-id", ""])
+    result = runner.invoke(cli.app, ["stop", "--job-id", job_id])
 
     assert result.exit_code == 1
     payload = _single_decoded_json_object(result.output)
     assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
-    method, params, _host, _port, timeout = called["rpc"]
-    assert method == "stop_keep"
-    assert params == {"job_id": ""}
-    assert timeout == 45.0
 
 
 def test_status_outputs_single_decoded_json_object(monkeypatch):
@@ -295,6 +288,21 @@ def test_status_outputs_single_decoded_json_object(monkeypatch):
     payload = _single_decoded_json_object(result.output)
     assert payload["active"] is True
     assert payload["active_jobs"][0]["job_id"] == "job-1"
+
+
+def test_status_job_outputs_single_decoded_json_object(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {"job_id": "job-1"}
+        return {"active": True, "job": {"job_id": "job-1"}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", "job-1"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload["job"]["job_id"] == "job-1"
 
 
 def test_stop_job_outputs_single_decoded_json_object(monkeypatch):


### PR DESCRIPTION
## Summary
- Validate explicit `keep-gpu status --job-id` and `keep-gpu stop --job-id` values locally with the shared session-id contract.
- Keep omitted status as all-session status, preserve stop target errors, and reject invalid targeted stop IDs before RPC or stop-all fallback.
- Update AGENTS.md, README, CLI docs, and the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_job_id_before or status_job_outputs'` (`7 passed, 61 deselected`)
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` (`68 passed`)
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` (`78 passed`)
- `PYTHONPATH=$PWD/src pytest tests -q` (`386 passed, 11 skipped`)
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check`

## Review
- Local subagent code review passed with no critical or important findings.
