### PR TITLE
[cli] fix: validate service endpoint flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,11 @@ This file defines how coding agents should work in this repository.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
-- `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, and `--gpu-ids` before auto-starting the service daemon or making RPC calls.
+- CLI service endpoint inputs (`--host`, `--port`) must be validated locally
+  before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
+  operations. JSON-output commands must return structured `{"error": "..."}`
+  objects for invalid endpoints, not tracebacks.
+- `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
 - `keep-gpu status --job-id` and `keep-gpu stop --job-id` must validate
   explicit custom IDs locally before service RPC, stop-all fallback, or daemon
   side effects. Only omitting the option means all-session status or no stop

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Flags that matter:
 - Service mode commands:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
   - `keep-gpu start`: create keep session and return immediately.
+    Service endpoint flags are validated locally: `--host` must be a DNS
+    hostname or IPv4 address, and `--port` must be in `1..65535`.
   - `keep-gpu status`: inspect tracked sessions, including in-progress or failed releases.
   - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
     The two stop targets are mutually exclusive; passing both returns a JSON
@@ -95,8 +97,8 @@ Flags that matter:
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
     that tools such as `jq` can parse directly. Malformed JSON-RPC service
-    envelopes are reported as those JSON error objects instead of empty success
-    results.
+    envelopes and invalid service endpoints are reported as those JSON error
+    objects instead of empty success results or tracebacks.
 
 ## Embed in Python
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -30,7 +30,9 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 
 Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
-fail without creating daemon runtime files or issuing RPC.
+fail without creating daemon runtime files or issuing RPC. Service endpoint
+flags are validated the same way: `--host` must be a DNS hostname or IPv4
+address, and `--port` must be in `1..65535`.
 Omit `--gpu-ids` to use all visible GPUs; an explicit empty or whitespace-only
 value is invalid.
 `--interval` must be finite, positive, and within the Python runtime wait
@@ -82,7 +84,8 @@ The `id` field in this output is the visible ordinal to pass to `--gpu-ids`.
 `{"error": "..."}` for service/runtime errors after CLI parsing succeeds, that
 can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes are reported as JSON error objects instead
