### PR TITLE
[cli] fix: require live service-stop status check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ This file defines how coding agents should work in this repository.
   has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
   must propagate synchronously so services cannot register false active sessions.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
+- Non-force `keep-gpu service-stop` must require a reachable service and a successful status/RPC check before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
 - Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.

--- a/docs/plans/cli-service-stop-require-live-status.md
+++ b/docs/plans/cli-service-stop-require-live-status.md
@@ -1,0 +1,50 @@
+# CLI Service Stop Live Status Plan
+
+## Background
+
+`keep-gpu service-stop` currently skips the status RPC when `_service_available()`
+returns false, then still calls `_stop_service_process()` in non-force mode. That
+can signal an ownership-verified auto-started daemon without first proving there
+are no tracked keep sessions.
+
+## Goal
+
+Require non-force `service-stop` to reach the service and complete the active
+session status check before it can signal the managed daemon.
+
+## Solution
+
+- Keep `service-stop --force` unchanged: it may call `_stop_service_process()`
+  directly, subject to ownership verification.
+- In non-force mode, fail fast when the service is unavailable and tell users to
+  use `keep-gpu service-stop --force` for an unresponsive auto-started daemon.
+- Preserve the reachable-service paths: reject active sessions, or stop sessions
+  by RPC and then stop the managed daemon when no active jobs are tracked.
+
+## Tasks
+
+- [x] Add a failing regression test proving unavailable non-force
+      `service-stop` does not call `_stop_service_process()`.
+- [x] Run the focused regression test and confirm it fails on current behavior.
+- [x] Add the minimal CLI guard for unavailable non-force service-stop.
+- [x] Add the concise `AGENTS.md` safety guideline.
+- [x] Run the focused and requested regression checks.
+- [x] Commit the scoped change.
+
+## Verification Notes
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_service_stop_requires_live_status_without_force -q`
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_service_stop_requires_live_status_without_force -q`
+- Focused file: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+- Broader CLI checks: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+- Diff hygiene: `git diff --check`
+
+## Verification Results
+
+- RED focused test failed before implementation because non-force
+  `service-stop` reached `_stop_service_process()` when the service was
+  unavailable.
+- GREEN focused test passed after adding the non-force live-service guard.
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed.
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed.
+- `git diff --check` passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -929,14 +929,19 @@ def service_stop(
             )
             return
 
-        if _service_available(host, port):
-            status = _rpc_call("status", {}, host, port)
-            active_jobs = status.get("active_jobs", [])
-            if active_jobs:
-                raise RuntimeError(
-                    "Tracked keep sessions detected. Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
-                )
-            _rpc_call("stop_keep", {}, host, port, timeout=45.0)
+        if not _service_available(host, port):
+            raise RuntimeError(
+                f"KeepGPU service is unavailable at {host}:{port}. Non-force service-stop must verify no tracked keep sessions before stopping the daemon. "
+                "For an unresponsive auto-started daemon, run `keep-gpu service-stop --force`."
+            )
+
+        status = _rpc_call("status", {}, host, port)
+        active_jobs = status.get("active_jobs", [])
+        if active_jobs:
+            raise RuntimeError(
+                "Tracked keep sessions detected. Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
+            )
+        _rpc_call("stop_keep", {}, host, port, timeout=45.0)
 
         stopped = _stop_service_process(host, port)
         if not stopped:

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -929,13 +929,14 @@ def service_stop(
             )
             return
 
-        if not _service_available(host, port):
+        try:
+            status = _rpc_call("status", {}, host, port)
+        except ServiceUnreachableError as exc:
             raise RuntimeError(
                 f"KeepGPU service is unavailable at {host}:{port}. Non-force service-stop must verify no tracked keep sessions before stopping the daemon. "
                 "For an unresponsive auto-started daemon, run `keep-gpu service-stop --force`."
-            )
+            ) from exc
 
-        status = _rpc_call("status", {}, host, port)
         active_jobs = status.get("active_jobs", [])
         if active_jobs:
             raise RuntimeError(

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -962,13 +962,37 @@ def test_start_prints_dashboard_and_stop_hints(monkeypatch):
 
 
 def test_service_stop_requires_managed_pid(monkeypatch):
-    monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        return {"stopped": []}
+
+    monkeypatch.setattr(cli, "_service_available", lambda host, port: True)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
     monkeypatch.setattr(cli, "_stop_service_process", lambda host, port: False)
 
     result = runner.invoke(cli.app, ["service-stop"])
 
     assert result.exit_code == 1
     assert "No managed daemon PID found" in result.output
+
+
+def test_service_stop_requires_live_status_without_force(monkeypatch):
+    called = {"stop_process": False}
+
+    def fail_stop_process(host, port):
+        called["stop_process"] = True
+        raise AssertionError("_stop_service_process must not be called")
+
+    monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
+    monkeypatch.setattr(cli, "_stop_service_process", fail_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert "service-stop --force" in result.output
+    assert called["stop_process"] is False
+    assert "Traceback" not in result.output
 
 
 def test_service_stop_refuses_active_sessions_without_force(monkeypatch):

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -984,7 +984,10 @@ def test_service_stop_requires_live_status_without_force(monkeypatch):
         called["stop_process"] = True
         raise AssertionError("_stop_service_process must not be called")
 
-    monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
+    def fake_rpc(*args, **kwargs):
+        raise cli.ServiceUnreachableError("mocked unreachable")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
     monkeypatch.setattr(cli, "_stop_service_process", fail_stop_process)
 
     result = runner.invoke(cli.app, ["service-stop"])


### PR DESCRIPTION
## Summary
- require non-force `keep-gpu service-stop` to reach the service and verify status before signaling a managed daemon
- preserve `service-stop --force` for unresponsive auto-started daemons
- add regression coverage plus plan/AGENTS guidance for the safety rule

## Local verification
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> 116 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py -q` -> 12 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` -> 128 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 475 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/unnav warnings
- `git diff --check` -> passed

## Local subagent review
- Spec review: approved, no must-fix findings
- Quality/reliability review: approved, no must-fix findings
