### PR TITLE
[cli] fix: label unconditional threshold logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,9 @@ This file defines how coding agents should work in this repository.
   as `0%` idle; aggregate utilization summaries must ignore unavailable readings
   and show `n/a` when no finite readings exist, and per-GPU utilization bars
   must not render an idle fill for unavailable telemetry.
-- Dashboard labels for sentinel values must render semantic meaning instead of
-  raw numeric shapes; for example, `busy_threshold=-1` is unconditional
-  keepalive mode, not `-1%` utilization.
+- Dashboard labels, CLI logs, and other user-facing sentinel renderings must
+  show semantic meaning instead of raw numeric shapes; for example,
+  `busy_threshold=-1` is unconditional keepalive mode, not `-1%` utilization.
 - Single-GPU keep workload iteration counts must be positive integers (`relu_iterations` for CUDA, `iterations` for ROCm/Mac M); reject invalid values before keep loops so no public path can create a silent no-op keeper or late background thread crash.
 - ROCm optional allocation retry counts must be `None` or positive plain
   integers; reject invalid values before worker startup so background retry

--- a/docs/plans/cli-unconditional-threshold-log.md
+++ b/docs/plans/cli-unconditional-threshold-log.md
@@ -1,0 +1,67 @@
+# CLI Unconditional Threshold Log Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make blocking-mode CLI logs describe `busy_threshold=-1` as unconditional mode instead of rendering it as `-1%`.
+
+**Architecture:** Keep validation and controller behavior unchanged. Add only a narrow log-formatting path in `src/keep_gpu/cli.py`, with focused CLI coverage in `tests/test_cli_thresholds.py`.
+
+**Tech Stack:** Python, Typer CLI, pytest, standard logging capture by way of `caplog`.
+
+---
+
+## Background
+
+Blocking mode currently validates `busy_threshold` and then logs it with
+`logger.info("Busy threshold: %s%%", busy_threshold)`. That is correct for normal
+percentage thresholds such as `25`, but misleading for the sentinel value `-1`,
+which means explicit unconditional keepalive mode with utilization backoff
+disabled.
+
+The existing product guidance already treats sentinel values as semantic labels
+for dashboard UI. This change applies the same clarity to blocking-mode CLI logs
+without changing CLI validation or controller inputs.
+
+## Solution
+
+- Add a focused failing test around `_run_blocking(..., busy_threshold=-1)` that
+  proves the log contains semantic unconditional wording and does not contain
+  `Busy threshold: -1%`.
+- Cover the normal threshold path so `busy_threshold=25` still logs `25%`.
+- Update the CLI logging line to format only `-1` semantically and keep
+  non-negative thresholds as percentages.
+- Add a CLI-focused sentinel-log note to `AGENTS.md` if the existing dashboard
+  note is too narrow.
+
+## Tasks
+
+- [x] Add the RED test in `tests/test_cli_thresholds.py`.
+- [x] Run the focused test and record the expected failure.
+- [x] Implement the minimal CLI logging formatter/change in `src/keep_gpu/cli.py`.
+- [x] Update `AGENTS.md` with blocking-mode log guidance.
+- [x] Run:
+  - `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py -q`
+  - `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  - `git diff --check`
+  - `pre-commit run --all-files` if available and cheap
+- [x] Commit with `fix(cli): label unconditional threshold logs`.
+
+## Verification Notes
+
+- RED focused test:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py::test_run_blocking_logs_busy_threshold_semantically -q`
+  failed before the production change because captured logs contained
+  `Busy threshold: -1%` instead of the semantic unconditional message.
+- GREEN focused test:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py::test_run_blocking_logs_busy_threshold_semantically -q`
+  passed with 2 tests after the CLI log change.
+- Full threshold suite:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py -q` passed with
+  14 tests.
+- Relevant CLI suite:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with 136 tests.
+- Hygiene:
+  `git diff --check` passed, and `pre-commit run --all-files` passed.
+- The final diff avoids controller behavior changes and keeps all changes scoped
+  to CLI logging, tests, docs guidance, and this plan.

