### PR TITLE
[mcp] fix: return null for invalid jsonrpc ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,9 @@ This file defines how coding agents should work in this repository.
 - JSON-RPC handlers must reject explicit request versions other than `"2.0"`
   with `-32600 Invalid Request` for request messages while preserving
   omitted-version legacy/internal calls and silent id-less notifications.
+- JSON-RPC error envelopes must use `id: null` when the request id is missing or
+  has an invalid response-id type, and must echo only valid non-boolean string or
+  integer ids.
 - HTTP JSON-RPC endpoints (`/` and `/rpc`) must return JSON-RPC envelopes for
   protocol parse errors, including `jsonrpc`, `id`, and numeric `error.code`;
   REST routes keep REST-shaped structured JSON errors.

--- a/docs/plans/jsonrpc-invalid-id-null.md
+++ b/docs/plans/jsonrpc-invalid-id-null.md
@@ -1,0 +1,53 @@
+# JSON-RPC Invalid ID Null Plan
+
+## Background
+
+`src/keep_gpu/mcp/server.py` stores `payload["id"]` before validating whether the
+value is a legal JSON-RPC response id. Invalid request ids such as `true`,
+arrays, or objects are then echoed in error envelopes, which can make strict MCP
+or JSON-RPC clients reject the error response itself.
+
+## Goal
+
+Return `id: null` for missing or invalid JSON-RPC request ids, while preserving
+the existing behavior that valid string and integer ids are echoed in responses.
+
+## Solution
+
+- Add MCP server tests for invalid JSON-RPC id types.
+- Keep valid integer and string id behavior unchanged.
+- Preserve id-less notification handling: id-less `notifications/*` messages do
+  not receive responses, and missing-id requests receive `id: null` errors.
+- Update `_handle_request` so the response id is assigned only after the raw id
+  passes JSON-RPC id validation.
+
+## Tasks
+
+- [x] Add a failing regression test for boolean, object, and array request ids.
+- [x] Verify the new test fails against the current implementation.
+- [x] Implement the minimal handler change.
+- [x] Run focused MCP tests and broader validation.
+- [ ] Request local subagent code review before opening the PR.
+- [ ] Resolve hosted PR review comments before squash merge.
+
+## Verification Log
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_invalid_request_id_types_return_null_id -q`
+  failed with all three invalid ids echoed in `resp["id"]`.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_invalid_request_id_types_return_null_id tests/mcp/test_server.py::test_jsonrpc_rejects_explicit_invalid_request_version tests/mcp/test_server.py::test_jsonrpc_accepts_explicit_valid_request_version tests/mcp/test_server.py::test_jsonrpc_omitted_version_legacy_direct_call_still_works tests/mcp/test_server.py::test_mcp_requests_require_id tests/mcp/test_server.py::test_mcp_notification_with_id_is_invalid_request -q`
+  passed with `8 passed`.
+- Focused MCP: `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`
+  passed with `98 passed`.
+- MCP plus HTTP API:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  passed with `155 passed`.
+- Full suite: `PYTHONPATH=$PWD/src pytest tests -q` passed with `509 passed,
+  11 skipped`.
+- Docs: `PYTHONPATH=$PWD/src mkdocs build` completed successfully. It emitted
+  the repository's existing unlisted-plan-page warnings and the upstream
+  Material for MkDocs 2.0 advisory.
+- Hygiene: `pre-commit run --all-files` passed; `git diff --check --cached`
+  produced no output.
+- Local review: spec and code-quality reviewers found no must-fix issues. The
+  optional coverage suggestion to include `False`, `None`, and `1.5` invalid ids
+  was applied before PR.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -598,6 +598,10 @@ def _jsonrpc_error(req_id: Any, code: int, message: str) -> Dict[str, Any]:
     }
 
 
+def _is_valid_jsonrpc_id(req_id: Any) -> bool:
+    return isinstance(req_id, (str, int)) and not isinstance(req_id, bool)
+
+
 _DIRECT_METHOD_PARAMS = {
     "start_keep": {"gpu_ids", "vram", "interval", "busy_threshold", "job_id"},
     "stop_keep": {"job_id"},
@@ -736,7 +740,9 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
             raise JSONRPCError(
                 JSONRPC_INVALID_REQUEST, "JSON-RPC messages must be objects."
             )
-        req_id = payload.get("id")
+        raw_id = payload.get("id")
+        if "id" in payload and _is_valid_jsonrpc_id(raw_id):
+            req_id = raw_id
         method = payload.get("method")
         params = payload.get("params", {})
         if not isinstance(method, str) or not method:
@@ -745,11 +751,7 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
             return None
         if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "JSON-RPC version must be 2.0.")
-        if (
-            "id" not in payload
-            or not isinstance(req_id, (str, int))
-            or isinstance(req_id, bool)
-        ):
+        if "id" not in payload or not _is_valid_jsonrpc_id(raw_id):
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Requests must include an id.")
         if method.startswith("notifications/"):
             raise JSONRPCError(

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -960,6 +960,22 @@ def test_mcp_requests_require_id():
     assert resp["error"]["message"] == "Requests must include an id."
 
 
+@pytest.mark.parametrize(
+    "invalid_id",
+    [True, False, None, 1.5, {"unexpected": "object"}, ["array-id"]],
+)
+def test_mcp_invalid_request_id_types_return_null_id(invalid_id):
+    server = make_server()
+    req = {"jsonrpc": "2.0", "id": invalid_id, "method": "tools/list"}
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] is None
+    assert resp["error"]["code"] == -32600
+    assert resp["error"]["message"] == "Requests must include an id."
+
+
 def test_mcp_unrecognized_notification_has_no_response():
     server = make_server()
     req = {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {}}


### PR DESCRIPTION
## Summary
- return `id: null` for missing or invalid JSON-RPC request ids in MCP error envelopes
- keep valid non-boolean string and integer ids echoed for request errors
- document the invariant in `AGENTS.md` and add a branch plan with verification notes

## Testing
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_invalid_request_id_types_return_null_id -q` failed before the fix with invalid ids echoed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_invalid_request_id_types_return_null_id tests/mcp/test_server.py::test_jsonrpc_rejects_explicit_invalid_request_version tests/mcp/test_server.py::test_jsonrpc_accepts_explicit_valid_request_version tests/mcp/test_server.py::test_jsonrpc_omitted_version_legacy_direct_call_still_works tests/mcp/test_server.py::test_mcp_requests_require_id tests/mcp/test_server.py::test_mcp_notification_with_id_is_invalid_request -q`
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`

## Local review
- Spec/protocol reviewer: no must-fix issues
- Code-quality reviewer: no must-fix issues; optional coverage suggestion applied and re-reviewed cleanly
