### PR TITLE
[cli] fix: validate start job id response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,10 @@ This file defines how coding agents should work in this repository.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
+- CLI commands that consume service-specific JSON-RPC results must validate
+  required result fields before rendering user-facing output; malformed
+  method-specific payloads should become clean `ServiceResponseError` messages,
+  not `KeyError`, tracebacks, or partial success text.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`

--- a/docs/plans/cli-validate-start-job-id.md
+++ b/docs/plans/cli-validate-start-job-id.md
@@ -1,0 +1,40 @@
+# CLI Start Job ID Response Validation Plan
+
+## Background
+
+`keep-gpu start` calls `_rpc_call("start_keep", ...)`, which validates the
+generic JSON-RPC envelope and ensures the top-level `result` is an object. The
+CLI then indexes `result["job_id"]` directly, so a buggy or hostile service can
+return `{}`, `{"job_id": 123}`, or `{"job_id": ""}` and make the CLI leak a
+raw exception or print unusable guidance.
+
+## Goal/Solution
+
+Reject malformed `start_keep` success payloads before rendering the start
+success text. Keep valid service starts unchanged, but convert missing,
+non-string, or empty `job_id` values into a clean `ServiceResponseError`.
+
+## Tasks
+
+- [x] Confirm the provided worktree is isolated on
+      `codex/cli-validate-start-job-id`.
+- [x] Add RED CLI regressions for missing, non-string, and empty `job_id`
+      values returned by `start_keep`.
+- [x] Preserve valid start-output expectations for a normal string `job_id`.
+- [x] Implement minimal `start_keep` result validation in `src/keep_gpu/cli.py`.
+- [x] Run focused RED, then GREEN, then requested verification commands.
+- [x] Commit with `fix(cli): validate start job id response`.
+
+## Verification Notes/Results
+
+- RED focused tests:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_command_rejects_malformed_job_id_result tests/test_cli_service_commands.py::test_start_prints_dashboard_and_stop_hints -q`,
+  `3 failed, 1 passed`; malformed `start_keep` results leaked `KeyError` or
+  exited successfully before validation.
+- GREEN focused tests:
+  same command, `4 passed`.
+- Requested shard `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`:
+  `119 passed`.
+- Requested shard `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py -q`:
+  `12 passed`.
+- `git diff --check`: passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -812,16 +812,14 @@ def start(
             port,
         )
         result_job_id = result.get("job_id")
-        try:
-            result_job_id = validate_job_id(result_job_id)
-        except ValueError as exc:
-            raise ServiceResponseError(
-                "Malformed JSON-RPC response: start_keep result must include job_id"
-            ) from exc
         if result_job_id is None:
             raise ServiceResponseError(
                 "Malformed JSON-RPC response: start_keep result must include job_id"
             )
