### PR TITLE
[cli] fix: reject root options before service commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ This file defines how coding agents should work in this repository.
 - MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
   before socket bind, matching the CLI service endpoint contract.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
+- Blocking-mode root CLI options (`--gpu-ids`, `--vram`,
+  `--busy-threshold`/`--util-threshold`, hidden `--threshold`, and
+  `--interval`) must be rejected when explicitly supplied before a service
+  subcommand; service options belong after the subcommand, for example
+  `keep-gpu start --gpu-ids 0`.
 - `keep-gpu status --job-id` and `keep-gpu stop --job-id` must validate
   explicit custom IDs locally before service RPC, stop-all fallback, or daemon
   side effects. Only omitting the option means all-session status or no stop

--- a/docs/plans/cli-reject-root-options-before-start.md
+++ b/docs/plans/cli-reject-root-options-before-start.md
@@ -38,5 +38,5 @@ explicitly supplied must remain ignored so normal service commands keep working.
 - GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` passed with 6 cases after the guard.
 - Review-polish check: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_status_rejects_root_blocking_options_before_service_rpc -q` passed after adding the non-`start` service-command regression.
 - Hosted-review RED/GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_root_option_source_helper_accepts_raw_commandline_value -q` failed before the fallback and passed after the helper accepted raw string sources.
-- Final targeted suite: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed with 126 tests.
+- Final targeted suite: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed with 127 tests.
 - Diff hygiene: `git diff --check` passed.

--- a/docs/plans/cli-reject-root-options-before-start.md
+++ b/docs/plans/cli-reject-root-options-before-start.md
@@ -1,0 +1,39 @@
+# CLI Reject Root Options Before Start Plan
+
+## Background
+
+The root callback owns blocking-mode options such as `--gpu-ids`, `--vram`,
+`--busy-threshold`/`--util-threshold`, hidden `--threshold`, and `--interval`.
+When a service subcommand is invoked, the callback currently returns before
+checking whether those root options were explicitly supplied. A command such as
+`keep-gpu --gpu-ids 0 start` therefore starts a service session with
+`gpu_ids=None`, which means all visible GPUs.
+
+## Solution
+
+Use Click's parameter-source tracking in the root callback. If a subcommand is
+being invoked and any blocking-mode root option came from the command line,
+raise a clear error telling the user to put service options after the
+subcommand, for example `keep-gpu start --gpu-ids 0`. Defaults that were not
+explicitly supplied must remain ignored so normal service commands keep working.
+
+## Tasks
+
+- [x] Add a failing service-command regression test for root blocking options
+      supplied before `start`.
+- [x] Confirm the test fails before implementation.
+- [x] Implement the minimal root-callback guard before service startup or RPC.
+- [x] Preserve blocking mode when no subcommand is invoked.
+- [x] Add a non-`start` service-command regression so the broader guard stays
+      intentional.
+- [x] Add the root/subcommand option-placement guideline to `AGENTS.md`.
+- [x] Run targeted tests and `git diff --check`.
+- [x] Commit with `fix(cli): reject root options before service commands`.
+
+## Verification Notes
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` failed before implementation with 6 failing parameter cases because the command exited successfully instead of rejecting root options.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` passed with 6 cases after the guard.
+- Review-polish check: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_status_rejects_root_blocking_options_before_service_rpc -q` passed after adding the non-`start` service-command regression.
+- Final targeted suite: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed with 126 tests.
+- Diff hygiene: `git diff --check` passed.

--- a/docs/plans/cli-reject-root-options-before-start.md
+++ b/docs/plans/cli-reject-root-options-before-start.md
@@ -26,6 +26,8 @@ explicitly supplied must remain ignored so normal service commands keep working.
 - [x] Preserve blocking mode when no subcommand is invoked.
 - [x] Add a non-`start` service-command regression so the broader guard stays
       intentional.