-of empty success results.
+of empty success results. Invalid service endpoints are also reported as JSON
+errors before any RPC or stop-all fallback runs.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/plans/cli-service-endpoint-validation.md
+++ b/docs/plans/cli-service-endpoint-validation.md
@@ -1,0 +1,90 @@
+# CLI Service Endpoint Validation Plan
+
+## Background
+
+Service-mode CLI commands build URLs directly from `--host` and `--port`.
+Malformed hosts such as `bad host` can leak lower-level URL tracebacks from
+JSON-output commands, and `keep-gpu start` can reach daemon auto-start logic
+before rejecting the endpoint. That violates the CLI contract that local bad
+inputs fail before service side effects and that JSON commands print parseable
+error objects.
+
+## Goal
+
+Reject invalid service endpoint flags locally before service RPC, daemon
+auto-start, stop-all fallback, or daemon ownership operations.
+
+## Solution
+
+- Add shared CLI service endpoint validation for `--host` and `--port`.
+- Apply it to `serve`, `start`, `status`, `stop`, `list-gpus`, and
+  `service-stop`.
+- Keep JSON-output commands (`status`, `stop`, `list-gpus`) returning a single
+  `{"error": "..."}` object for invalid endpoints.
+- Wrap lower-level malformed URL `InvalidURL`/`ValueError` failures as
+  `ServiceUnreachableError` as a defensive fallback.
+- Update docs and `AGENTS.md` with the no-side-effect endpoint contract.
+
+## Tasks
+
+- [x] Add RED CLI regression tests for invalid `--host` before RPC,
+      auto-start, or stop-all fallback.
+- [x] Implement shared service endpoint validation and command integration.
+- [x] Add explicit invalid-port regression coverage.
+- [x] Update `AGENTS.md`, README, CLI guide/reference, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and `git diff
+      --check`.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_host'`
+  failed with four cases because `start`, `status`, `stop --all`, and
+  `list-gpus` continued into service/RPC paths with `--host "bad host"`.
+- GREEN focused endpoint regressions:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'invalid_host or invalid_port'`
+  passed with `6 passed, 68 deselected`.
+- GREEN CLI service-command shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed
+  with `76 passed` after adding defensive malformed-URL and `service-stop`
+  endpoint coverage.
+- Live symptom check:
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli status --host 'bad host'` and
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli list-gpus --host 'bad host'`
+  returned parseable JSON error objects instead of tracebacks.
+- Broad verification before local review:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with `87 passed`; `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `415 passed, 11 skipped`; `PYTHONPATH=$PWD/src mkdocs build` passed with the
+  repository's existing Material warning and unnav'd plan notices; and
+  `pre-commit run --all-files` plus `git diff --check` passed.
+- Local review follow-up: reviewer found that the first host guard still
+  accepted malformed non-whitespace values such as `%` and `\host`. Tightened
+  validation to DNS hostnames or IPv4 addresses, added syntax-level host tests,
+  added a non-whitespace malformed-host command regression, documented the
+  `service-stop` endpoint safety contract, and reran
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'validate_cli_service_host or non_whitespace_malformed_host or invalid_host or invalid_port or service_stop'`
+  with `32 passed, 66 deselected` and
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` with
+  `98 passed`.
+- Final branch gate after local-review follow-up:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with `109 passed`; `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `437 passed, 11 skipped`; `PYTHONPATH=$PWD/src mkdocs build` passed with the
+  repository's existing Material warning and unnav'd plan notices; and
+  `pre-commit run --all-files` plus `git diff --check` passed.
+- Second local subagent review: passed with no critical, important, or minor
+  findings. Reviewer reran the endpoint shard with `32 passed, 66 deselected`,
+  confirmed malformed host/port live checks return single JSON error objects,
+  and confirmed `git diff --check`.
+- Gemini review follow-up: rejected numeric single-label hosts and numeric TLDs
+  such as `123` and `foo.123`, and changed invalid UTF-8 service bodies from a
+  misleading unreachable-service error to `ServiceResponseError`. The focused
+  review-fix shard passed with `35 passed, 66 deselected`. Final post-review
+  gates passed: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  with `112 passed`; `PYTHONPATH=$PWD/src pytest tests -q` with `440 passed,
+  11 skipped`; `PYTHONPATH=$PWD/src mkdocs build`; `pre-commit run
+  --all-files`; and `git diff --check`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,17 +34,17 @@ Starts local KeepGPU service (HTTP + JSON-RPC + dashboard).
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--host` | `127.0.0.1` | Service bind host. |
-| `--port` | `8765` | Service port. |
+| `--host` | `127.0.0.1` | Service bind host. Must be a DNS hostname or IPv4 address. |
+| `--port` | `8765` | Service port in `1..65535`. |
 
 ### `keep-gpu start`
 
 Starts a keep session and returns immediately with `job_id`.
 
 Local input validation runs before service auto-start. Invalid `--vram`,
-`--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values fail before
-daemon startup or RPC. Omit `--gpu-ids` to use all visible GPUs; explicit empty
-or whitespace-only values are invalid.
+`--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, or `--port`
+values fail before daemon startup or RPC. Omit `--gpu-ids` to use all visible
+GPUs; explicit empty or whitespace-only values are invalid.
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -53,8 +53,8 @@ or whitespace-only values are invalid.
 | `--interval` | `300` | Finite positive keep cycle interval in seconds, capped by the Python runtime wait limit. |
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
-| `--host` | `127.0.0.1` | Service host to contact. |
-| `--port` | `8765` | Service port to contact. |
+| `--host` | `127.0.0.1` | Service host to contact; invalid values are rejected before auto-start. |
+| `--port` | `8765` | Service port to contact; must be in `1..65535`. |
 | `--auto-start/--no-auto-start` | `--auto-start` | Auto-start local service if unavailable. |
 
 ### `keep-gpu status`
@@ -62,7 +62,7 @@ or whitespace-only values are invalid.
 | Option | Description |
 | --- | --- |
 | `--job-id` | Optional non-empty URL-path-safe session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. Invalid explicit IDs are rejected locally before RPC. |
-| `--host`, `--port` | Service host/port. |
+| `--host`, `--port` | Service host/port. Invalid endpoint values are rejected locally and printed as JSON errors before RPC. |
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
@@ -78,7 +78,7 @@ runtime failure.
 | --- | --- |
 | `--job-id` | Stop one non-empty URL-path-safe session id. Invalid explicit IDs are rejected locally before RPC or stop-all fallback. |
 | `--all` | Stop all sessions. |
