### PR TITLE
[mcp] fix: validate jsonrpc request version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,9 @@ This file defines how coding agents should work in this repository.
 - Keep the MCP server compatible with standard MCP lifecycle/tool methods
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.
+- JSON-RPC handlers must reject explicit request versions other than `"2.0"`
+  with `-32600 Invalid Request` while preserving omitted-version legacy/internal
+  calls.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ This file defines how coding agents should work in this repository.
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.
 - JSON-RPC handlers must reject explicit request versions other than `"2.0"`
-  with `-32600 Invalid Request` while preserving omitted-version legacy/internal
-  calls.
+  with `-32600 Invalid Request` for request messages while preserving
+  omitted-version legacy/internal calls and silent id-less notifications.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -46,6 +46,10 @@ servers:
 The stdio transport writes only JSON protocol messages to stdout. KeepGPU logs
 and diagnostics go to stderr so MCP clients can parse stdout safely.
 
+JSON-RPC request messages that include a `jsonrpc` version must use `"2.0"`;
+id-less `notifications/*` messages remain silent and do not produce response
+envelopes.
+
 ## HTTP JSON-RPC quick example
 
 HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the

--- a/docs/plans/jsonrpc-request-version-validation.md
+++ b/docs/plans/jsonrpc-request-version-validation.md
@@ -16,13 +16,14 @@ The audit found that `_handle_request()` accepts requests such as `{"jsonrpc": "
 
 ## Solution
 
-Add explicit version validation in `_handle_request()` after confirming the payload is an object and before method dispatch. If `jsonrpc` is present and its value is not `"2.0"`, return `JSONRPC_INVALID_REQUEST` (`-32600`). Do not require `jsonrpc` for legacy/internal direct calls.
+Add explicit version validation in `_handle_request()` after confirming the payload is an object and before method dispatch. If a non-notification request message includes `jsonrpc` and its value is not `"2.0"`, return `JSONRPC_INVALID_REQUEST` (`-32600`). Do not require `jsonrpc` for legacy/internal direct calls, and keep id-less `notifications/*` messages silent even when they carry a malformed version.
 
 ## Tasks
 
 - [x] Add RED tests in `tests/mcp/test_server.py` for invalid explicit version, valid explicit `"2.0"`, and omitted legacy version.
 - [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` and confirm the invalid-version test fails before implementation.
 - [x] Implement the minimal `_handle_request()` validation in `src/keep_gpu/mcp/server.py`.
+- [x] Preserve id-less notification silence before request-only version validation.
 - [x] Update `AGENTS.md` with the JSON-RPC version compatibility note.
 - [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`.
 - [x] Run `git diff --check`.

--- a/docs/plans/jsonrpc-request-version-validation.md
+++ b/docs/plans/jsonrpc-request-version-validation.md
@@ -1,0 +1,33 @@
+# JSON-RPC Request Version Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject explicit JSON-RPC request versions that are not exactly `"2.0"` while preserving legacy direct calls that omit `jsonrpc`.
+
+**Architecture:** The MCP server funnels JSON-RPC and legacy direct method calls through `_handle_request()` in `src/keep_gpu/mcp/server.py`. The fix belongs at the top-level request validation boundary before method dispatch so all MCP lifecycle and tool methods share the same JSON-RPC version contract.
+
+**Tech Stack:** Python, pytest, KeepGPU MCP JSON-RPC server.
+
+---
+
+## Background
+
+The audit found that `_handle_request()` accepts requests such as `{"jsonrpc": "1.0", "id": 1, "method": "tools/list"}` and returns a successful JSON-RPC 2.0 response. Standard JSON-RPC requests that include a `jsonrpc` member must use the exact string `"2.0"`. Existing local scripts and tests also use legacy direct calls without a `jsonrpc` member, so omitted versions must remain supported.
+
+## Solution
+
+Add explicit version validation in `_handle_request()` after confirming the payload is an object and before method dispatch. If `jsonrpc` is present and its value is not `"2.0"`, return `JSONRPC_INVALID_REQUEST` (`-32600`). Do not require `jsonrpc` for legacy/internal direct calls.
+
+## Tasks
+
+- [x] Add RED tests in `tests/mcp/test_server.py` for invalid explicit version, valid explicit `"2.0"`, and omitted legacy version.
+- [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` and confirm the invalid-version test fails before implementation.
+- [x] Implement the minimal `_handle_request()` validation in `src/keep_gpu/mcp/server.py`.
+- [x] Update `AGENTS.md` with the JSON-RPC version compatibility note.
+- [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`.
+- [x] Run `git diff --check`.
+- [x] Commit with `fix(mcp): validate jsonrpc request version`.
+
+## Verification Notes
+
+The RED run must fail because explicit `"jsonrpc": "1.0"` currently succeeds. The final targeted pytest run must pass all MCP server tests, and `git diff --check` must report no whitespace errors before commit.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -724,9 +724,11 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
             raise JSONRPCError(
                 JSONRPC_INVALID_REQUEST, "JSON-RPC messages must be objects."
             )
+        req_id = payload.get("id")
+        if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
+            raise JSONRPCError(JSONRPC_INVALID_REQUEST, "JSON-RPC version must be 2.0.")
         method = payload.get("method")
         params = payload.get("params", {})
-        req_id = payload.get("id")
         if not isinstance(method, str) or not method:
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Request method is required.")
         if (

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -725,19 +725,19 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
                 JSONRPC_INVALID_REQUEST, "JSON-RPC messages must be objects."
             )
         req_id = payload.get("id")
-        if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
-            raise JSONRPCError(JSONRPC_INVALID_REQUEST, "JSON-RPC version must be 2.0.")
         method = payload.get("method")
         params = payload.get("params", {})
         if not isinstance(method, str) or not method:
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Request method is required.")
+        if method.startswith("notifications/") and "id" not in payload:
+            return None
+        if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
+            raise JSONRPCError(JSONRPC_INVALID_REQUEST, "JSON-RPC version must be 2.0.")
         if (
             "id" not in payload
             or not isinstance(req_id, (str, int))
             or isinstance(req_id, bool)
         ):
-            if method.startswith("notifications/") and "id" not in payload:
-                return None
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Requests must include an id.")
         if method.startswith("notifications/"):
             raise JSONRPCError(

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -12,6 +12,7 @@ import pytest
 
 from keep_gpu.mcp.server import (
     JSONRPC_INTERNAL_ERROR,
+    JSONRPC_INVALID_REQUEST,
     JSONRPC_INVALID_PARAMS,
     KeepGPUServer,
     _handle_request,
@@ -718,6 +719,39 @@ def test_mcp_tools_list_exposes_keepgpu_actions():
         "string",
         "null",
     ]
+
+
+def test_jsonrpc_rejects_explicit_invalid_request_version():
+    server = make_server()
+    req = {"jsonrpc": "1.0", "id": 12, "method": "tools/list"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 12
+    assert resp["error"]["code"] == JSONRPC_INVALID_REQUEST
+
+
+def test_jsonrpc_accepts_explicit_valid_request_version():
+    server = make_server()
+    req = {"jsonrpc": "2.0", "id": 13, "method": "tools/list"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 13
+    assert "tools" in resp["result"]
+
+
+def test_jsonrpc_omitted_version_legacy_direct_call_still_works():
+    server = make_server()
+    req = {"id": 14, "method": "tools/list"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 14
+    assert "tools" in resp["result"]
 
 
 def test_mcp_tools_call_routes_to_existing_status_method():

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -696,6 +696,15 @@ def test_mcp_initialized_notification_has_no_response():
     assert resp is None
 
 
+def test_mcp_initialized_notification_with_bad_version_has_no_response():
+    server = make_server()
+    req = {"jsonrpc": "1.0", "method": "notifications/initialized"}
+
+    resp = _handle_request(server, req)
+
+    assert resp is None
+
+
 def test_mcp_tools_list_exposes_keepgpu_actions():
     server = make_server()
     req = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}


### PR DESCRIPTION
## Summary
- Reject explicit JSON-RPC request versions other than `"2.0"` with `-32600 Invalid Request`.
- Preserve omitted-version legacy/internal direct calls.
- Add regression coverage for invalid explicit, valid explicit, and omitted legacy requests.

## Test Plan
- RED observed before implementation: `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` failed on `test_jsonrpc_rejects_explicit_invalid_request_version` with `KeyError: error`.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` -> 90 passed.
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 139 passed.
- `PYTHONPATH=$PWD/src pytest tests -q` -> 463 passed, 11 skipped.
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/unnav warnings.
- `pre-commit run --all-files` -> passed.
- `git diff --check origin/main...HEAD` -> passed.

## Local Review
- Local subagent review found no Critical, Important, or Minor issues and marked ready to PR/merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests that explicitly specify an unsupported JSON-RPC version are now rejected with an invalid request error.
  * Requests using the supported `"2.0"` version continue to work normally.
  * Legacy calls that omit the version field still succeed.

* **Documentation**
  * Updated guidance to reflect the expected JSON-RPC version behavior for MCP requests.

* **Tests**
  * Added coverage for invalid, valid, and omitted JSON-RPC version cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->