+- [x] Address hosted review by accepting raw `"COMMANDLINE"` parameter-source
+      values as well as Click enum members.
 - [x] Add the root/subcommand option-placement guideline to `AGENTS.md`.
 - [x] Run targeted tests and `git diff --check`.
 - [x] Commit with `fix(cli): reject root options before service commands`.
@@ -35,5 +37,6 @@ explicitly supplied must remain ignored so normal service commands keep working.
 - RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` failed before implementation with 6 failing parameter cases because the command exited successfully instead of rejecting root options.
 - GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` passed with 6 cases after the guard.
 - Review-polish check: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_status_rejects_root_blocking_options_before_service_rpc -q` passed after adding the non-`start` service-command regression.
+- Hosted-review RED/GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_root_option_source_helper_accepts_raw_commandline_value -q` failed before the fallback and passed after the helper accepted raw string sources.
 - Final targeted suite: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed with 126 tests.
 - Diff hygiene: `git diff --check` passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -339,8 +339,8 @@ def _validate_cli_service_endpoint(host: str, port: int) -> Tuple[str, int]:
 
 
 def _is_commandline_parameter_source(source: Any) -> bool:
-    # Typer can return its vendored Click enum, so compare the semantic name.
-    return getattr(source, "name", None) == "COMMANDLINE"
+    # Typer can return its vendored Click enum or a string; compare semantics.
+    return getattr(source, "name", source) == "COMMANDLINE"
 
 
 def _reject_root_blocking_options_before_subcommand(ctx: typer.Context) -> None:

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -33,6 +33,13 @@ DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
 SERVICE_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
 SERVICE_PORT_ERROR = "port must be an integer between 1 and 65535"
+ROOT_BLOCKING_OPTION_LABELS = {
+    "gpu_ids": "--gpu-ids",
+    "vram": "--vram",
+    "legacy_threshold": "--threshold",
+    "busy_threshold": "--busy-threshold/--util-threshold",
+    "interval": "--interval",
+}
 
 app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -329,6 +336,29 @@ def _validate_cli_service_port(port: int) -> int:
 
 def _validate_cli_service_endpoint(host: str, port: int) -> Tuple[str, int]:
     return _validate_cli_service_host(host), _validate_cli_service_port(port)
+
+
+def _is_commandline_parameter_source(source: Any) -> bool:
+    # Typer can return its vendored Click enum, so compare the semantic name.
+    return getattr(source, "name", None) == "COMMANDLINE"
+
+
+def _reject_root_blocking_options_before_subcommand(ctx: typer.Context) -> None:
+    explicit_options = [
+        option_label
+        for param_name, option_label in ROOT_BLOCKING_OPTION_LABELS.items()
+        if _is_commandline_parameter_source(ctx.get_parameter_source(param_name))
+    ]
+    if not explicit_options:
+        return
+
+    option_text = ", ".join(explicit_options)
+    raise typer.BadParameter(
+        f"Root blocking option(s) {option_text} were placed before the "
+        f"`{ctx.invoked_subcommand}` service subcommand. Omit blocking-mode "
+        "root options before service subcommands; for start options, place "
+        "them after `start`, for example: `keep-gpu start --gpu-ids 0`."
+    )
 
 
 def _service_base_url(host: str, port: int) -> str:
@@ -679,9 +709,10 @@ def main(
 ):
     """Run blocking keep-alive mode when no subcommand is provided."""
     try:
-        interval = _validate_cli_interval(interval)
         if ctx.invoked_subcommand is not None:
+            _reject_root_blocking_options_before_subcommand(ctx)
             return
+        interval = _validate_cli_interval(interval)
         _parse_gpu_ids(gpu_ids)
         _run_blocking(interval, gpu_ids, vram, legacy_threshold, busy_threshold)
     except typer.BadParameter as exc:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -140,6 +140,10 @@ def test_status_rejects_root_blocking_options_before_service_rpc(monkeypatch):
     assert called == {"rpc": False}
 
 
