### PR TITLE
[mcp] fix: classify startup unavailable errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ This file defines how coding agents should work in this repository.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
+- Expected controller startup unavailability, such as no usable visible GPUs or
+  unsupported platforms, must surface as explicit startup-unavailable errors
+  (direct JSON-RPC `-32000`, REST `503`, MCP tool `isError=true`) while
+  arbitrary unexpected startup/runtime failures remain internal errors.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - CLI commands that consume service-specific JSON-RPC results must validate

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -86,13 +86,19 @@ Successful direct-method responses are KeepGPU JSON-RPC envelopes with
 `jsonrpc: "2.0"`, the matching request `id`, and an object `result`.
 
 For direct JSON-RPC calls, public validation failures and unknown parameters
-return JSON-RPC `-32602 Invalid params`. Unexpected server failures use
+return JSON-RPC `-32602 Invalid params`. Expected startup-unavailable
+conditions, such as an unsupported controller platform or no usable visible
+GPUs, return `-32000` with the startup message. Unexpected server failures use
 `-32603 Internal error`.
+
+MCP `tools/call` responses keep protocol envelopes successful. If a tool cannot
+start because hardware or the platform is unavailable, the response contains
+`result.isError=true` and the startup-unavailable text in the tool content.
 
 For supported REST route/method calls, service errors stay parseable. Public
 validation failures return JSON `400` responses, unknown API routes return JSON
-`404`, and unexpected runtime failures return JSON `500` responses with an
-`error` object.
+`404`, expected startup-unavailable session creation returns JSON `503`, and
+unexpected runtime failures return JSON `500` responses with an `error` object.
 
 REST session creation accepts a JSON object body, not arrays or scalar values.
 Omitting `gpu_ids` means all GPUs visible to the service process. Omitting

