### PR TITLE
[mcp] fix: validate executable endpoint flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ This file defines how coding agents should work in this repository.
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`
   objects for invalid endpoints, not tracebacks.
+- MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
+  before socket bind, matching the CLI service endpoint contract.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
 - `keep-gpu status --job-id` and `keep-gpu stop --job-id` must validate
   explicit custom IDs locally before service RPC, stop-all fallback, or daemon

--- a/docs/plans/mcp-executable-endpoint-validation.md
+++ b/docs/plans/mcp-executable-endpoint-validation.md
@@ -1,0 +1,51 @@
+# MCP Executable Endpoint Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for the code change. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `keep-gpu-mcp-server --mode http` and `python -m keep_gpu.mcp.server --mode http` reject invalid endpoint flags before attempting to bind a socket.
+
+**Architecture:** Keep validation local to `src/keep_gpu/mcp/server.py` so the MCP executable does not import the Typer CLI module. Mirror the CLI service contract for small endpoint checks: host must be a DNS hostname or IPv4 address, and port must be an integer in `1..65535`.
+
+**Tech Stack:** Python `argparse`, pytest, KeepGPU MCP server entrypoint.
+
+---
+
+## Background
+
+`keep-gpu serve` validates `--host` and `--port` before starting the HTTP server. The direct MCP executable path currently parses `--port` as `int` but passes values straight to `run_http`. Audit repros show invalid values can surface as low-level socket exceptions:
+
+- `PYTHONPATH=$PWD/src python -m keep_gpu.mcp.server --mode http --port 70000` raises `OverflowError`.
+- `PYTHONPATH=$PWD/src python -m keep_gpu.mcp.server --mode http --host 'bad host'` raises `socket.gaierror`.
+
+## Solution
+
+- Add focused tests in `tests/mcp/test_server.py` that monkeypatch `server.main()` dependencies and prove invalid HTTP endpoint flags exit before `run_http`.
+- Add a small MCP-local endpoint validator in `src/keep_gpu/mcp/server.py`.
+- Call that validator only for `--mode http`, immediately before creating `KeepGPUServer` and invoking `run_http`.
+- Update `AGENTS.md` to document that both CLI service and MCP executable endpoint flags must be validated before socket bind.
+
+## Tasks
+
+- [x] Add RED tests for invalid MCP executable endpoint flags:
+  - `--port 0`
+  - `--port 70000`
+  - `--port true`
+  - `--host "bad host"`
+- [x] Add a valid-case test proving normalized `host` and `port` reach `run_http`.
+- [x] Run the focused new tests and confirm the invalid host/range tests fail before implementation.
+- [x] Implement minimal endpoint validation in `src/keep_gpu/mcp/server.py`.
+- [x] Update `AGENTS.md` with the endpoint validation rule.
+- [x] Run `pytest tests/mcp/test_server.py -q`.
+- [x] Run `git diff --check`.
+- [x] Commit as `fix(mcp): validate executable endpoint flags`.
+
+## Verification Notes
+
+Expected final checks:
+
+```bash
+pytest tests/mcp/test_server.py -q
+git diff --check
+```
+
+The RED run should show the new invalid `--host`, `--port 0`, and `--port 70000` tests failing because `run_http` was called instead of argparse exiting. The bool-ish string case is already rejected by argparse's `type=int`, and remains covered as part of the executable contract.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -28,6 +28,7 @@ HTTP endpoints:
 from __future__ import annotations
 
 import atexit
+import ipaddress
 import json
 import sys
 import uuid
@@ -67,6 +68,8 @@ JSONRPC_INVALID_REQUEST = -32600
 JSONRPC_METHOD_NOT_FOUND = -32601
 JSONRPC_INVALID_PARAMS = -32602
 JSONRPC_INTERNAL_ERROR = -32603
+MCP_ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
+MCP_ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
 
 MCP_TOOLS: List[Dict[str, Any]] = [
     {
@@ -1051,6 +1054,47 @@ def run_http(server: KeepGPUServer, host: str = "127.0.0.1", port: int = 8765) -
         server.shutdown()
 
 
+def _validate_mcp_http_host(host: str) -> str:
+    def _is_dns_hostname(value: str) -> bool:
+        if len(value) > 253 or value.endswith("."):
+            return False
+        labels = value.split(".")
+        if labels[-1].isdigit():
+            return False
+        for label in labels:
+            if not 1 <= len(label) <= 63:
+                return False
+            if label.startswith("-") or label.endswith("-"):
+                return False
+            if not all(
+                char.isascii() and (char.isalnum() or char == "-") for char in label
+            ):
+                return False
+        return True
+
+    if not isinstance(host, str) or host.strip() != host or not host:
+        raise ValueError(MCP_ENDPOINT_HOST_ERROR)
+    try:
+        parsed_ip = ipaddress.ip_address(host)
+    except ValueError:
+        if not _is_dns_hostname(host):
+            raise ValueError(MCP_ENDPOINT_HOST_ERROR) from None
+    else:
+        if parsed_ip.version != 4:
+            raise ValueError(MCP_ENDPOINT_HOST_ERROR)
+    return host
+
+
+def _validate_mcp_http_port(port: int) -> int:
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise ValueError(MCP_ENDPOINT_PORT_ERROR)
+    return port
+
+
+def _validate_mcp_http_endpoint(host: str, port: int) -> tuple[str, int]:
+    return _validate_mcp_http_host(host), _validate_mcp_http_port(port)
+
+
 def main() -> None:
     """CLI entry point for the KeepGPU MCP server."""
     parser = argparse.ArgumentParser(description="KeepGPU MCP server")
@@ -1063,6 +1107,12 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1", help="HTTP host (http mode)")
     parser.add_argument("--port", type=int, default=8765, help="HTTP port (http mode)")
     args = parser.parse_args()
+
+    if args.mode == "http":
+        try:
+            args.host, args.port = _validate_mcp_http_endpoint(args.host, args.port)
+        except ValueError as exc:
+            parser.error(str(exc))
 
     server = KeepGPUServer()
     if args.mode == "stdio":

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -16,6 +16,7 @@ from keep_gpu.mcp.server import (
     KeepGPUServer,
     _handle_request,
 )
+from keep_gpu.mcp import server as server_module
 from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
 from keep_gpu.utilities import platform_manager as pm
 
@@ -51,6 +52,66 @@ def _wait_until(condition, timeout_s=1.0):
             return True
         time.sleep(0.01)
     return condition()
+
+
+@pytest.mark.parametrize(
+    "endpoint_args",
+    [
+        ["--port", "0"],
+        ["--port", "70000"],
+        ["--port", "true"],
+        ["--host", "bad host"],
+    ],
+)
+def test_http_main_rejects_invalid_endpoint_before_binding(monkeypatch, endpoint_args):
+    run_http_calls = []
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keep-gpu-mcp-server", "--mode", "http", *endpoint_args],
+    )
+    monkeypatch.setattr(server_module, "KeepGPUServer", lambda: object())
+    monkeypatch.setattr(
+        server_module,
+        "run_http",
+        lambda *args, **kwargs: run_http_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        server_module.main()
+
+    assert exc_info.value.code != 0
+    assert run_http_calls == []
+
+
+def test_http_main_passes_valid_endpoint_to_run_http(monkeypatch):
+    run_http_calls = []
+    server_instance = object()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "keep-gpu-mcp-server",
+            "--mode",
+            "http",
+            "--host",
+            "localhost",
+            "--port",
+            "9876",
+        ],
+    )
+    monkeypatch.setattr(server_module, "KeepGPUServer", lambda: server_instance)
+    monkeypatch.setattr(
+        server_module,
+        "run_http",
+        lambda *args, **kwargs: run_http_calls.append((args, kwargs)),
+    )
+
+    server_module.main()
+
+    assert run_http_calls == [((server_instance,), {"host": "localhost", "port": 9876})]
 
 
 def test_start_status_stop_cycle():


### PR DESCRIPTION
## Summary
- Validate `keep-gpu-mcp-server --mode http` host and port before socket bind.
- Keep the direct MCP executable endpoint contract aligned with `keep-gpu serve`.
- Add regression tests for invalid host/port inputs and the valid endpoint path.

## Test Plan
- RED observed before implementation: new invalid `--host`, `--port 0`, and `--port 70000` tests failed because `run_http` was reached instead of argparse exiting; `--port true` was already rejected by argparse.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` -> 87 passed.
- `PYTHONPATH=$PWD/src pytest tests -q` -> 460 passed, 11 skipped.
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/unnav warnings.
- `pre-commit run --all-files` -> passed.
- `git diff --check origin/main...HEAD` -> passed.
- `PYTHONPATH=$PWD/src python -m keep_gpu.mcp.server --mode http --port 70000` -> exits 2 with argparse validation error.
- `PYTHONPATH=$PWD/src python -m keep_gpu.mcp.server --mode http --host "bad host"` -> exits 2 with argparse validation error.

## Local Review
- Local subagent review found no Critical, Important, or Minor issues and marked ready to PR/merge.