### PR TITLE
[mcp] fix: return json for unsupported http methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ This file defines how coding agents should work in this repository.
 - HTTP body readers must validate `Content-Length` as a non-negative integer
   before reading; invalid values must fail quickly with REST JSON 400 errors or
   JSON-RPC `-32700` parse-error envelopes.
+- API/RPC unsupported HTTP methods must not fall back to
+  `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
+  JSON `405 Method Not Allowed` responses with `Allow`, and unknown `/api/*`
+  routes return structured JSON `404 Unknown endpoint` responses.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/plans/http-json-unsupported-methods.md
+++ b/docs/plans/http-json-unsupported-methods.md
@@ -1,0 +1,86 @@
+# HTTP JSON Unsupported Methods Plan
+
+## Background
+
+The HTTP service has explicit handlers for `GET`, `POST`, and `DELETE`. Methods
+without a `do_*` handler, such as `HEAD`, `OPTIONS`, `PUT`, and `PATCH`, fall
+through to `BaseHTTPRequestHandler.send_error()` and return an HTML `501`
+response. That breaks the structured JSON contract for the REST API and
+JSON-RPC surfaces.
+
+## Goal
+
+Return machine-readable JSON errors for unsupported HTTP methods on KeepGPU
+API/RPC routes without changing existing supported `GET`, `POST`, or `DELETE`
+behavior, and without changing the adjacent `GET /rpc` dashboard/static
+fallback behavior.
+
+## Solution
+
+- Add HTTP regression tests for unsupported known API routes, `/rpc`, unknown
+  `/api/*` routes, and `HEAD /api/sessions`.
+- Intercept unsupported-method `501` dispatches only for known API/RPC surfaces.
+- Return REST-shaped JSON `405 Method Not Allowed` responses with an `Allow`
+  header for known API/RPC routes.
+- Return REST-shaped JSON `404 Unknown endpoint` responses for unknown `/api/*`
+  routes.
+- Preserve HTTP `HEAD` semantics by sending headers for the JSON error payload
+  without writing a response body.
+- Document the invariant in `AGENTS.md`.
+
+## Tasks
+
+- [x] Add RED regression tests in `tests/mcp/test_http_api.py`.
+- [x] Run the RED shard and confirm it fails because unsupported methods return
+      HTML-backed `501` responses.
+- [x] Implement narrow unsupported-method JSON handling in
+      `src/keep_gpu/mcp/server.py`.
+- [x] Update `AGENTS.md` with the API/RPC unsupported-method invariant.
+- [x] Run targeted and broad verification commands.
+- [x] Commit with `fix(mcp): return json for unsupported http methods`.
+
+## Verification Log
+
+- Baseline from coordinator:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` -> `57 passed`.
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_api_known_routes_reject_unsupported_methods_with_json_405 tests/mcp/test_http_api.py::test_http_rpc_rejects_unsupported_options_with_json_405 tests/mcp/test_http_api.py::test_http_unknown_api_routes_reject_unsupported_methods_with_json_404 tests/mcp/test_http_api.py::test_http_head_api_sessions_rejects_with_json_405_headers_and_empty_body -q`
+  failed with 7 failures. Each case returned HTTP `501` instead of the expected
+  structured JSON `405` or `404`.
+- GREEN focused shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_api_known_routes_reject_unsupported_methods_with_json_405 tests/mcp/test_http_api.py::test_http_rpc_rejects_unsupported_options_with_json_405 tests/mcp/test_http_api.py::test_http_unknown_api_routes_reject_unsupported_methods_with_json_404 tests/mcp/test_http_api.py::test_http_head_api_sessions_rejects_with_json_405_headers_and_empty_body -q`
+  passed with 7 tests.
+- HTTP API shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with
+  64 tests.
+- MCP/HTTP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  passed with 165 tests.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 538 tests and 11 skipped.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build` passed. It emitted the existing Material
+  for MkDocs warning and unnav'd docs notices, including this plan page.
+- Hooks:
+  `pre-commit run --all-files` passed.
+- Whitespace:
+  `git diff --check` passed.
+
+## Review Notes
+
+- Local spec review found no must-fix issues.
+- Local code-quality review found that `/rpc` must advertise the preserved
+  `GET` fallback in `Allow`, and that multi-segment `/api/sessions/*` paths
+  must not be classified as known session item routes for unsupported methods.
+  Regression tests were added for both cases before the classifier fix.
+- Review regressions:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_rpc_rejects_unsupported_options_with_json_405 tests/mcp/test_http_api.py::test_http_multisegment_session_route_rejects_unsupported_method_with_json_404 -q`
+  failed before the fix with `/rpc` advertising only `POST` and
+  `/api/sessions/foo/bar` returning `405`.
+- Review regression green:
+  the same command passed with 2 tests after the classifier fix.
+- Hosted review:
+  Gemini suggested guarding `self.path` and `self.command` before intercepting
+  base-class unsupported-method errors. A focused regression reproduced the
+  missing-attribute failure on an uninitialized handler, then passed after the
+  guard was added.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -39,7 +39,7 @@ from http.server import BaseHTTPRequestHandler
 from socketserver import TCPServer, ThreadingMixIn
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote, urlparse
 
 from keep_gpu import __version__
@@ -785,13 +785,71 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         self.send_header("content-length", "0")
         self.end_headers()
 
-    def _json_response(self, status: int, payload: Dict[str, Any]) -> None:
+    def _json_response(
+        self,
+        status: int,
+        payload: Dict[str, Any],
+        headers: Optional[Dict[str, str]] = None,
+        write_body: bool = True,
+    ) -> None:
         data = json.dumps(payload).encode("utf-8")
         self.send_response(status)
         self.send_header("content-type", "application/json")
         self.send_header("content-length", str(len(data)))
+        if headers is not None:
+            for name, value in headers.items():
+                self.send_header(name, value)
         self.end_headers()
-        self.wfile.write(data)
+        if write_body:
+            self.wfile.write(data)
+
+    @staticmethod
+    def _allowed_methods_for_path(path: str) -> Optional[Tuple[str, ...]]:
+        if path == "/health":
+            return ("GET",)
+        if path == "/api/gpus":
+            return ("GET",)
+        if path == "/api/sessions":
+            return ("GET", "POST", "DELETE")
+        if path.startswith("/api/sessions/"):
+            encoded_job_id = path[len("/api/sessions/") :]
+            if encoded_job_id == "" or "/" in encoded_job_id:
+                return None
+            return ("GET", "DELETE")
+        if path == "/":
+            return ("GET", "POST")
+        if path == "/rpc":
+            return ("GET", "POST")
+        return None
+
+    def _send_api_rpc_unsupported_method_response(self) -> bool:
+        if not hasattr(self, "path") or not hasattr(self, "command"):
+            return False
+        parsed = urlparse(self.path)
+        path = parsed.path
+        write_body = self.command != "HEAD"
+        allowed_methods = self._allowed_methods_for_path(path)
+        if allowed_methods is not None:
+            self._json_response(
+                405,
+                {"error": {"message": "Method not allowed"}},
+                headers={"Allow": ", ".join(allowed_methods)},
+                write_body=write_body,
+            )
+            return True
+        if path.startswith("/api/"):
+            self._json_response(
+                404,
+                {"error": {"message": "Unknown endpoint"}},
+                write_body=write_body,
+            )
+            return True
+        return False
+
+    def send_error(self, code, message=None, explain=None):  # noqa: ANN001, N802
+        if int(code) == 501 and self._send_api_rpc_unsupported_method_response():
+            return
+        super().send_error(code, message, explain)
 
     def _json_runtime_error(self, method: str, path: str, exc: Exception) -> None:
         logger.exception("%s request failed for path %s", method, path)

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -108,6 +108,26 @@ def _request_raw(method, url, data=None):
         return exc.code, json.loads(body) if body else {}
 
 
+def _request_http_response(method, url, data=None):
+    request = Request(url=url, data=data, method=method)
+    request.add_header("content-type", "application/json")
+    try:
+        with urlopen(request, timeout=2.0) as response:  # nosec B310
+            body = response.read()
+            return response.status, response.headers, body
+    except HTTPError as exc:
+        body = exc.read()
+        return exc.code, exc.headers, body
+
+
+def _allow_methods(headers):
+    return {
+        method.strip()
+        for method in headers.get("allow", "").split(",")
+        if method.strip()
+    }
+
+
 def _raw_post_with_content_length(httpd, path: str, content_length: str):
     host, port = httpd.server_address
     request = (
@@ -142,6 +162,126 @@ def _raw_post_with_content_length(httpd, path: str, content_length: str):
     status_line = header_bytes.splitlines()[0].decode("iso-8859-1")
     status_code = int(status_line.split()[1])
     return status_code, json.loads(body.decode("utf-8")) if body else {}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "allowed_methods"),
+    [
+        ("PUT", "/api/sessions", {"GET", "POST", "DELETE"}),
+        ("PATCH", "/api/sessions/demo", {"GET", "DELETE"}),
+        ("OPTIONS", "/api/sessions", {"GET", "POST", "DELETE"}),
+    ],
+)
+def test_http_api_known_routes_reject_unsupported_methods_with_json_405(
+    method, path, allowed_methods
+):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(method, f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == allowed_methods
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Method not allowed"}
+    }
+
+
+def test_http_rpc_rejects_unsupported_options_with_json_405():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("OPTIONS", f"{base}/rpc")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == {"GET", "POST"}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Method not allowed"}
+    }
+
+
+@pytest.mark.parametrize("method", ["PUT", "OPTIONS"])
+def test_http_unknown_api_routes_reject_unsupported_methods_with_json_404(method):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(method, f"{base}/api/unknown")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+def test_http_multisegment_session_route_rejects_unsupported_method_with_json_404():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(
+            "OPTIONS", f"{base}/api/sessions/foo/bar"
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+def test_http_head_api_sessions_rejects_with_json_405_headers_and_empty_body():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}/api/sessions")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == {"GET", "POST", "DELETE"}
+    assert body == b""
+
+
+def test_http_unsupported_method_helper_ignores_uninitialized_handler():
+    handler = _JSONRPCHandler.__new__(_JSONRPCHandler)
+
+    assert handler._send_api_rpc_unsupported_method_response() is False
 
 
 @pytest.mark.parametrize("rpc_path", ["/", "/rpc"])


### PR DESCRIPTION
## Summary
- return structured JSON errors for unsupported HTTP methods on API/RPC surfaces instead of BaseHTTPRequestHandler HTML 501 responses
- add `405 Method Not Allowed` with `Allow` for known API/RPC routes and JSON `404` for unknown `/api/*` routes
- preserve existing supported GET/POST/DELETE behavior, including empty HEAD bodies and the existing GET `/rpc` static fallback
- document the invariant in `AGENTS.md` and add a branch plan with verification notes

## Testing
- RED unsupported-method shard before the fix: 7 failures from HTML/501 responses
- Review regressions before follow-up fix: 2 failures for `/rpc` Allow and multi-segment `/api/sessions/foo/bar`
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q`
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`

## Local review
- Spec/behavior reviewer: no must-fix issues
- Code-quality reviewer: two P2 protocol findings fixed and re-reviewed cleanly