--- a/docs/plans/controller-startup-unavailable-errors.md
+++ b/docs/plans/controller-startup-unavailable-errors.md
@@ -1,0 +1,105 @@
+# Controller Startup Unavailable Errors Plan
+
+## Background
+
+`GlobalGPUController` currently raises broad Python exceptions for two expected
+startup-unavailable cases: unsupported platforms raise `NotImplementedError`,
+and zero resolved visible GPUs raises `ValueError`. `KeepGPUServer.start_keep()`
+cleans up reserved starting state and re-raises those exceptions. Direct
+JSON-RPC then maps them through the generic `_handle_request()` defensive catch
+as `-32603 Internal error`, while REST `POST /api/sessions` returns HTTP 500.
+
+Existing tests intentionally preserve arbitrary startup/runtime `ValueError`,
+`TypeError`, and `RuntimeError` as internal errors. This fix must keep that
+boundary: only expected hardware/platform unavailability is public
+startup-unavailable state.
+
+## Goal
+
+Expected startup-unavailable conditions should be explicit and parseable:
+direct JSON-RPC returns `-32000`, REST session creation returns HTTP 503, MCP
+`tools/call` returns `result.isError=true`, and no failed start leaves an active
+session behind. Unexpected runtime failures remain internal.
+
+## Solution
+
+- Add controller-domain exceptions in
+  `src/keep_gpu/global_gpu_controller/global_gpu_controller.py`.
+- Raise those exceptions for unsupported controller platforms and zero visible
+  GPU resolution, while preserving compatibility with existing
+  `NotImplementedError` and `ValueError` expectations through multiple
+  inheritance.
+- Add a service-domain `SessionStartupUnavailable` in
+  `src/keep_gpu/mcp/server.py`.
+- Wrap `ControllerStartupUnavailable` raised during `start_keep()` into
+  `SessionStartupUnavailable`.
+- Map `SessionStartupUnavailable` to direct JSON-RPC
+  `JSONRPC_STARTUP_UNAVAILABLE = -32000` and REST HTTP 503 structured errors.
+- Leave `SessionInputError` as JSON-RPC `-32602`/REST 400 and arbitrary
+  exceptions as JSON-RPC `-32603`/REST 500.
+
+## Tasks
+
+- [x] Add direct JSON-RPC tests for custom `SessionStartupUnavailable`, real
+  CPU/unsupported platform startup, real zero-visible-GPU startup, and
+  continued arbitrary `ValueError` internal behavior.
+- [x] Add MCP `tools/call` test for startup-unavailable tool error text and no
+  active jobs.
+- [x] Add REST `POST /api/sessions` HTTP 503 test for
+  `SessionStartupUnavailable` and preserve existing 500 tests.
+- [x] Run focused RED tests and record failure evidence.
+- [x] Implement controller and service exception mapping.
+- [x] Run focused GREEN tests and record pass evidence.
+- [x] Update `AGENTS.md`, `docs/guides/mcp.md`, and `docs/reference/cli.md`.
+- [x] Run required verification commands and record evidence.
+- [x] Commit with `fix(mcp): classify startup unavailable errors`.
+
+## RED Evidence
+
+Command:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_startup_unavailable_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_unsupported_platform_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_runtime_value_error_remains_internal_error tests/mcp/test_server.py::test_mcp_tools_call_startup_unavailable_returns_tool_error tests/mcp/test_http_api.py::test_http_post_sessions_startup_unavailable_returns_json_503 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_value_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 -q
+```
+
+Result: failed as expected before production changes: 3 failed, 4 passed. The
+custom startup-unavailable JSON-RPC test returned `-32603` instead of `-32000`;
+the real CPU/unsupported-platform JSON-RPC test returned `-32603` instead of
+`-32000`; the REST startup-unavailable test returned HTTP 500 instead of 503.
+The arbitrary `ValueError`/`TypeError` internal-error tests and MCP tool text
+test passed.
+
+## GREEN Evidence
+
+Command:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_startup_unavailable_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_unsupported_platform_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_runtime_value_error_remains_internal_error tests/mcp/test_server.py::test_mcp_tools_call_startup_unavailable_returns_tool_error tests/mcp/test_http_api.py::test_http_post_sessions_startup_unavailable_returns_json_503 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_value_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 -q
+```
+
+Result: passed after implementation: 8 passed. Direct JSON-RPC startup
+unavailability now returns `-32000` for custom service startup failures, real
+unsupported platforms, and real zero-visible-GPU startup. REST startup
+unavailability returns HTTP 503 with `type="SessionStartupUnavailable"`, MCP
+`tools/call` exposes the text as a tool error, and arbitrary
+`ValueError`/`TypeError` cases remain internal.
+
+## Verification Commands
+
+Run in `/root/new_test/KeepGPU/.worktrees/codex/controller-startup-unavailable-errors`:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py tests/global_controller -q
+PYTHONPATH=$PWD/src pytest tests -q
+PYTHONPATH=$PWD/src mkdocs build
+pre-commit run --all-files
+git diff --check
+```
+
+## Verification Evidence
+
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py tests/global_controller -q`: 203 passed, 1 skipped.
+- `PYTHONPATH=$PWD/src pytest tests -q`: 493 passed, 11 skipped.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed. MkDocs reported the existing Material for MkDocs 2.0 warning and existing `docs/plans/*` nav warnings, including this plan file.
+- `pre-commit run --all-files`: initially reformatted `tests/mcp/test_server.py` with Black; rerun passed all hooks.
+- `git diff --check`: passed with no whitespace errors.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -119,10 +119,14 @@ Only omitted/`null` `job_id` values mean generated IDs or all-sessions, dependin
 on the method. Custom IDs must be non-empty strings containing only letters,
 digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
 Supported REST route/method errors are JSON objects: validation errors return
-`400`, unknown API routes return `404`, and unexpected service/runtime failures
-return `500` instead of dropping the connection.
+`400`, unknown API routes return `404`, expected startup-unavailable session
+creation returns `503`, and unexpected service/runtime failures return `500`
+instead of dropping the connection.
 The dashboard consumes those JSON objects and displays `error.message` when it is
 present, falling back to the plain response body or HTTP status only when needed.
+Direct JSON-RPC service calls report the same expected hardware/platform
+startup-unavailable conditions with error code `-32000`; arbitrary runtime
+failures remain `-32603 Internal error`.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -16,6 +16,20 @@ from keep_gpu.utilities.platform_manager import ComputingPlatform, get_platform
 logger = setup_logger(__name__)
 
 
+class ControllerStartupUnavailable(Exception):
+    """Expected hardware/platform unavailability during controller startup."""
+
+
+class NoGPUAvailableError(ControllerStartupUnavailable, ValueError):
+    """No visible GPU devices are available for a global keep session."""
+
+
+class UnsupportedControllerPlatformError(
+    ControllerStartupUnavailable, NotImplementedError
+):
+    """The current platform cannot run the global GPU controller."""
+
+
 def _resolve_visible_gpu_ids(gpu_ids: Optional[List[int]]) -> List[int]:
     visible_count = torch.cuda.device_count()
     if gpu_ids is None:
