### PR TITLE
[mcp] fix: return jsonrpc parse error envelopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,9 @@ This file defines how coding agents should work in this repository.
 - JSON-RPC handlers must reject explicit request versions other than `"2.0"`
   with `-32600 Invalid Request` for request messages while preserving
   omitted-version legacy/internal calls and silent id-less notifications.
+- HTTP JSON-RPC endpoints (`/` and `/rpc`) must return JSON-RPC envelopes for
+  protocol parse errors, including `jsonrpc`, `id`, and numeric `error.code`;
+  REST routes keep REST-shaped structured JSON errors.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -56,6 +56,9 @@ HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
 same JSON-RPC message shapes at `/rpc`, but it is not a Streamable HTTP MCP
 endpoint.
 
+Malformed HTTP JSON-RPC bodies return a JSON-RPC `-32700 Parse error` envelope
+with `id: null`; REST routes keep REST-shaped JSON errors.
+
 ```bash
 curl -X POST http://127.0.0.1:8765/rpc \
   -H "content-type: application/json" \

--- a/docs/plans/http-jsonrpc-parse-error-envelope.md
+++ b/docs/plans/http-jsonrpc-parse-error-envelope.md
@@ -1,0 +1,35 @@
+# HTTP JSON-RPC Parse Error Envelope Plan
+
+## Background
+
+HTTP `POST /rpc` and `POST /` are JSON-RPC compatibility endpoints. Before this
+fix, malformed JSON bodies were rejected by the shared HTTP body parser before
+the handler distinguished REST from JSON-RPC routes, so JSON-RPC clients saw a
+REST-shaped HTTP 400 body such as `{"error":{"message":"Bad request: ..."}}`.
+That body has no `jsonrpc`, `id`, or numeric JSON-RPC error code.
+
+## Solution
+
+Keep REST `/api/sessions` parse failures as structured HTTP 400 errors, but map
+parse failures on `/` and `/rpc` to a JSON-RPC parse-error envelope:
+`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"..."}}`.
+
+## Tasks
+
+- [x] Add a failing HTTP JSON-RPC regression test for malformed `/rpc` JSON.
+- [x] Confirm the test fails before implementation.
+- [x] Return `_jsonrpc_error(None, JSONRPC_PARSE_ERROR, ...)` for `/` and `/rpc`
+      parse failures.
+- [x] Document JSON-RPC parse-error envelopes in the MCP guide and POST handler
+      docstring.
+- [x] Update `AGENTS.md` with the protocol boundary guideline.
+- [x] Run targeted tests and `git diff --check`.
+- [x] Commit with `fix(mcp): return jsonrpc parse error envelopes`.
+
+## Verification Notes
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_jsonrpc_parse_error_returns_jsonrpc_envelope -q` failed because the route returned HTTP 400.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_jsonrpc_parse_error_returns_jsonrpc_envelope -q` passed after routing `/` and `/rpc` parse failures through the JSON-RPC envelope path.
+- Final targeted suite: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with 51 tests.
+- Broader MCP suite: `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with 142 tests.
+- Hygiene: `pre-commit run --all-files`, `PYTHONPATH=$PWD/src mkdocs build`, and `git diff --check` passed.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -888,10 +888,10 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):  # noqa: N802
         """
-        Handle an HTTP JSON-RPC request and write a JSON response.
+        Handle HTTP JSON-RPC and REST session POST requests.
 
-        Expects application/json bodies containing {"method", "params", "id"}.
-        Returns 400 with an error object if parsing fails.
+        JSON-RPC parse failures return JSON-RPC parse-error envelopes. REST
+        session parse failures return HTTP 400 with a structured error object.
         """
         parsed = urlparse(self.path)
         path = parsed.path
@@ -914,6 +914,11 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 UnicodeDecodeError,
                 TypeError,
             ) as exc:
+                if path in ("/", "/rpc"):
+                    self._json_response(
+                        200, _jsonrpc_error(None, JSONRPC_PARSE_ERROR, str(exc))
+                    )
+                    return
                 self._json_response(400, {"error": {"message": f"Bad request: {exc}"}})
                 return
 

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -103,6 +103,25 @@ def _request_raw(method, url, data=None):
         return exc.code, json.loads(body) if body else {}
 
 
+@pytest.mark.parametrize("rpc_path", ["/", "/rpc"])
+def test_http_jsonrpc_parse_error_returns_jsonrpc_envelope(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_raw("POST", f"{base}{rpc_path}", b"{")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] is None
+    assert payload["error"]["code"] == -32700
+
+
 def test_http_health_and_static_index():
     server = make_server()
 


### PR DESCRIPTION
## Summary
- Return JSON-RPC `-32700 Parse error` envelopes for malformed HTTP JSON-RPC bodies on `/` and `/rpc`.
- Keep REST `/api/sessions` malformed-body errors as structured HTTP 400 responses.
- Document the protocol boundary in AGENTS, the MCP guide, and a focused plan doc.

## Test Plan
- RED before implementation: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_jsonrpc_parse_error_returns_jsonrpc_envelope -q` failed because `/rpc` returned HTTP 400.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_jsonrpc_parse_error_returns_jsonrpc_envelope -q` -> 2 passed for `/` and `/rpc`.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` -> 51 passed.
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 142 passed.
- `PYTHONPATH=$PWD/src pytest tests -q` -> 474 passed, 11 skipped.
- `pre-commit run --all-files` -> passed.
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/material and unnav warnings.
- `git diff --check origin/main..HEAD` -> passed.

## Local Review
- Spec compliance subagent: approved; no missing requirements or extra behavior.
- Code quality subagent: no Critical or Important issues. Minor docstring/MCP-guide polish was addressed before PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP JSON-RPC endpoints now return a proper JSON-RPC parse-error response for malformed request bodies, including the expected error code and `id: null`.
  * REST endpoints continue to return structured REST-style JSON errors for invalid input.

* **Documentation**
  * Updated the HTTP JSON-RPC guidance to reflect the revised error behavior.
  * Added implementation notes and verification guidance for the new parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->