--- a/docs/plans/cli-unconditional-threshold-log.md
+++ b/docs/plans/cli-unconditional-threshold-log.md
@@ -44,6 +44,8 @@ without changing CLI validation or controller inputs.
   - `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
   - `git diff --check`
   - `pre-commit run --all-files` if available and cheap
+- [x] Strengthen the hosted-review follow-up assertion so forbidden messages
+      are checked as substrings of captured log entries.
 - [x] Commit with `fix(cli): label unconditional threshold logs`.
 
 ## Verification Notes
@@ -63,5 +65,9 @@ without changing CLI validation or controller inputs.
   passed with 136 tests.
 - Hygiene:
   `git diff --check` passed, and `pre-commit run --all-files` passed.
+- Hosted review follow-up:
+  Gemini noted the forbidden-message check needed substring matching. The test
+  now checks `expected_message` and `forbidden_message` against captured log
+  entry substrings before re-running verification.
 - The final diff avoids controller behavior changes and keeps all changes scoped
   to CLI logging, tests, docs guidance, and this plan.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -655,7 +655,10 @@ def _run_blocking(
     logger.info("GPU count: %s", gpu_count)
     logger.info("VRAM to keep occupied: %s", vram)
     logger.info("Check interval: %s seconds", interval)
-    logger.info("Busy threshold: %s%%", busy_threshold)
+    if busy_threshold == -1:
+        logger.info("Busy threshold: unconditional (utilization backoff disabled)")
+    else:
+        logger.info("Busy threshold: %s%%", busy_threshold)
 
     global_controller = GlobalGPUController(
         gpu_ids=gpu_id_list,

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -140,3 +141,58 @@ def test_run_blocking_preserves_cuda_visible_devices_for_gpu_ids(monkeypatch):
         "entered": True,
         "exited": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("busy_threshold", "expected_message", "forbidden_message"),
+    [
+        (
+            -1,
+            "Busy threshold: unconditional (utilization backoff disabled)",
+            "Busy threshold: -1%",
+        ),
+        (25, "Busy threshold: 25%", "unconditional"),
+    ],
+)
+def test_run_blocking_logs_busy_threshold_semantically(
+    monkeypatch, caplog, busy_threshold, expected_message, forbidden_message
+):
+    class DummyGlobalController:
+        def __init__(self, *, gpu_ids, interval, vram_to_keep, busy_threshold):
+            self.gpu_ids = gpu_ids
+            self.interval = interval
+            self.vram_to_keep = vram_to_keep
+            self.busy_threshold = busy_threshold
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    import keep_gpu.global_gpu_controller.global_gpu_controller as global_module
+
+    monkeypatch.setattr(global_module, "GlobalGPUController", DummyGlobalController)
+
+    def interrupt_sleep(_seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli.time, "sleep", interrupt_sleep)
+    monkeypatch.setattr(cli.logger, "propagate", True)
+    caplog.set_level(logging.INFO, logger=cli.logger.name)
+
+    cli._run_blocking(
+        interval=1,
+        gpu_ids="0",
+        vram="1MiB",
+        legacy_threshold=None,
+        busy_threshold=busy_threshold,
+    )
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == cli.logger.name
+    ]
+    assert expected_message in messages
+    assert forbidden_message not in messages

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -194,5 +194,5 @@ def test_run_blocking_logs_busy_threshold_semantically(
         for record in caplog.records
         if record.name == cli.logger.name
     ]
-    assert expected_message in messages
-    assert forbidden_message not in messages
+    assert any(expected_message in message for message in messages)
+    assert not any(forbidden_message in message for message in messages)


### PR DESCRIPTION
## Summary
- Render blocking-mode `busy_threshold=-1` logs as semantic unconditional/backoff-disabled text instead of `-1%`.
- Preserve normal threshold logs such as `25%` and leave validation/controller inputs unchanged.
- Update AGENTS.md and add a plan doc for the fix.

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py::test_run_blocking_logs_busy_threshold_semantically -q` failed before the fix with `Busy threshold: -1%`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py::test_run_blocking_logs_busy_threshold_semantically -q` (2 passed)
- `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py -q` (14 passed)
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` (136 passed)
- `PYTHONPATH=$PWD/src pytest tests -q` (488 passed, 11 skipped)
- `PYTHONPATH=$PWD/src mkdocs build` (built; existing MkDocs/material + unnav'd plan warnings only)
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`

## Local review
- Spec reviewer: APPROVED; no must-fix gaps, controller/validation untouched.
- Quality reviewer: APPROVED; no important issues, scoped to human-facing logging.