### PR TITLE
[rocm] fix: validate allocation retry limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,9 @@ This file defines how coding agents should work in this repository.
   and show `n/a` when no finite readings exist, and per-GPU utilization bars
   must not render an idle fill for unavailable telemetry.
 - Single-GPU keep workload iteration counts must be positive integers (`relu_iterations` for CUDA, `iterations` for ROCm/Mac M); reject invalid values before keep loops so no public path can create a silent no-op keeper or late background thread crash.
+- ROCm optional allocation retry counts must be `None` or positive plain
+  integers; reject invalid values before worker startup so background retry
+  loops cannot crash with type errors after `keep()` returns.
 - Direct CUDA/ROCm single-GPU `rank` values must be plain integer visible
   device ordinals validated against the current visible device count during
   construction, before `torch.device`, backend `set_device`, telemetry, or keep

--- a/docs/plans/rocm-max-allocation-retries-validation.md
+++ b/docs/plans/rocm-max-allocation-retries-validation.md
@@ -1,0 +1,30 @@
+# ROCm Max Allocation Retries Validation Plan
+
+## Background
+
+`RocmGPUController(max_allocation_retries=...)` currently stores caller input directly. Non-integer, boolean, zero, or negative values can make the allocation retry loop crash or behave ambiguously after `keep()` has already returned.
+
+## Goal
+
+Validate `max_allocation_retries` at `RocmGPUController` construction time so callers get a synchronous error before any worker startup.
+
+## Solution
+
+Reuse the existing plain positive integer validation style in `src/keep_gpu/utilities/session_config.py`. Accept only `None` or a positive plain `int`; reject `bool`, strings, zero, and negative values.
+
+## Tasks
+
+- [x] Add RED tests in `tests/rocm_controller/test_rocm_backoff.py` for invalid values `"1"`, `True`, `0`, and `-1`, plus a valid positive integer.
+- [x] Run the targeted ROCm backoff test and confirm the invalid-value cases fail before implementation.
+- [x] Update `src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py` to validate `max_allocation_retries` in `__init__`.
+- [x] Add a concise ROCm retry validation note to `AGENTS.md`.
+- [x] Run targeted tests and `git diff --check`.
+- [x] Commit with `fix(rocm): validate allocation retry limit`.
+
+## Verification Notes
+
+Required targeted checks:
+
+- `pytest tests/rocm_controller/test_rocm_backoff.py -q`
+- `pytest tests/global_controller/test_contract.py tests/rocm_controller/test_rocm_backoff.py tests/utilities/test_session_config.py -q`
+- `git diff --check`

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -36,10 +36,16 @@ class RocmGPUController(BaseGPUController):
         super().__init__(vram_to_keep=vram_to_keep, interval=interval)
         self.busy_threshold = validate_busy_threshold(busy_threshold)
         self.iterations = validate_positive_integer(iterations, "iterations")
+        self.max_allocation_retries = (
+            None
+            if max_allocation_retries is None
+            else validate_positive_integer(
+                max_allocation_retries, "max_allocation_retries"
+            )
+        )
         rank = validate_visible_rank(rank, torch.cuda.device_count())
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")
-        self.max_allocation_retries = max_allocation_retries
         self._stop_evt: Optional[threading.Event] = None
         self._thread: Optional[threading.Thread] = None
         self._failure_exc: Optional[Exception] = None

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -88,6 +88,40 @@ def test_rocm_controller_rejects_non_positive_iterations(iterations):
         RocmGPUController(rank=0, vram_to_keep=4, iterations=iterations)
 
 
+@pytest.mark.parametrize(
+    ("max_allocation_retries", "error_type", "message"),
+    [
+        ("1", TypeError, "max_allocation_retries must be an integer"),
+        (True, TypeError, "max_allocation_retries must be an integer"),
+        (0, ValueError, "max_allocation_retries must be positive"),
+        (-1, ValueError, "max_allocation_retries must be positive"),
+    ],
+)
+def test_rocm_controller_rejects_invalid_max_allocation_retries(
+    monkeypatch, max_allocation_retries, error_type, message
+):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+
+    with pytest.raises(error_type, match=message):
+        RocmGPUController(
+            rank=0,
+            vram_to_keep=4,
+            max_allocation_retries=max_allocation_retries,
+        )
+
+
+def test_rocm_controller_accepts_positive_max_allocation_retries(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+
+    ctrl = RocmGPUController(rank=0, vram_to_keep=4, max_allocation_retries=1)
+
+    assert ctrl.max_allocation_retries == 1
+
+
 class _StopAfterOneWait:
     def __init__(self):
         self.stopped = False


### PR DESCRIPTION
## Summary
- Validate `RocmGPUController(max_allocation_retries=...)` synchronously so it accepts only `None` or positive plain integers.
- Add regression tests for string, bool, zero, negative, and positive retry limits.
- Document the retry validation rule in `AGENTS.md` and add a focused implementation plan.

## Test Plan
- RED observed before implementation: `pytest tests/rocm_controller/test_rocm_backoff.py -q` failed with 4 invalid retry cases reporting `DID NOT RAISE`.
- `pytest tests/rocm_controller/test_rocm_backoff.py -q` -> 16 passed.
- `pytest tests/global_controller/test_contract.py tests/rocm_controller/test_rocm_backoff.py tests/utilities/test_session_config.py -q` -> 105 passed.
- `pytest tests/rocm_controller -q` -> 24 passed.
- `pytest tests -q` -> 455 passed, 11 skipped.
- `mkdocs build` -> passed with existing MkDocs/unnav warnings.
- `pre-commit run --all-files` -> passed.
- `git diff --check origin/main...HEAD` -> passed.

## Local Review
- Local subagent review found no Critical, Important, or Minor issues and marked ready to PR/merge.