-| `--host`, `--port` | Service host/port. |
+| `--host`, `--port` | Service host/port. Invalid endpoint values are rejected locally and printed as JSON errors before RPC or stop-all fallback. |
 
 `--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
 error before any RPC or stop-all fallback runs.
@@ -99,15 +99,18 @@ ordinals accepted by `--gpu-ids` and service `gpu_ids`; optional `physical_id`
 or `uuid` fields are metadata only. The output is a directly parseable JSON
 object, including `{"error": "..."}` for service/runtime errors after CLI
 parsing succeeds. Malformed JSON-RPC service envelopes are reported as JSON
-error objects instead of empty success results.
+error objects instead of empty success results. Invalid endpoint values are
+reported as JSON errors before RPC.
 
 ### `keep-gpu service-stop`
 
 Stops the ownership-verified local daemon process created by auto-start logic.
+Invalid endpoint values are rejected locally before service checks or
+ownership-verified stop operations.
 
 | Option | Description |
 | --- | --- |
-| `--host`, `--port` | Service host/port. |
+| `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be in `1..65535`. |
 | `--force` | Skip active-session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
 
 ## Service HTTP endpoints

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import shlex
@@ -9,6 +10,7 @@ import signal
 import subprocess
 import sys
 import time
+from http.client import InvalidURL
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.error import HTTPError, URLError
@@ -29,6 +31,8 @@ from keep_gpu.utilities.session_config import (
 
 DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
+SERVICE_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
+SERVICE_PORT_ERROR = "port must be an integer between 1 and 65535"
 
 app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -271,6 +275,47 @@ def _validate_cli_job_id(job_id: Optional[str]) -> Optional[str]:
         raise typer.BadParameter(str(exc)) from exc
 
 
+def _validate_cli_service_host(host: str) -> str:
+    def _is_dns_hostname(value: str) -> bool:
+        if len(value) > 253 or value.endswith("."):
+            return False
+        labels = value.split(".")
+        if labels[-1].isdigit():
+            return False
+        for label in labels:
+            if not 1 <= len(label) <= 63:
+                return False
+            if label.startswith("-") or label.endswith("-"):
+                return False
+            if not all(
+                char.isascii() and (char.isalnum() or char == "-") for char in label
+            ):
+                return False
+        return True
+
+    if not isinstance(host, str) or host.strip() != host or not host:
+        raise typer.BadParameter(SERVICE_HOST_ERROR)
+    try:
+        parsed_ip = ipaddress.ip_address(host)
+    except ValueError:
+        if not _is_dns_hostname(host):
+            raise typer.BadParameter(SERVICE_HOST_ERROR) from None
+    else:
+        if parsed_ip.version != 4:
+            raise typer.BadParameter(SERVICE_HOST_ERROR)
+    return host
+
+
+def _validate_cli_service_port(port: int) -> int:
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise typer.BadParameter(SERVICE_PORT_ERROR)
+    return port
+
+
+def _validate_cli_service_endpoint(host: str, port: int) -> Tuple[str, int]:
+    return _validate_cli_service_host(host), _validate_cli_service_port(port)
+
+
 def _service_base_url(host: str, port: int) -> str:
     return f"http://{host}:{port}"
 
@@ -285,8 +330,8 @@ def _http_json_request(
     headers = {"content-type": "application/json"}
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
-    request = Request(url=url, data=data, headers=headers, method=method)
     try:
+        request = Request(url=url, data=data, headers=headers, method=method)
         with urlopen(request, timeout=timeout) as response:  # nosec B310
             body = response.read().decode("utf-8")
             if not body:
@@ -302,6 +347,14 @@ def _http_json_request(
         detail = body or str(exc)
         raise ServiceResponseError(f"Service HTTP error: {detail}") from exc
     except (URLError, TimeoutError, OSError) as exc:
+        raise ServiceUnreachableError(
+            f"Cannot reach KeepGPU service at {url}: {exc}"
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise ServiceResponseError(
+            f"Invalid UTF-8 response from service endpoint: {url}"
+        ) from exc
+    except (InvalidURL, ValueError) as exc:
         raise ServiceUnreachableError(
             f"Cannot reach KeepGPU service at {url}: {exc}"
         ) from exc
@@ -634,6 +687,12 @@ def serve(
     """Run KeepGPU local service (HTTP + JSON-RPC + dashboard)."""
     from keep_gpu.mcp.server import KeepGPUServer, run_http
 
+    try:
+        host, port = _validate_cli_service_endpoint(host, port)
+    except typer.BadParameter as exc:
+        console.print(f"[bold red]Error: {exc}[/bold red]")
+        raise typer.Exit(code=1) from exc
+
     console.print(f"[bold cyan]Service URL:[/bold cyan] http://{host}:{port}/")
     console.print(
         "[dim]Press Ctrl+C to stop the foreground service, or use `keep-gpu service-stop` for auto-started daemons.[/dim]"
@@ -684,6 +743,7 @@ def start(
     `keep-gpu service-stop` to stop the local service daemon.
     """
     try:
+        host, port = _validate_cli_service_endpoint(host, port)
         interval = _validate_cli_interval(interval)
         busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         parsed_gpu_ids = _parse_gpu_ids(gpu_ids)
@@ -729,6 +789,7 @@ def status(
 ):
     """Show session status from KeepGPU local service."""
     try:
+        host, port = _validate_cli_service_endpoint(host, port)
         job_id = _validate_cli_job_id(job_id)
         result = _rpc_call(
             "status",
@@ -762,6 +823,7 @@ def stop(
             raise RuntimeError("Use either --job-id or --all, not both.")
         if job_id is None and not all_sessions:
             raise RuntimeError("Provide --job-id or use --all.")
+        host, port = _validate_cli_service_endpoint(host, port)
         job_id = _validate_cli_job_id(job_id)
         if all_sessions:
             result = _stop_all_sessions_with_fallback(host, port)
@@ -786,9 +848,10 @@ def list_gpus(
 ):
     """List GPU telemetry from local service."""
     try:
+        host, port = _validate_cli_service_endpoint(host, port)
         result = _rpc_call("list_gpus", {}, host, port)
         console.print_json(data=result)
-    except RuntimeError as exc:
+    except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
@@ -805,6 +868,7 @@ def service_stop(
 ):
     """Stop local KeepGPU service daemon started by auto-start logic."""
     try:
+        host, port = _validate_cli_service_endpoint(host, port)
         if force:
             stopped = _stop_service_process(host, port)
             if not stopped:
@@ -834,7 +898,7 @@ def service_stop(
         console.print(
             f"[bold green]Stopped KeepGPU service daemon[/bold green] at http://{host}:{port}/"
         )
-    except RuntimeError as exc:
+    except (RuntimeError, typer.BadParameter) as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -212,6 +212,117 @@ def test_start_command_rejects_local_inputs_before_auto_start(
     assert message in result.output
 
 
+def test_start_command_rejects_invalid_host_before_auto_start(monkeypatch):
+    called = {"ensure": False, "rpc": False}
+
+    def fake_ensure(*args, **kwargs):
+        called["ensure"] = True
+        return False
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {"job_id": "job-host"}
+
+    monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["start", "--host", "bad host"])
+
+    assert result.exit_code == 1
+    assert "host must be a DNS hostname or IPv4 address" in result.output
+    assert "Traceback" not in result.output
+    assert called == {"ensure": False, "rpc": False}
+
+
+def test_start_command_rejects_invalid_port_before_auto_start(monkeypatch):
+    called = {"ensure": False, "rpc": False}
+
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: called.__setitem__("ensure", True),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: called.__setitem__("rpc", True),
+    )
+
+    result = runner.invoke(cli.app, ["start", "--port", "0"])
+
+    assert result.exit_code == 1
+    assert "port must be an integer between 1 and 65535" in result.output
+    assert called == {"ensure": False, "rpc": False}
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "localhost",
+        "gpu-box",
+        "gpu-box.local",
+        "node-01.cluster.local",
+        "127.0.0.1",
+        "0.0.0.0",
+    ],
+)
+def test_validate_cli_service_host_accepts_dns_names_and_ipv4_literals(host):
+    assert cli._validate_cli_service_host(host) == host
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "",
+        " ",
+        "bad host",
+        "%",
+        "%zz",
+        "\\host",
+        "host\\path",
+        "*",
+        "-bad",
+        "bad-",
+        "bad..host",
+        "999.999.999.999",
+        "256.0.0.1",
+        "123",
+        "foo.123",
+        "http://localhost",
+        "localhost:8765",
+    ],
+)
+def test_validate_cli_service_host_rejects_malformed_values(host):
+    with pytest.raises(
+        cli.typer.BadParameter,
+        match="host must be a DNS hostname or IPv4 address",
+    ):
+        cli._validate_cli_service_host(host)
+
+
+def test_start_command_rejects_non_whitespace_malformed_host_before_auto_start(
+    monkeypatch,
+):
+    called = {"ensure": False, "rpc": False}
+
+    def fake_ensure(*args, **kwargs):
+        called["ensure"] = True
+        return False
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {"job_id": "job-host"}
+
+    monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["start", "--host", "%"])
+
+    assert result.exit_code == 1
+    assert "host must be a DNS hostname or IPv4 address" in result.output
+    assert called == {"ensure": False, "rpc": False}
+
+
 def test_stop_requires_job_id_or_all():
     result = runner.invoke(cli.app, ["stop"])
     assert result.exit_code == 1
@@ -272,6 +383,98 @@ def test_stop_rejects_invalid_job_id_before_rpc_or_fallback(monkeypatch, job_id)
     assert result.exit_code == 1
     payload = _single_decoded_json_object(result.output)
     assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
+
+
+@pytest.mark.parametrize(
+    ("command", "called_key"),
+    [
+        (["status", "--host", "bad host"], "rpc"),
+        (["stop", "--all", "--host", "bad host"], "stop_all"),
+        (["list-gpus", "--host", "bad host"], "rpc"),
+    ],
+)
+def test_service_json_commands_reject_invalid_host_before_rpc_or_fallback(
+    monkeypatch, command, called_key
+):
+    called = {"rpc": False, "stop_all": False}
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {}
+
+    def fake_stop_all(*args, **kwargs):
+        called["stop_all"] = True
+        return {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_all_sessions_with_fallback", fake_stop_all)
+
+    result = runner.invoke(cli.app, command)
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "host must be a DNS hostname or IPv4 address"
+    assert called[called_key] is False
+
+
+def test_service_json_command_rejects_invalid_port_before_rpc(monkeypatch):
+    called = {"rpc": False}
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--port", "70000"])
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "port must be an integer between 1 and 65535"
+    assert called["rpc"] is False
+
+
+def test_service_stop_rejects_invalid_host_before_daemon_operations(monkeypatch):
+    called = {"available": False, "stop": False}
+
+    def fake_available(*args, **kwargs):
+        called["available"] = True
+        return False
+
+    def fake_stop(*args, **kwargs):
+        called["stop"] = True
+        return True
+
+    monkeypatch.setattr(cli, "_service_available", fake_available)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop)
+
+    result = runner.invoke(cli.app, ["service-stop", "--host", "bad host", "--force"])
+
+    assert result.exit_code == 1
+    assert "host must be a DNS hostname or IPv4 address" in result.output
+    assert called == {"available": False, "stop": False}
+
+
+def test_http_json_request_wraps_malformed_url_as_service_unreachable():
+    with pytest.raises(cli.ServiceUnreachableError, match="Cannot reach KeepGPU"):
+        cli._http_json_request("GET", "http://bad host:8765/health")
+
+
+def test_http_json_request_reports_invalid_utf8_as_service_response_error(monkeypatch):
+    class InvalidUtf8Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self):
+            return b"\xff"
+
+    monkeypatch.setattr(cli, "urlopen", lambda *args, **kwargs: InvalidUtf8Response())
+
+    with pytest.raises(cli.ServiceResponseError, match="Invalid UTF-8 response"):
+        cli._http_json_request("GET", "http://127.0.0.1:8765/health")
 
 
 def test_status_outputs_single_decoded_json_object(monkeypatch):


### PR DESCRIPTION
## Summary
- validate CLI service `--host`/`--port` before RPC, auto-start, stop-all fallback, or daemon ownership operations
- return structured JSON errors for invalid endpoints from JSON-output commands
- add DNS/IPv4 host syntax coverage, malformed URL wrapping, docs, AGENTS.md, and branch plan

## Verification
- live: `PYTHONPATH=$PWD/src python -m keep_gpu.cli status --host "bad host"` -> JSON error, no traceback
- live: `PYTHONPATH=$PWD/src python -m keep_gpu.cli list-gpus --host "bad host"` -> JSON error, no traceback
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` -> 109 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 437 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unnav'd plan notices
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed

## Local Review
- First local subagent review found host syntax too permissive for `%`, backslashes, bad labels; fixed before PR
- Second local subagent review: no critical, important, or minor findings; reviewer reran endpoint shard with 32 passed, 66 deselected
