### PR TITLE
[mcp] fix: reject invalid content length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ This file defines how coding agents should work in this repository.
 - HTTP JSON-RPC endpoints (`/` and `/rpc`) must return JSON-RPC envelopes for
   protocol parse errors, including `jsonrpc`, `id`, and numeric `error.code`;
   REST routes keep REST-shaped structured JSON errors.
+- HTTP body readers must validate `Content-Length` as a non-negative integer
+  before reading; invalid values must fail quickly with REST JSON 400 errors or
+  JSON-RPC `-32700` parse-error envelopes.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/plans/http-reject-negative-content-length.md
+++ b/docs/plans/http-reject-negative-content-length.md
@@ -1,0 +1,46 @@
+# HTTP Reject Negative Content-Length Plan
+
+## Background
+
+HTTP `POST` handling reads JSON request bodies through `_read_json_body()`.
+Before this fix, the helper converted `Content-Length` with `int()` and then
+passed the value directly to `self.rfile.read()`. `Content-Length: -1` therefore
+became `read(-1)`, which can wait until the client closes the socket and tie up
+a server thread instead of returning a parseable protocol error.
+
+## Solution
+
+Validate `Content-Length` as a non-negative integer before any body read.
+Negative or non-integer values should use the existing parse-failure routing:
+REST `/api/sessions` returns HTTP 400 with a structured JSON error, while
+JSON-RPC `/` and `/rpc` return a JSON-RPC parse-error envelope with
+`jsonrpc: "2.0"`, `id: null`, and `error.code == -32700`. Keep the existing
+oversized-body check and message after the length is proven non-negative.
+
+## Tasks
+
+- [x] Add raw-socket regression tests that keep the client socket open and
+      prove negative `Content-Length` receives a quick response.
+- [x] Run the focused negative `Content-Length` tests before implementation and
+      confirm they fail by timing out.
+- [x] Add minimal `_read_json_body()` validation for negative and non-integer
+      `Content-Length` values.
+- [x] Update `AGENTS.md` with a concise body-length validation guideline.
+- [x] Run focused and MCP test suites plus `git diff --check`.
+- [x] Commit with `fix(mcp): reject invalid content length`.
+
+## Verification Notes
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_sessions_rejects_negative_content_length_without_client_close tests/mcp/test_http_api.py::test_http_jsonrpc_rejects_negative_content_length_with_parse_error -q`
+  failed with 3 timeout assertions, proving negative `Content-Length` waited for
+  client close before the fix.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_sessions_rejects_negative_content_length_without_client_close tests/mcp/test_http_api.py::test_http_jsonrpc_rejects_negative_content_length_with_parse_error -q`
+  passed with 3 tests.
+- Final targeted suite:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with 56
+  tests.
+- Broader MCP suite: `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with 147
+  tests.
+- Hygiene: `git diff --check` passed.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -792,7 +792,13 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         )
 
     def _read_json_body(self) -> Any:
-        length = int(self.headers.get("content-length", "0"))
+        raw_length = self.headers.get("content-length", "0")
+        try:
+            length = int(raw_length)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Content-Length must be a non-negative integer") from exc
+        if length < 0:
+            raise ValueError("Content-Length must be a non-negative integer")
         if length > MAX_JSON_BODY_BYTES:
             raise ValueError(
                 f"Request body too large: {length} bytes (max {MAX_JSON_BODY_BYTES})"

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -116,8 +116,8 @@ def _raw_post_with_content_length(httpd, path: str, content_length: str):
         "{}"
     ).encode("ascii")
 
-    with socket.create_connection((host, port), timeout=0.5) as sock:
-        sock.settimeout(0.5)
+    with socket.create_connection((host, port), timeout=2.0) as sock:
+        sock.settimeout(2.0)
         sock.sendall(request)
 
         chunks = []

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -1,5 +1,6 @@
 import json
 import math
+import socket
 import threading
 from typing import Any, cast
 from urllib.error import HTTPError
@@ -103,6 +104,42 @@ def _request_raw(method, url, data=None):
         return exc.code, json.loads(body) if body else {}
 
 
+def _raw_post_with_content_length(httpd, path: str, content_length: str):
+    host, port = httpd.server_address
+    request = (
+        f"POST {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {content_length}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+        "{}"
+    ).encode("ascii")
+
+    with socket.create_connection((host, port), timeout=0.5) as sock:
+        sock.settimeout(0.5)
+        sock.sendall(request)
+
+        chunks = []
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout as exc:
+                raise AssertionError(
+                    "HTTP response timed out before the client closed the socket"
+                ) from exc
+            if not chunk:
+                break
+            chunks.append(chunk)
+
+    response = b"".join(chunks)
+    assert response
+    header_bytes, body = response.split(b"\r\n\r\n", 1)
+    status_line = header_bytes.splitlines()[0].decode("iso-8859-1")
+    status_code = int(status_line.split()[1])
+    return status_code, json.loads(body.decode("utf-8")) if body else {}
+
+
 @pytest.mark.parametrize("rpc_path", ["/", "/rpc"])
 def test_http_jsonrpc_parse_error_returns_jsonrpc_envelope(rpc_path):
     server = make_server()
@@ -120,6 +157,76 @@ def test_http_jsonrpc_parse_error_returns_jsonrpc_envelope(rpc_path):
     assert payload["jsonrpc"] == "2.0"
     assert payload["id"] is None
     assert payload["error"]["code"] == -32700
+
+
+def test_http_post_sessions_rejects_negative_content_length_without_client_close():
+    server = make_server()
+    httpd, thread, _ = _start_threaded_http_server(server)
+
+    try:
+        status, payload = _raw_post_with_content_length(httpd, "/api/sessions", "-1")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 400
+    assert (
+        "Content-Length must be a non-negative integer" in payload["error"]["message"]
+    )
+    assert server.status()["active_jobs"] == []
+
+
+@pytest.mark.parametrize("rpc_path", ["/", "/rpc"])
+def test_http_jsonrpc_rejects_negative_content_length_with_parse_error(rpc_path):
+    server = make_server()
+    httpd, thread, _ = _start_threaded_http_server(server)
+
+    try:
+        status, payload = _raw_post_with_content_length(httpd, rpc_path, "-1")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] is None
+    assert payload["error"]["code"] == -32700
+    assert (
+        "Content-Length must be a non-negative integer" in payload["error"]["message"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_status"),
+    [
+        ("/api/sessions", 400),
+        ("/rpc", 200),
+    ],
+)
+def test_http_post_rejects_non_integer_content_length(path, expected_status):
+    server = make_server()
+    httpd, thread, _ = _start_threaded_http_server(server)
+
+    try:
+        status, payload = _raw_post_with_content_length(httpd, path, "abc")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == expected_status
+    assert "Content-Length must be a non-negative integer" in (
+        payload["error"]["message"]
+    )
+    if path == "/rpc":
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] is None
+        assert payload["error"]["code"] == -32700
 
 
 def test_http_health_and_static_index():


### PR DESCRIPTION
Summary:
- Validate HTTP Content-Length before reading JSON bodies.
- Return REST 400 JSON errors or JSON-RPC -32700 parse-error envelopes for invalid lengths.
- Add raw-socket regressions for negative lengths without client half-close.

Verification:
- PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_post_sessions_rejects_negative_content_length_without_client_close tests/mcp/test_http_api.py::test_http_jsonrpc_rejects_negative_content_length_with_parse_error -q
- PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q
- PYTHONPATH=$PWD/src pytest tests/mcp -q
- git diff --check
- pre-commit run --all-files