@@ -62,7 +76,7 @@ class GlobalGPUController:
 
             controller_cls = MacMGPUController
         else:
-            raise NotImplementedError(
+            raise UnsupportedControllerPlatformError(
                 f"GlobalGPUController not implemented for platform {self.computing_platform}"
             )
 
@@ -84,7 +98,7 @@ class GlobalGPUController:
             self.gpu_ids = gpu_ids
 
         if not self.gpu_ids:
-            raise ValueError("No GPUs available for GlobalGPUController")
+            raise NoGPUAvailableError("No GPUs available for GlobalGPUController")
 
         self.controllers = [
             controller_cls(

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -43,7 +43,10 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import unquote, urlparse
 
 from keep_gpu import __version__
-from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.global_gpu_controller.global_gpu_controller import (
+    ControllerStartupUnavailable,
+    GlobalGPUController,
+)
 from keep_gpu.utilities.humanized_input import (
     PUBLIC_VRAM_MAX_BYTES,
     parse_vram_to_elements,
@@ -68,6 +71,7 @@ JSONRPC_INVALID_REQUEST = -32600
 JSONRPC_METHOD_NOT_FOUND = -32601
 JSONRPC_INVALID_PARAMS = -32602
 JSONRPC_INTERNAL_ERROR = -32603
+JSONRPC_STARTUP_UNAVAILABLE = -32000
 MCP_ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
 MCP_ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
 
@@ -175,6 +179,10 @@ class JSONRPCError(Exception):
 
 class SessionInputError(ValueError):
     """Public session input validation error."""
+
+
+class SessionStartupUnavailable(Exception):
+    """Expected session startup failure caused by unavailable hardware/platform."""
 
 
 def _validate_public_session_input(validator: Callable[..., Any], *args: Any) -> Any:
@@ -297,11 +305,13 @@ class KeepGPUServer:
                 busy_threshold=busy_threshold,
             )
             controller.keep()
-        except Exception:
+        except Exception as exc:
             with self._sessions_lock:
                 self._starting_job_ids.discard(job_id)
                 self._starting_params.pop(job_id, None)
                 self._sessions_cond.notify_all()
+            if isinstance(exc, ControllerStartupUnavailable):
+                raise SessionStartupUnavailable(str(exc)) from exc
             raise
 
         with self._sessions_lock:
@@ -625,6 +635,8 @@ def _call_keepgpu_method(
             return server.list_gpus()
     except SessionInputError as exc:
         raise JSONRPCError(JSONRPC_INVALID_PARAMS, str(exc)) from exc
+    except SessionStartupUnavailable as exc:
+        raise JSONRPCError(JSONRPC_STARTUP_UNAVAILABLE, str(exc)) from exc
     raise JSONRPCError(JSONRPC_METHOD_NOT_FOUND, f"Unknown method: {method}")
 
 
@@ -974,6 +986,17 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 except SessionInputError as exc:
                     self._json_response(
                         400, {"error": {"message": f"Bad request: {exc}"}}
+                    )
+                    return
+                except SessionStartupUnavailable as exc:
+                    self._json_response(
+                        503,
+                        {
+                            "error": {
+                                "message": str(exc),
+                                "type": exc.__class__.__name__,
+                            }
+                        },
                     )
                     return
                 self._json_response(200, result)

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -9,7 +9,11 @@ from urllib.request import Request, urlopen
 
 import pytest
 
-from keep_gpu.mcp.server import KeepGPUServer, _JSONRPCHandler
+from keep_gpu.mcp.server import (
+    KeepGPUServer,
+    SessionStartupUnavailable,
+    _JSONRPCHandler,
+)
 
 
 class DummyController:
@@ -992,6 +996,30 @@ def test_http_post_sessions_runtime_value_error_returns_json_500(monkeypatch):
     assert status_code == 500
     assert payload["error"]["message"] == "startup invariant broke"
     assert payload["error"]["type"] == "ValueError"
+
+
+def test_http_post_sessions_startup_unavailable_returns_json_503(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "start_keep",
+        lambda **_: (_ for _ in ()).throw(
+            SessionStartupUnavailable("No usable GPUs are available")
+        ),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("POST", f"{base}/api/sessions", {})
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 503
+    assert payload["error"]["message"] == "No usable GPUs are available"
+    assert payload["error"]["type"] == "SessionStartupUnavailable"
 
 
 def test_http_get_setup_runtime_error_returns_json_500():

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -14,7 +14,9 @@ from keep_gpu.mcp.server import (
     JSONRPC_INTERNAL_ERROR,
     JSONRPC_INVALID_REQUEST,
     JSONRPC_INVALID_PARAMS,
+    JSONRPC_STARTUP_UNAVAILABLE,
     KeepGPUServer,
+    SessionStartupUnavailable,
     _handle_request,
 )
 from keep_gpu.mcp import server as server_module
@@ -540,6 +542,71 @@ def test_jsonrpc_start_keep_runtime_value_error_remains_internal_error():
     assert server.status()["active_jobs"] == []
 
 
+def test_jsonrpc_start_keep_startup_unavailable_returns_public_code():
+    def failing_factory(**kwargs):
+        raise SessionStartupUnavailable("No usable GPUs are available")
+
+    server = KeepGPUServer(controller_factory=cast(Any, failing_factory))
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "no-usable-gpus", "gpu_ids": [0]},
+    }
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+    assert "No usable GPUs are available" in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
+def test_jsonrpc_start_keep_unsupported_platform_returns_public_code(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CPU)
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "unsupported-platform"},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+        assert (
+            "GlobalGPUController not implemented for platform"
+            in resp["error"]["message"]
+        )
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
+def test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code(monkeypatch):
+    import torch
+
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "zero-visible-gpus"},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+        assert "No GPUs available for GlobalGPUController" in resp["error"]["message"]
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
 def test_jsonrpc_cuda_worker_startup_failure_creates_no_active_session(monkeypatch):
     import torch
 
@@ -806,6 +873,32 @@ def test_mcp_tools_call_rejects_oversized_integer_vram_as_tool_error():
     result = resp["result"]
     assert result["isError"] is True
     assert "vram must be no more than" in result["content"][0]["text"]
+    assert server.status()["active_jobs"] == []
+
+
+def test_mcp_tools_call_startup_unavailable_returns_tool_error():
+    def failing_factory(**kwargs):
+        raise SessionStartupUnavailable("No usable GPUs are available")
+
+    server = KeepGPUServer(controller_factory=cast(Any, failing_factory))
+    req = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "start_keep",
+            "arguments": {"job_id": "tool-no-gpus", "gpu_ids": [0]},
+        },
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 4
+    assert "result" in resp
+    result = resp["result"]
+    assert result["isError"] is True
+    assert "No usable GPUs are available" in result["content"][0]["text"]
     assert server.status()["active_jobs"] == []
 
 