+def test_root_option_source_helper_accepts_raw_commandline_value():
+    assert cli._is_commandline_parameter_source("COMMANDLINE") is True
+
+
 def test_start_command_accepts_fractional_interval(monkeypatch):
     called = {}
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -82,6 +82,64 @@ def test_start_command_uses_rpc(monkeypatch):
     assert port == cli.DEFAULT_SERVICE_PORT
 
 
+@pytest.mark.parametrize(
+    "root_args",
+    [
+        ["--gpu-ids", "0"],
+        ["--vram", "2GiB"],
+        ["--interval", "60"],
+        ["--busy-threshold", "30"],
+        ["--util-threshold", "30"],
+        ["--threshold", "30"],
+    ],
+)
+def test_start_rejects_root_blocking_options_before_service_calls(
+    monkeypatch, root_args
+):
+    called = {"ensure": False, "rpc": False}
+
+    def fake_ensure(host, port, auto_start=True):
+        called["ensure"] = True
+        return False
+
+    def fake_rpc(method, params, host, port):
+        called["rpc"] = True
+        return {"job_id": "job-root-options"}
+
+    monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, [*root_args, "start"])
+
+    normalized_output = " ".join(result.output.split())
+    assert result.exit_code == 1
+    assert "Omit blocking-mode root options before service subcommands" in (
+        normalized_output
+    )
+    assert "keep-gpu start --gpu-ids 0" in normalized_output
+    assert called == {"ensure": False, "rpc": False}
+
+
+def test_status_rejects_root_blocking_options_before_service_rpc(monkeypatch):
+    called = {"rpc": False}
+
+    def fake_rpc(method, params, host, port):
+        called["rpc"] = True
+        return {"active_jobs": []}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["--gpu-ids", "0", "status"])
+
+    normalized_output = " ".join(result.output.split())
+    assert result.exit_code == 1
+    assert "`status` service subcommand" in normalized_output
+    assert "Omit blocking-mode root options before service subcommands" in (
+        normalized_output
+    )
+    assert called == {"rpc": False}
+
+
 def test_start_command_accepts_fractional_interval(monkeypatch):
     called = {}
 
@@ -850,8 +908,12 @@ def test_invalid_root_interval_before_subcommand_is_rejected(monkeypatch):
 
     result = runner.invoke(cli.app, ["--interval", "not-a-number", "start"])
 
+    normalized_output = " ".join(result.output.split())
     assert result.exit_code == 1
-    assert "interval must be finite and positive" in result.output
+    assert "--interval" in normalized_output
+    assert "Omit blocking-mode root options before service subcommands" in (
+        normalized_output
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Reject explicitly supplied blocking-mode root options before service subcommands so `keep-gpu --gpu-ids 0 start` cannot silently expand to all visible GPUs.
- Use Click parameter-source metadata so implicit root defaults remain ignored for service commands.
- Document the option-placement contract in AGENTS and a focused plan doc.

## Test Plan
- RED before implementation: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls -q` failed because root options before `start` were ignored.
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rejects_root_blocking_options_before_service_calls tests/test_cli_service_commands.py::test_status_rejects_root_blocking_options_before_service_rpc tests/test_cli_service_commands.py::test_invalid_root_interval_before_subcommand_is_rejected -q` -> 8 passed.
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` -> 126 passed.
- `PYTHONPATH=$PWD/src pytest tests -q` -> 471 passed, 11 skipped.
- `pre-commit run --all-files` -> passed.
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/material and unnav warnings.
- `git diff --check origin/main..HEAD` -> passed.

## Local Review
- Spec compliance subagent: approved, no missing requirements or extra behavior.
- Code quality subagent: found only minor wording/test-surface suggestions; addressed with clearer wording and a non-`start` `status` regression.
- Final code quality subagent: no Critical or Important issues; ready to PR.
