### PR TITLE
[cli] fix: validate service result payloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ This file defines how coding agents should work in this repository.
   required result fields before rendering user-facing output; malformed
   method-specific payloads should become clean `ServiceResponseError` messages,
   not `KeyError`, tracebacks, or partial success text.
+- Keep `_rpc_call()` limited to generic JSON-RPC envelope validation; validate
+  method-specific `status`, `stop_keep`, and `list_gpus` result payloads at CLI
+  call sites before reading fields or triggering daemon stop side effects, while
+  allowing extra result fields for forward compatibility.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`

--- a/docs/plans/cli-service-payload-validation.md
+++ b/docs/plans/cli-service-payload-validation.md
@@ -1,0 +1,62 @@
+# CLI Service Payload Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CLI service commands reject malformed method-specific JSON-RPC result payloads with clean errors before rendering output or stopping daemons.
+
+**Architecture:** Keep `_rpc_call()` focused on generic JSON-RPC envelope validation. Add small CLI-side result validators for `status`, `stop_keep`, and `list_gpus`, and call them immediately after each method-specific result is received.
+
+**Tech Stack:** Python, Typer CLI, pytest, mkdocs, pre-commit.
+
+---
+
+## Background
+
+The CLI already validates JSON-RPC envelopes in `_rpc_call()`: response object shape, `jsonrpc`, `id`, `error`, and top-level `result` object. The bug is that command handlers trust method-specific result fields after that point. A version-skewed or malformed service can return `{}` and be treated as success, including in non-force `service-stop` before daemon termination.
+
+## Solution
+
+Add permissive validators that require only the fields each CLI command consumes:
+
+- `status` without `--job-id`: `active_jobs` must be a list.
+- `status --job-id`: `active` must be a bool and `job_id` must be a string.
+- `stop_keep`: `stopped`, `timed_out`, and `failed` must be lists; `errors` must be a dict; optional `message` must be a string.
+- `list_gpus`: `gpus` must be a list and each element must be a dict.
+
+Extra fields remain allowed so newer servers can add data without breaking older CLIs.
+
+## Tasks
+
+- [x] Write failing regression tests in `tests/test_cli_service_commands.py` for malformed `status`, `stop`, `list-gpus`, and non-force `service-stop` payloads.
+- [x] Run the new regression tests before production changes and record RED evidence below.
+- [x] Add a durable CLI result-validation invariant to `AGENTS.md`.
+- [x] Implement minimal validators in `src/keep_gpu/cli.py` and call them after `_rpc_call()` results are received.
+- [x] Validate `_stop_all_sessions_with_fallback()` direct and synthesized `stop_keep` results.
+- [x] Run targeted and broad verification commands and record GREEN evidence below.
+- [x] Commit with `fix(cli): validate service result payloads`.
+
+## Verification Log
+
+### RED
+
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'malformed_all_session_payloads or status_job_rejects_malformed_payloads or stop_job_rejects_malformed_payloads or stop_all_rejects_malformed_payload or list_gpus_rejects_malformed_payloads or service_stop_rejects_malformed_status_before_side_effects or service_stop_rejects_malformed_stop_keep_before_stopping_daemon or status_job_outputs_single_decoded_json_object or service_stop_requires_managed_pid'`
+  - Result: `19 failed, 2 passed, 120 deselected`.
+  - Expected failure mode: malformed method-specific result payloads exited successfully (`exit_code == 0`) instead of returning clean CLI errors.
+
+### GREEN
+
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+  - Result: `141 passed in 1.29s`.
+- `PYTHONPATH=$PWD/src pytest tests -q`
+  - Result: `531 passed, 11 skipped in 34.09s`.
+- `PYTHONPATH=$PWD/src mkdocs build`
+  - Result: passed. Existing warnings noted for MkDocs Material advisory and unnav'ed `docs/plans/` pages.
+- `pre-commit run --all-files`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+
+## Review Notes
+
+- Local spec and code-quality reviewers found no must-fix issues.
+- The optional stop-all fallback safety-test suggestion was applied before PR.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -581,6 +581,59 @@ def _rpc_call(
     return result
 
 
+def _malformed_method_result(method: str, detail: str) -> ServiceResponseError:
+    return ServiceResponseError(f"Malformed {method} response: {detail}")
+
+
+def _require_list_field(result: Dict[str, Any], field: str, method: str) -> List[Any]:
+    value = result.get(field)
+    if not isinstance(value, list):
+        raise _malformed_method_result(method, f"{field} must be a list")
+    return value
+
+
+def _require_dict_field(
+    result: Dict[str, Any], field: str, method: str
+) -> Dict[str, Any]:
+    value = result.get(field)
+    if not isinstance(value, dict):
+        raise _malformed_method_result(method, f"{field} must be an object")
+    return value
+
+
+def _validate_status_result(
+    result: Dict[str, Any], *, single_job: bool
+) -> Dict[str, Any]:
+    if single_job:
+        if not isinstance(result.get("active"), bool):
+            raise _malformed_method_result("status", "active must be a bool")
+        if not isinstance(result.get("job_id"), str):
+            raise _malformed_method_result("status", "job_id must be a string")
+    else:
+        _require_list_field(result, "active_jobs", "status")
+    return result
+
+
+def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    for field in ("stopped", "timed_out", "failed"):
+        _require_list_field(result, field, "stop_keep")
+    _require_dict_field(result, "errors", "stop_keep")
+    message = result.get("message")
+    if message is not None and not isinstance(message, str):
+        raise _malformed_method_result("stop_keep", "message must be a string")
+    return result
+
+
+def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    gpus = _require_list_field(result, "gpus", "list_gpus")
+    for index, gpu in enumerate(gpus):
+        if not isinstance(gpu, dict):
+            raise _malformed_method_result(
+                "list_gpus", f"gpus[{index}] must be an object"
+            )
+    return result
+
+
 def _is_service_unreachable_error(exc: RuntimeError) -> bool:
     if isinstance(exc, ServiceUnreachableError):
         return True
@@ -592,14 +645,15 @@ def _is_service_unreachable_error(exc: RuntimeError) -> bool:
 
 def _stop_all_sessions_with_fallback(host: str, port: int) -> Dict[str, Any]:
     try:
-        return _rpc_call("stop_keep", {}, host, port, timeout=45.0)
+        result = _rpc_call("stop_keep", {}, host, port, timeout=45.0)
+        return _validate_stop_keep_result(result)
     except RuntimeError as exc:
         if not _is_service_unreachable_error(exc):
             raise
         managed_pid = _read_service_pid(host, port)
         if managed_pid and _pid_alive(managed_pid):
             if _stop_service_process(host, port):
-                return {
+                result = {
                     "stopped": [],
                     "timed_out": [],
                     "failed": [],
@@ -609,6 +663,7 @@ def _stop_all_sessions_with_fallback(host: str, port: int) -> Dict[str, Any]:
                         f"pid={managed_pid}. Reserved VRAM should be released by process exit."
                     ),
                 }
+                return _validate_stop_keep_result(result)
             raise RuntimeError(
                 f"{exc}. No ownership-verified daemon could be force-stopped."
             ) from exc
@@ -858,6 +913,7 @@ def status(
             host,
             port,
         )
+        result = _validate_status_result(result, single_job=job_id is not None)
         console.print_json(data=result)
     except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
@@ -896,6 +952,7 @@ def stop(
                 port,
                 timeout=45.0,
             )
+            result = _validate_stop_keep_result(result)
         console.print_json(data=result)
     except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
@@ -911,6 +968,7 @@ def list_gpus(
     try:
         host, port = _validate_cli_service_endpoint(host, port)
         result = _rpc_call("list_gpus", {}, host, port)
+        result = _validate_list_gpus_result(result)
         console.print_json(data=result)
     except (RuntimeError, typer.BadParameter) as exc:
         console.print_json(data={"error": str(exc)})
@@ -943,6 +1001,7 @@ def service_stop(
 
         try:
             status = _rpc_call("status", {}, host, port)
+            status = _validate_status_result(status, single_job=False)
         except ServiceUnreachableError as exc:
             raise RuntimeError(
                 f"KeepGPU service is unavailable at {host}:{port}. Non-force service-stop must verify no tracked keep sessions before stopping the daemon. "
@@ -954,7 +1013,8 @@ def service_stop(
             raise RuntimeError(
                 "Tracked keep sessions detected. Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
             )
-        _rpc_call("stop_keep", {}, host, port, timeout=45.0)
+        stop_result = _rpc_call("stop_keep", {}, host, port, timeout=45.0)
+        _validate_stop_keep_result(stop_result)
 
         stopped = _stop_service_process(host, port)
         if not stopped:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -638,7 +638,7 @@ def test_status_job_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "status"
         assert params == {"job_id": "job-1"}
-        return {"active": True, "job": {"job_id": "job-1"}}
+        return {"active": True, "job_id": "job-1"}
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
 
@@ -646,7 +646,48 @@ def test_status_job_outputs_single_decoded_json_object(monkeypatch):
 
     assert result.exit_code == 0
     payload = _single_decoded_json_object(result.output)
-    assert payload["job"]["job_id"] == "job-1"
+    assert payload["job_id"] == "job-1"
+
+
+@pytest.mark.parametrize("payload", [{}, {"active_jobs": {}}])
+def test_status_rejects_malformed_all_session_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "active_jobs must be a list" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"active": "yes", "job_id": "job-1"},
+        {"active": True, "job_id": 1},
+    ],
+)
+def test_status_job_rejects_malformed_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {"job_id": "job-1"}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert "Traceback" not in result.output
 
 
 def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
@@ -663,6 +704,40 @@ def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
     assert result.exit_code == 0
     payload = _single_decoded_json_object(result.output)
     assert payload["stopped"] == ["job-1"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"stopped": "job-1", "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": {}, "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": None, "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": [], "errors": []},
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": [],
+            "errors": {},
+            "message": {"text": "bad"},
+        },
+    ],
+)
+def test_stop_job_rejects_malformed_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "job-1"}
+        assert timeout == 45.0
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert "Traceback" not in result.output
 
 
 def test_stop_all_outputs_single_decoded_json_object(monkeypatch):
