### PR TITLE
[controllers] fix: clean caches after delayed release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,9 @@ This file defines how coding agents should work in this repository.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Release paths must be idempotent after timeout: when a previously stopping
+  worker has since died, perform backend cache cleanup and clear stale thread
+  and stop-event state instead of returning early as not running.
 - Runtime/allocation failures reported by a started worker must be retained in
   status as `state="runtime_failed"` with `last_error`; the session remains
   visible and stoppable. Busy or unavailable telemetry backoff is normal

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -75,7 +75,9 @@ CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
    or `0..100`; `busy_threshold=-1` is the explicit unconditional mode.
 6. When you call `release()` (or exit the context), every worker sets a stop
    event, joins the thread, and clears the device cache. Release attempts every
-   worker and then raises a summary if any worker failed to stop.
+   worker and then raises a summary if any worker failed to stop. If a timed-out
+   worker exits before a later release attempt, that later release still clears
+   the backend cache before dropping stale thread state.
 
 ## Why lightweight elementwise batches?
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -91,7 +91,9 @@ with GlobalGPUController(
   utilization spikes. When utilization telemetry is unavailable, non-negative
   thresholds sleep before allocating the keep tensor or running compute; use
   `busy_threshold=-1` only for explicit unconditional keepalive work.
-- `release()` uses threads too, so all GPUs free up quickly.
+- `release()` uses threads too, so all GPUs free up quickly. If a stop times out
+  but the worker exits before a later release attempt, KeepGPU still clears the
+  backend cache before forgetting the stale worker state.
 
 ## Combine with schedulers or callbacks
 

--- a/docs/plans/late-release-cache-cleanup.md
+++ b/docs/plans/late-release-cache-cleanup.md
@@ -1,0 +1,139 @@
+# Late Release Cache Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for the regression and superpowers:verification-before-completion before claiming completion. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CUDA, ROCm, and MPS release paths clean backend caches when a timed-out worker exits before a later release attempt.
+
+**Architecture:** Keep the fix local to each single-GPU controller release method. Preserve the current live-thread path: set the stop event, join once, clean cache only when the thread stops, and raise `TimeoutError` when it remains alive. Add one idempotent late-cleanup branch for stale `_thread` plus set `_stop_evt`.
+
+**Tech Stack:** Python, pytest, PyTorch cache APIs, KeepGPU single-GPU controllers.
+
+---
+
+## Background
+
+`CudaGPUController.release()`, `RocmGPUController.release()`, and `MacMGPUController.release()` currently return early when no worker thread is alive. If the first release attempt times out, it sets `_stop_evt` and raises before backend cache cleanup. When the same thread exits shortly after that timeout, a second release sees a dead thread and returns as "not running", leaving backend cache cleanup skipped and stale `_thread` / `_stop_evt` references in place.
+
+ROCm already guarantees `_shutdown_rocm_smi()` through a `finally` block in release paths, and that behavior must remain unchanged.
+
+## Solution
+
+1. Add regression tests in `tests/single_gpu_controller/test_release_contract.py` that simulate a worker surviving the first join, then dying before a second release call.
+2. Verify those tests fail before controller changes because cleanup is skipped and stale state remains.
+3. Add a minimal late-cleanup branch to each controller release method:
+   - only when `_thread` exists,
+   - the thread is no longer alive,
+   - `_stop_evt` exists and is already set.
+4. In that branch, run backend cache cleanup, clear `_thread` and `_stop_evt`, log an info message, and return.
+5. Preserve warning behavior for no thread / not stopping states.
+6. Keep ROCm SMI shutdown in all release paths.
+
+## Task Checklist
+
+- [x] Inspect existing release methods and release-contract tests.
+- [x] Add failing late-cleanup regression tests before production code changes.
+- [x] Record RED evidence in this plan.
+- [x] Implement CUDA late cleanup.
+- [x] Implement ROCm late cleanup while preserving `_shutdown_rocm_smi()`.
+- [x] Implement MPS late cleanup.
+- [x] Update `AGENTS.md` with the release idempotency lifecycle invariant.
+- [x] Add post-review coverage for dead-but-not-stopping workers that must keep
+  the existing not-running warning behavior.
+- [x] Address hosted review feedback so successful normal release also clears
+  stale thread and stop-event state.
+- [x] Run focused GREEN verification and record evidence.
+- [x] Run broader targeted tests, docs build, pre-commit, and diff check.
+- [x] Commit with `fix(controllers): clean caches after delayed release`.
+
+## RED Evidence
+
+Command:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py -q
+```
+
+Result: failed as expected before production changes.
+
+Key failures:
+
+- CUDA late release: `cache_calls == []`, expected `["empty_cache"]`; second release logged `keep thread not running`.
+- ROCm late release: `cache_calls == []`, expected `["empty_cache"]`; second release logged `keep thread not running`.
+- MPS late release: `cache_calls == []`, expected `["empty_cache", "gc.collect"]`; second release logged `keep thread not running`.
+
+Summary: `3 failed, 5 passed`.
+
+Hosted review follow-up:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py::test_release_success_clears_state_so_second_release_keeps_not_running_behavior -q
+```
+
+Result: failed before the follow-up fix with `3 failed`. A normal successful
+release cleaned the backend cache but left `_thread` and `_stop_evt` populated,
+so a later release could be mistaken for late cleanup.
+
+## GREEN Evidence
+
+Focused command:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py -q
+```
+
+Result: passed after controller changes. After local review, the focused command
+was expanded with negative coverage for dead threads whose stop event is missing
+or not set; those paths preserve the existing not-running behavior and skip
+cache cleanup.
+
+Summary: `17 passed`.
+
+Hosted review follow-up:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py::test_release_success_clears_state_so_second_release_keeps_not_running_behavior -q
+```
+
+Result: `3 passed`.
+
+## Final Verification Evidence
+
+Focused regression:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py -q
+```
+
+Result: `17 passed`.
+
+Broader targeted:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py tests/cuda_controller/test_keep_and_release.py tests/rocm_controller/test_rocm_backoff.py tests/macm_controller -q
+```
+
+Result: `39 passed, 6 skipped`.
+
+Documentation build:
+
+```bash
+PYTHONPATH=$PWD/src mkdocs build
+```
+
+Result: succeeded; MkDocs reported existing nav warnings for plan files not included in navigation.
+
+Pre-commit:
+
+```bash
+pre-commit run --all-files
+```
+
+Result: all hooks passed.
+
+Whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -149,7 +149,20 @@ class CudaGPUController(BaseGPUController):
         Stop the background thread and clear CUDA cache so the memory
         becomes immediately available to other code.
         """
-        if not (self._thread and self._thread.is_alive()):
+        thread = self._thread
+        if thread is not None and not thread.is_alive():
+            stop_evt = self._stop_evt
+            if stop_evt is not None and stop_evt.is_set():
+                torch.cuda.empty_cache()
+                self._thread = None
+                self._stop_evt = None
+                logger.info(
+                    "rank %s: previously stopping keep thread exited; cache cleared",
+                    self.rank,
+                )
+                return
+
+        if not (thread and thread.is_alive()):
             logger.warning("rank %s: keep thread not running", self.rank)
             return
 
@@ -160,8 +173,8 @@ class CudaGPUController(BaseGPUController):
 
         stop_evt.set()
         join_timeout = max(2.0, min(float(self.interval) + 2.0, 30.0))
-        self._thread.join(timeout=join_timeout)
-        if self._thread.is_alive():
+        thread.join(timeout=join_timeout)
+        if thread.is_alive():
             logger.warning(
                 "rank %s: keep thread did not stop within %.1fs",
                 self.rank,
@@ -171,6 +184,8 @@ class CudaGPUController(BaseGPUController):
                 f"rank {self.rank}: keep thread did not stop within {join_timeout:.1f}s"
             )
         torch.cuda.empty_cache()
+        self._thread = None
+        self._stop_evt = None
         logger.info("rank %s: keep thread stopped & cache cleared", self.rank)
 
     # Context-manager helpers -------------------------------------------------

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -63,7 +63,21 @@ class MacMGPUController(BaseGPUController):
         logger.info("rank %s: MPS keep thread started", self.rank)
 
     def release(self) -> None:
-        if not (self._thread and self._thread.is_alive()):
+        thread = self._thread
+        if thread is not None and not thread.is_alive():
+            stop_evt = self._stop_evt
+            if stop_evt is not None and stop_evt.is_set():
+                torch.mps.empty_cache()
+                gc.collect()
+                self._thread = None
+                self._stop_evt = None
+                logger.info(
+                    "rank %s: previously stopping keep thread exited; cache cleared",
+                    self.rank,
+                )
+                return
+
+        if not (thread and thread.is_alive()):
             logger.warning("rank %s: keep thread not running", self.rank)
             return
 
@@ -73,8 +87,8 @@ class MacMGPUController(BaseGPUController):
 
         stop_evt.set()
         join_timeout = max(2.0, min(float(self.interval) + 2.0, 30.0))
-        self._thread.join(timeout=join_timeout)
-        if self._thread.is_alive():
+        thread.join(timeout=join_timeout)
+        if thread.is_alive():
             logger.warning(
                 "rank %s: MPS keep thread did not stop within %.1fs",
                 self.rank,
@@ -86,6 +100,8 @@ class MacMGPUController(BaseGPUController):
 
         torch.mps.empty_cache()
         gc.collect()
+        self._thread = None
+        self._stop_evt = None
         logger.info("rank %s: keep thread stopped & cache cleared", self.rank)
 
     def __enter__(self):

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -123,15 +123,28 @@ class RocmGPUController(BaseGPUController):
 
     def release(self) -> None:
         try:
-            if self._thread and self._thread.is_alive():
+            thread = self._thread
+            if thread is not None and not thread.is_alive():
+                stop_evt = self._stop_evt
+                if stop_evt is not None and stop_evt.is_set():
+                    torch.cuda.empty_cache()
+                    self._thread = None
+                    self._stop_evt = None
+                    logger.info(
+                        "rank %s: previously stopping keep thread exited; cache cleared",
+                        self.rank,
+                    )
+                    return
+
+            if thread and thread.is_alive():
                 stop_evt = self._stop_evt
                 if stop_evt is None:
                     raise RuntimeError(f"rank {self.rank}: stop event missing")
                 assert stop_evt is not None
                 stop_evt.set()
                 join_timeout = max(2.0, min(float(self.interval) + 2.0, 30.0))
-                self._thread.join(timeout=join_timeout)
-                if self._thread.is_alive():
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
                     logger.warning(
                         "rank %s: ROCm keep thread did not stop within %.1fs",
                         self.rank,
@@ -141,6 +154,8 @@ class RocmGPUController(BaseGPUController):
                         f"rank {self.rank}: ROCm keep thread did not stop within {join_timeout:.1f}s"
                     )
                 torch.cuda.empty_cache()
+                self._thread = None
+                self._stop_evt = None
             else:
                 logger.warning("rank %s: keep thread not running", self.rank)
                 return

--- a/tests/single_gpu_controller/test_release_contract.py
+++ b/tests/single_gpu_controller/test_release_contract.py
@@ -19,6 +19,24 @@ class StuckThread:
         self.join_timeout = timeout
 
 
+class ControllableThread:
+    def __init__(self):
+        self.alive = True
+        self.join_timeout = None
+
+    def is_alive(self):
+        return self.alive
+
+    def join(self, timeout=None):
+        self.join_timeout = timeout
+
+
+class StopsDuringJoinThread(ControllableThread):
+    def join(self, timeout=None):
+        self.join_timeout = timeout
+        self.alive = False
+
+
 @pytest.mark.parametrize(
     ("controller_cls", "extra_attrs"),
     [
@@ -60,3 +78,211 @@ def test_rocm_release_without_worker_does_not_log_stopped(monkeypatch):
     controller.release()
 
     assert info_messages == []
+
+
+@pytest.mark.parametrize(
+    ("controller_cls", "cache_path", "extra_attrs"),
+    [
+        (
+            CudaGPUController,
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.torch.cuda.empty_cache",
+            {},
+        ),
+        (
+            RocmGPUController,
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.torch.cuda.empty_cache",
+            {"_rocm_smi": None},
+        ),
+        (
+            MacMGPUController,
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.torch.mps.empty_cache",
+            {},
+        ),
+    ],
+)
+def test_release_cleans_cache_after_timed_out_worker_later_exits(
+    monkeypatch, controller_cls, cache_path, extra_attrs
+):
+    controller = controller_cls.__new__(controller_cls)
+    controller.rank = 0
+    controller.interval = 0.01
+    thread = ControllableThread()
+    controller._thread = thread
+    controller._stop_evt = threading.Event()
+    for name, value in extra_attrs.items():
+        setattr(controller, name, value)
+
+    cache_calls = []
+    monkeypatch.setattr(cache_path, lambda: cache_calls.append("empty_cache"))
+    if controller_cls is MacMGPUController:
+        monkeypatch.setattr(
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.gc.collect",
+            lambda: cache_calls.append("gc.collect"),
+        )
+
+    with pytest.raises(TimeoutError, match="did not stop"):
+        controller.release()
+
+    assert cache_calls == []
+    assert controller._stop_evt.is_set()
+    assert controller._thread is thread
+
+    thread.alive = False
+    controller.release()
+
+    expected_calls = (
+        ["empty_cache", "gc.collect"]
+        if controller_cls is MacMGPUController
+        else ["empty_cache"]
+    )
+    assert cache_calls == expected_calls
+    assert controller._thread is None
+    assert controller._stop_evt is None
+
+
+@pytest.mark.parametrize(
+    ("controller_cls", "cache_path", "logger_path", "extra_attrs"),
+    [
+        (
+            CudaGPUController,
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.torch.cuda.empty_cache",
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.logger.warning",
+            {},
+        ),
+        (
+            RocmGPUController,
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.torch.cuda.empty_cache",
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.logger.warning",
+            {"_rocm_smi": None},
+        ),
+        (
+            MacMGPUController,
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.torch.mps.empty_cache",
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.logger.warning",
+            {},
+        ),
+    ],
+)
+def test_release_success_clears_state_so_second_release_keeps_not_running_behavior(
+    monkeypatch, controller_cls, cache_path, logger_path, extra_attrs
+):
+    controller = controller_cls.__new__(controller_cls)
+    controller.rank = 0
+    controller.interval = 0.01
+    thread = StopsDuringJoinThread()
+    controller._thread = thread
+    controller._stop_evt = threading.Event()
+    for name, value in extra_attrs.items():
+        setattr(controller, name, value)
+
+    cache_calls = []
+    warnings = []
+    monkeypatch.setattr(cache_path, lambda: cache_calls.append("empty_cache"))
+    if controller_cls is MacMGPUController:
+        monkeypatch.setattr(
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.gc.collect",
+            lambda: cache_calls.append("gc.collect"),
+        )
+    monkeypatch.setattr(
+        logger_path,
+        lambda message, *args: warnings.append(message % args),
+    )
+
+    controller.release()
+
+    expected_calls = (
+        ["empty_cache", "gc.collect"]
+        if controller_cls is MacMGPUController
+        else ["empty_cache"]
+    )
+    assert cache_calls == expected_calls
+    assert controller._thread is None
+    assert controller._stop_evt is None
+
+    controller.release()
+
+    assert cache_calls == expected_calls
+    assert warnings == ["rank 0: keep thread not running"]
+
+
+@pytest.mark.parametrize("stop_evt", [None, threading.Event()])
+@pytest.mark.parametrize(
+    ("controller_cls", "cache_path", "logger_path", "extra_attrs"),
+    [
+        (
+            CudaGPUController,
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.torch.cuda.empty_cache",
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.logger.warning",
+            {},
+        ),
+        (
+            RocmGPUController,
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.torch.cuda.empty_cache",
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.logger.warning",
+            {"_rocm_smi": None},
+        ),
+        (
+            MacMGPUController,
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.torch.mps.empty_cache",
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.logger.warning",
+            {},
+        ),
+    ],
+)
+def test_release_dead_thread_without_stopping_state_keeps_not_running_behavior(
+    monkeypatch, controller_cls, cache_path, logger_path, extra_attrs, stop_evt
+):
+    controller = controller_cls.__new__(controller_cls)
+    controller.rank = 0
+    controller.interval = 0.01
+    thread = ControllableThread()
+    thread.alive = False
+    controller._thread = thread
+    controller._stop_evt = stop_evt
+    for name, value in extra_attrs.items():
+        setattr(controller, name, value)
+
+    cache_calls = []
+    warnings = []
+    monkeypatch.setattr(cache_path, lambda: cache_calls.append("empty_cache"))
+    monkeypatch.setattr(
+        logger_path,
+        lambda message, *args: warnings.append(message % args),
+    )
+
+    controller.release()
+
+    assert cache_calls == []
+    assert warnings == ["rank 0: keep thread not running"]
+    assert controller._thread is thread
+    assert controller._stop_evt is stop_evt
+
+
+def test_rocm_late_release_still_shuts_down_rocm_smi(monkeypatch):
+    class FakeRocmSmi:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        def rsmi_shut_down(self):
+            self.shutdown_calls += 1
+
+    controller = RocmGPUController.__new__(RocmGPUController)
+    controller.rank = 0
+    controller.interval = 0.01
+    thread = ControllableThread()
+    controller._thread = thread
+    controller._stop_evt = threading.Event()
+    rocm_smi = FakeRocmSmi()
+    controller._rocm_smi = rocm_smi
+    monkeypatch.setattr(
+        "keep_gpu.single_gpu_controller.rocm_gpu_controller.torch.cuda.empty_cache",
+        lambda: None,
+    )
+
+    with pytest.raises(TimeoutError, match="did not stop"):
+        controller.release()
+
+    thread.alive = False
+    controller.release()
+
+    assert rocm_smi.shutdown_calls == 2


### PR DESCRIPTION
## Summary
- clean CUDA, ROCm, and MPS backend caches when a previously timed-out release worker later exits
- clear stale thread/stop-event state after both late cleanup and normal successful release, avoiding duplicate release actions
- keep non-stopping dead-thread behavior unchanged: warn as not running and skip cache cleanup
- document the lifecycle invariant in `AGENTS.md`, architecture docs, Python guide, and the plan

## Verification
- `PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py -q` -> 17 passed
- `PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py tests/cuda_controller/test_keep_and_release.py tests/rocm_controller/test_rocm_backoff.py tests/macm_controller -q` -> 39 passed, 6 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 506 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material/nav warnings
- `pre-commit run --all-files` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Local review
- Spec reviewer: compliant; CUDA/ROCm/MPS release paths match requirements
- Quality reviewer: no critical/important issues; suggested optional dead-thread/not-stopping negative coverage
- Follow-up reviewer: confirmed optional coverage was added and found no new issues
- Hosted Gemini review: fixed normal successful release stale-state issue and locally re-reviewed the fix