### PR DESCRIPTION
## Summary
- classify expected `GlobalGPUController` startup unavailability with controller-domain exceptions
- map startup-unavailable starts to direct JSON-RPC `-32000`, REST `503`, and MCP tool `isError=true`
- preserve arbitrary startup/runtime failures as internal errors and add regression coverage for unsupported platform and zero visible GPU paths
- update `AGENTS.md`, MCP/CLI docs, and the implementation plan

## Verification
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_startup_unavailable_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_unsupported_platform_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code tests/mcp/test_server.py::test_jsonrpc_start_keep_runtime_value_error_remains_internal_error tests/mcp/test_server.py::test_mcp_tools_call_startup_unavailable_returns_tool_error tests/mcp/test_http_api.py::test_http_post_sessions_startup_unavailable_returns_json_503 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_value_error_returns_json_500 tests/mcp/test_http_api.py::test_http_post_sessions_runtime_type_error_returns_json_500 -q` -> 8 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py tests/global_controller -q` -> 203 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 493 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material/nav warnings
- `pre-commit run --all-files` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Local review
- Spec reviewer: compliant, no missing or extra requirements
- Quality reviewer: no critical/important issues; suggested optional zero-visible-GPU coverage
- Follow-up reviewer: confirmed zero-visible-GPU coverage resolves the note and found no new issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer startup error responses when the service can’t begin due to unsupported platforms or no available GPUs.
  * Session creation now returns consistent errors across JSON-RPC, REST, and MCP interfaces.

* **Bug Fixes**
  * Startup failures are now reported as availability issues instead of generic internal errors.
  * REST session requests now return `503` for startup-unavailable cases.

* **Documentation**
  * Updated guides and references to explain the new error behavior and response codes.

* **Tests**
  * Expanded coverage for unsupported-platform, no-GPU, and MCP error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->