@@ -684,6 +759,33 @@ def test_stop_all_outputs_single_decoded_json_object(monkeypatch):
     assert payload["stopped"] == ["job-1"]
 
 
+def test_stop_all_rejects_malformed_payload(monkeypatch):
+    called = {"stop_process": False}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {}
+        assert timeout == 45.0
+        return {"stopped": []}
+
+    def fake_stop_process(host, port):
+        called["stop_process"] = True
+        raise AssertionError("_stop_service_process must not be called")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert called["stop_process"] is False
+    assert "Traceback" not in result.output
+
+
 def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "list_gpus"
@@ -697,6 +799,23 @@ def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
     assert result.exit_code == 0
     payload = _single_decoded_json_object(result.output)
     assert payload["gpus"][0]["id"] == 0
+
+
+@pytest.mark.parametrize("payload", [{}, {"gpus": {}}, {"gpus": [1]}])
+def test_list_gpus_rejects_malformed_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "list_gpus"
+        assert params == {}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["list-gpus"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed list_gpus response" in decoded["error"]
+    assert "Traceback" not in result.output
 
 
 def test_list_gpus_error_outputs_single_decoded_json_object(monkeypatch):
@@ -1007,7 +1126,7 @@ def test_service_stop_requires_managed_pid(monkeypatch):
     def fake_rpc(method, params, host, port, timeout=8.0):
         if method == "status":
             return {"active_jobs": []}
-        return {"stopped": []}
+        return {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
 
     monkeypatch.setattr(cli, "_service_available", lambda host, port: True)
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
@@ -1017,6 +1136,69 @@ def test_service_stop_requires_managed_pid(monkeypatch):
 
     assert result.exit_code == 1
     assert "No managed daemon PID found" in result.output
+
+
+@pytest.mark.parametrize("payload", [{}, {"active_jobs": {}}])
+def test_service_stop_rejects_malformed_status_before_side_effects(
+    monkeypatch, payload
+):
+    calls = {"stop_keep": 0, "stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return payload
+        if method == "stop_keep":
+            calls["stop_keep"] += 1
+            return {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert "active_jobs must be a list" in result.output
+    assert calls == {"stop_keep": 0, "stop_process": 0}
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"stopped": [], "timed_out": [], "failed": [], "errors": []},
+    ],
+)
+def test_service_stop_rejects_malformed_stop_keep_before_stopping_daemon(
+    monkeypatch, payload
+):
+    calls = {"stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        if method == "stop_keep":
+            return payload
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert "Malformed stop_keep response" in result.output
+    assert calls["stop_process"] == 0
+    assert "Traceback" not in result.output
 
 
 def test_service_stop_requires_live_status_without_force(monkeypatch):


### PR DESCRIPTION
## Summary
- validate method-specific `status`, `stop_keep`, and `list_gpus` service payloads after generic JSON-RPC envelope validation
- return clean CLI errors for malformed service payloads instead of success output or tracebacks
- prevent non-force `service-stop` and stop-all fallback paths from stopping daemons after malformed service payloads
- document the CLI payload-validation invariant in `AGENTS.md` and add a branch plan with evidence

## Testing
- RED regression slice before production changes: `19 failed, 2 passed, 120 deselected`
- GREEN regression slice after fix: `21 passed, 120 deselected`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`

## Local review
- Spec/behavior reviewer: no must-fix issues
- Code-quality reviewer: no must-fix issues
- Optional stop-all fallback safety-test comment was applied and re-reviewed cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now validates command responses more strictly before displaying results or taking action.
  * Added clearer handling for `status`, `stop`, `list-gpus`, and service stop flows when response data is incomplete or malformed.

* **Bug Fixes**
  * Prevents the app from continuing with invalid response payloads.
  * Improves error handling so failures stop early and avoid confusing tracebacks.

* **Documentation**
  * Added guidance and a plan for response validation behavior and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->