+        try:
+            result_job_id = validate_job_id(result_job_id)
+        except ValueError as exc:
+            raise ServiceResponseError(f"Malformed JSON-RPC response: {exc}") from exc
         if auto_started:
             console.print(
                 f"[bold cyan]Auto-started KeepGPU service[/bold cyan] at http://{host}:{port}/"

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -811,16 +811,27 @@ def start(
             host,
             port,
         )
+        result_job_id = result.get("job_id")
+        try:
+            result_job_id = validate_job_id(result_job_id)
+        except ValueError as exc:
+            raise ServiceResponseError(
+                "Malformed JSON-RPC response: start_keep result must include job_id"
+            ) from exc
+        if result_job_id is None:
+            raise ServiceResponseError(
+                "Malformed JSON-RPC response: start_keep result must include job_id"
+            )
         if auto_started:
             console.print(
                 f"[bold cyan]Auto-started KeepGPU service[/bold cyan] at http://{host}:{port}/"
             )
         console.print(
-            f"[bold green]Started keep session[/bold green] job_id={result['job_id']}"
+            f"[bold green]Started keep session[/bold green] job_id={result_job_id}"
         )
         console.print(f"[cyan]Dashboard:[/cyan] http://{host}:{port}/")
         console.print(
-            f"[dim]Next: keep-gpu status --job-id {result['job_id']} | keep-gpu stop --job-id {result['job_id']}[/dim]"
+            f"[dim]Next: keep-gpu status --job-id {result_job_id} | keep-gpu stop --job-id {result_job_id}[/dim]"
         )
         console.print(
             "[dim]When all sessions are done, stop daemon with: keep-gpu service-stop[/dim]"

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -83,6 +83,24 @@ def test_start_command_uses_rpc(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "rpc_result",
+    [{}, {"job_id": 123}, {"job_id": ""}, {"job_id": "   "}, {"job_id": "bad id"}],
+)
+def test_start_command_rejects_malformed_job_id_result(monkeypatch, rpc_result):
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_rpc_call", lambda *args, **kwargs: rpc_result)
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert (
+        "Malformed JSON-RPC response: start_keep result must include job_id"
+        in result.output
+    )
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
     "root_args",
     [
         ["--gpu-ids", "0"],
@@ -957,7 +975,10 @@ def test_start_prints_dashboard_and_stop_hints(monkeypatch):
 
     assert result.exit_code == 0
     assert "Auto-started KeepGPU service" in result.output
+    assert "job_id=job-abc" in result.output
     assert "Dashboard:" in result.output
+    assert "keep-gpu status --job-id job-abc" in result.output
+    assert "keep-gpu stop --job-id job-abc" in result.output
     assert "keep-gpu service-stop" in result.output
 
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -83,20 +83,41 @@ def test_start_command_uses_rpc(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "rpc_result",
-    [{}, {"job_id": 123}, {"job_id": ""}, {"job_id": "   "}, {"job_id": "bad id"}],
+    ("rpc_result", "expected_message"),
+    [
+        ({}, "Malformed JSON-RPC response: start_keep result must include job_id"),
+        (
+            {"job_id": None},
+            "Malformed JSON-RPC response: start_keep result must include job_id",
+        ),
+        (
+            {"job_id": 123},
+            "Malformed JSON-RPC response: job_id must be a URL-path-safe non-empty string",
+        ),
+        (
+            {"job_id": ""},
+            "Malformed JSON-RPC response: job_id must be a URL-path-safe non-empty string",
+        ),
+        (
+            {"job_id": "   "},
+            "Malformed JSON-RPC response: job_id must be a URL-path-safe non-empty string",
+        ),
+        (
+            {"job_id": "bad id"},
+            "Malformed JSON-RPC response: job_id must be a URL-path-safe non-empty string",
+        ),
+    ],
 )
-def test_start_command_rejects_malformed_job_id_result(monkeypatch, rpc_result):
+def test_start_command_rejects_malformed_job_id_result(
+    monkeypatch, rpc_result, expected_message
+):
     monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_rpc_call", lambda *args, **kwargs: rpc_result)
 
     result = runner.invoke(cli.app, ["start"])
 
     assert result.exit_code == 1
-    assert (
-        "Malformed JSON-RPC response: start_keep result must include job_id"
-        in result.output
-    )
+    assert expected_message in " ".join(result.output.split())
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Summary
- validate `start_keep` method-specific `job_id` before `keep-gpu start` prints success
- reject missing, non-string, empty, whitespace-only, and path-unsafe IDs as clean `ServiceResponseError` CLI failures
- add regression coverage plus plan/AGENTS guidance for method-specific service result validation

## Local verification
- RED expanded regression: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_command_rejects_malformed_job_id_result -q` failed for whitespace/path-unsafe IDs before the follow-up fix
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` -> 133 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 485 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing MkDocs/unnav warnings
- `git diff --check` -> passed

## Local subagent review
- Spec review: approved, no must-fix findings
- Quality/reliability review: initially requested shared job-id contract validation; fixed with `validate_job_id`, re-reviewed and approved
