### PR TITLE
[controllers] fix: surface cuda mps runtime failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,12 @@ This file defines how coding agents should work in this repository.
   deferred allocation behavior, not a runtime failure.
 - Controller runtime-health hooks used by service status must stay non-blocking
   and read-only because status refresh runs under the session lock.
+- CUDA and MPS controllers must retain fatal post-start worker failures by way of
+  `allocation_status()` so `GlobalGPUController.runtime_error()` can move
+  service status to `runtime_failed`; normal busy/unknown telemetry backoff and
+  out-of-memory allocation `RuntimeError` retries are not runtime failures.
+  Non-OOM allocation or steady-state `RuntimeError` failures after startup must
+  be retained as runtime failures.
 - Single-GPU `keep()` must not report success until fatal backend startup setup
   has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
   must propagate synchronously so services cannot register false active sessions.

--- a/docs/plans/cuda-mps-runtime-health-status.md
+++ b/docs/plans/cuda-mps-runtime-health-status.md
@@ -1,0 +1,142 @@
+# CUDA/MPS Runtime Health Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface fatal post-start CUDA and MPS worker failures through `allocation_status()` so service status can retain `state="runtime_failed"`.
+
+**Architecture:** Match the existing ROCm health-hook shape with a controller-local `_failure_exc` field and a non-blocking `allocation_status()` reader. CUDA and MPS should continue treating busy or unavailable telemetry and out-of-memory allocation `RuntimeError` retries as normal backoff; non-OOM allocation or steady-state `RuntimeError` failures, unexpected fatal worker exceptions, and invalid post-start initialized state become retained runtime failures.
+
+**Tech Stack:** Python, pytest, KeepGPU single-GPU controllers, MCP service status contract.
+
+---
+
+## Background
+
+`KeepGPUServer.status()` already checks `GlobalGPUController.runtime_error()`, and the global controller already asks child controllers for `allocation_status()`. ROCm implements that hook and retains terminal allocation failures. CUDA and MPS currently lack the hook and only log unexpected post-start worker exceptions, which can leave service sessions looking active after the worker has failed.
+
+## Solution
+
+- Add no-GPU regression tests for CUDA and MPS direct worker loops.
+- Add `_failure_exc: Optional[Exception] = None` to CUDA and MPS controllers.
+- Reset `_failure_exc` at the start of `keep()` before a new worker launch.
+- Add `allocation_status()` to CUDA and MPS controllers, matching ROCm's read-only health hook.
+- Record retained `RuntimeError` details for non-OOM allocation and steady-state `RuntimeError` failures, unexpected non-`RuntimeError` worker exceptions, and invalid direct-loop initialized state when the synchronous startup-error path is not active.
+- Leave out-of-memory allocation `RuntimeError` retry behavior unchanged for CUDA/MPS.
+
+## Tasks
+
+- [x] Add failing CUDA regression test for unexpected post-start worker exception retention.
+- [x] Add failing MPS regression test for unexpected post-start worker exception retention.
+- [x] Run targeted RED tests and record evidence below.
+- [x] Implement minimal CUDA health hook and failure capture.
+- [x] Implement minimal MPS health hook and failure capture.
+- [x] Add the durable `AGENTS.md` invariant.
+- [x] Run targeted and full GREEN verification.
+- [x] Commit with `fix(controllers): surface cuda mps runtime failures`.
+
+## Local Review Follow-up
+
+Reviewer findings addressed on branch `codex/cuda-mps-runtime-health-status`:
+
+- CUDA and MPS steady-state compute `RuntimeError` failures after successful allocation were still hidden from `allocation_status()`. Non-OOM `RuntimeError` now becomes a retained runtime failure, while out-of-memory `RuntimeError` keeps the existing cache-clear/sleep/retry behavior.
+- CUDA and MPS `release()` skipped backend cleanup when a worker was already dead with `_failure_exc` set but `_stop_evt` was missing or unset. Release now performs backend cleanup and clears `_thread`/`_stop_evt` for dead runtime-failed workers, while preserving the existing dead-thread-without-failure "not running" behavior.
+- Added a small global status-path assertion that a child health error already prefixed with `rank N:` is returned as-is by `GlobalGPUController.runtime_error()`.
+
+Follow-up tasks:
+
+- [x] Add failing CUDA regression test for post-allocation non-OOM `RuntimeError` retention.
+- [x] Add failing MPS regression test for post-allocation non-OOM `RuntimeError` retention.
+- [x] Add failing CUDA/MPS release-contract regression test for dead runtime-failed workers with missing or unset stop events.
+- [x] Add global runtime-health passthrough assertion for rank-prefixed child failures.
+- [x] Run requested RED test command before production edits.
+- [x] Implement minimal CUDA/MPS fixes.
+- [x] Run focused and broader GREEN verification.
+- [x] Address local code-quality review P2 for allocation-time non-OOM
+      `RuntimeError` failures.
+- [x] Update durable docs to distinguish out-of-memory allocation retries from
+      fatal non-OOM allocation failures.
+
+## Verification Log
+
+- RED targeted tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_unexpected_post_start_worker_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_unexpected_post_start_worker_failure -q`
+  failed with 2 failures. CUDA and MPS both logged the unexpected
+  `ValueError("fatal compute exploded")`, then called the fake stop-event
+  `wait()`, which raised `AssertionError("fatal worker failures should stop immediately")`.
+- RED gap tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_unexpected_post_start_allocation_failure tests/cuda_controller/test_throttle.py::test_cuda_records_invalid_post_start_num_elements_without_startup_errors tests/macm_controller/test_macm_backoff.py::test_macm_records_unexpected_post_start_allocation_failure -q`
+  failed with 3 failures. CUDA/MPS allocation `ValueError("allocator corrupted")`
+  escaped from `torch.rand`, and CUDA invalid direct-loop `num_elements`
+  returned `allocation_status() is None`.
+- GREEN focused regression tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_unexpected_post_start_worker_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_unexpected_post_start_worker_failure tests/cuda_controller/test_throttle.py::test_cuda_records_unexpected_post_start_allocation_failure tests/cuda_controller/test_throttle.py::test_cuda_records_invalid_post_start_num_elements_without_startup_errors tests/macm_controller/test_macm_backoff.py::test_macm_records_unexpected_post_start_allocation_failure -q`
+  passed with `5 passed`.
+- GREEN targeted controller/service tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/rocm_controller/test_rocm_backoff.py tests/mcp/test_server.py -q`
+  passed with `135 passed, 9 skipped`.
+- Full tests: `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `545 passed, 11 skipped`.
+- Docs build: `PYTHONPATH=$PWD/src mkdocs build` passed. It emitted the repository's
+  existing Material for MkDocs notice and listed plan pages not included in nav.
+- Pre-commit: `pre-commit run --all-files` passed after the first pass
+  reformatted the CUDA and MPS test files.
+- Diff check: `git diff --check` passed.
+- Local review RED tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker -q`
+  failed with `6 failed`. CUDA and MPS non-OOM steady-state `RuntimeError`
+  failures called the forbidden wait path instead of returning immediately with
+  `_failure_exc`; CUDA/MPS dead runtime-failed release cases warned
+  `keep thread not running` and did not call backend cleanup.
+- Local review focused GREEN tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker -q`
+  passed with `6 passed in 1.22s`.
+- Local review broader controller/status tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  initially failed with 4 existing dead-thread-without-failure contract cases
+  because release read `_failure_exc` directly on `__new__`-constructed
+  controllers. After narrowing that check to `getattr(..., None)`, the same
+  command passed with `52 passed, 10 skipped in 1.29s`.
+- Coordinator final focused tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker -q`
+  passed with `6 passed in 1.15s`.
+- Coordinator final broader controller/status tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with `52 passed, 10 skipped in 1.26s`.
+- Coordinator final full tests:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `552 passed, 11 skipped`.
+- Coordinator final docs build:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material for MkDocs
+  notice and the repository's existing list of plan pages not included in nav.
+- Coordinator final pre-commit:
+  `pre-commit run --all-files` passed.
+- Coordinator final diff check:
+  `git diff --check` passed.
+- Local code-quality review P2 RED tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_allocation_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_allocation_runtime_error_as_failure -q`
+  failed with 2 failures. CUDA reached the forbidden wait path for
+  `RuntimeError("illegal memory access")`, and MPS attempted non-OOM cache
+  cleanup for `RuntimeError("mps allocation exploded")` instead of retaining a
+  runtime failure.
+- Local code-quality review P2 GREEN tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_allocation_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_allocation_runtime_error_as_failure -q`
+  passed with `2 passed in 1.17s`.
+- Final combined focused runtime-health tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_allocation_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_allocation_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker tests/global_controller/global_keep_test.py::test_global_runtime_error_preserves_rank_prefixed_child_failure -q`
+  passed with `9 passed in 1.18s`.
+- Final broader controller/status tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with `54 passed, 10 skipped in 1.26s`.
+- Final full tests after local review P2 fix:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `554 passed, 11 skipped`.
+- OOM retry coverage tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_retries_post_start_allocation_oom_without_failure tests/cuda_controller/test_throttle.py::test_cuda_retries_steady_state_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_post_start_allocation_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_steady_state_oom_without_failure -q`
+  passed with `4 passed in 1.29s`, closing the final local-review residual
+  test gap for recoverable OOM retry behavior.
+- Final focused runtime-health plus OOM tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_allocation_runtime_error_as_failure tests/cuda_controller/test_throttle.py::test_cuda_retries_post_start_allocation_oom_without_failure tests/cuda_controller/test_throttle.py::test_cuda_retries_steady_state_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_allocation_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_post_start_allocation_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_steady_state_oom_without_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker tests/global_controller/global_keep_test.py::test_global_runtime_error_preserves_rank_prefixed_child_failure -q`
+  passed with `13 passed in 1.30s`.
+- Final broader controller/status tests after OOM coverage:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with `58 passed, 10 skipped in 1.25s`.
+- Final full tests after OOM coverage:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `558 passed, 11 skipped`.

--- a/docs/plans/cuda-mps-runtime-health-status.md
+++ b/docs/plans/cuda-mps-runtime-health-status.md
@@ -140,3 +140,14 @@ Follow-up tasks:
   passed with `58 passed, 10 skipped in 1.25s`.
 - Final full tests after OOM coverage:
   `PYTHONPATH=$PWD/src pytest tests -q` passed with `558 passed, 11 skipped`.
+- Hosted CodeRabbit follow-up test:
+  Added `test_macm_records_invalid_post_start_num_elements_as_failure` to keep
+  MPS invalid post-start `vram_to_keep` coverage aligned with CUDA.
+- Hosted CodeRabbit follow-up verification:
+  `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py::test_macm_records_invalid_post_start_num_elements_as_failure tests/cuda_controller/test_throttle.py::test_cuda_records_invalid_post_start_num_elements_without_startup_errors -q`
+  passed with `2 passed in 1.29s`.
+- Hosted CodeRabbit follow-up broader tests:
+  `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with `59 passed, 10 skipped in 1.26s`.
+- Hosted CodeRabbit follow-up full tests:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `559 passed, 11 skipped`.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -87,6 +87,7 @@ class CudaGPUController(BaseGPUController):
 
         self._stop_evt: Optional[threading.Event] = None
         self._thread: Optional[threading.Thread] = None
+        self._failure_exc: Optional[Exception] = None
         self._num_elements: Optional[int] = None
 
     @staticmethod
@@ -107,6 +108,7 @@ class CudaGPUController(BaseGPUController):
             logger.warning("rank %s: keep thread already running", self.rank)
             return
 
+        self._failure_exc = None
         self._num_elements = int(self.vram_to_keep)
         if self._num_elements <= 0:
             raise ValueError("vram_to_keep must be positive")
@@ -152,7 +154,9 @@ class CudaGPUController(BaseGPUController):
         thread = self._thread
         if thread is not None and not thread.is_alive():
             stop_evt = self._stop_evt
-            if stop_evt is not None and stop_evt.is_set():
+            if (stop_evt is not None and stop_evt.is_set()) or getattr(
+                self, "_failure_exc", None
+            ) is not None:
                 torch.cuda.empty_cache()
                 self._thread = None
                 self._stop_evt = None
@@ -211,6 +215,8 @@ class CudaGPUController(BaseGPUController):
             logger.error("%s", exc)
             if startup_errors is not None:
                 startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
             if startup_evt is not None:
                 startup_evt.set()
             return
@@ -222,6 +228,8 @@ class CudaGPUController(BaseGPUController):
             logger.error("rank %s: CUDA startup failed: %s", self.rank, exc)
             if startup_errors is not None:
                 startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
             if startup_evt is not None:
                 startup_evt.set()
             return
@@ -233,6 +241,8 @@ class CudaGPUController(BaseGPUController):
             logger.error("%s", exc)
             if startup_errors is not None:
                 startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
             if startup_evt is not None:
                 startup_evt.set()
             return
@@ -260,8 +270,21 @@ class CudaGPUController(BaseGPUController):
                 break
             except RuntimeError as e:
                 logger.error("rank %s: failed to allocate matrix: %s", self.rank, e)
-                if stop_evt.wait(self.interval):
-                    return
+                if "out of memory" in str(e).lower():
+                    if stop_evt.wait(self.interval):
+                        return
+                    continue
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected CUDA keep worker failure: {e}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
         if matrix is None:
             logger.error("rank %s: failed to allocate matrix, exiting loop", self.rank)
             return
@@ -282,13 +305,28 @@ class CudaGPUController(BaseGPUController):
                 # Handle OOM by clearing cache; then sleep and continue
                 if "out of memory" in str(e).lower():
                     torch.cuda.empty_cache()
-                if stop_evt.wait(self.interval):
-                    break
-            except Exception:
-                # Log unexpected exceptions but keep running
-                logger.exception("rank %s: unexpected error", self.rank)
-                if stop_evt.wait(self.interval):
-                    break
+                    if stop_evt.wait(self.interval):
+                        break
+                    continue
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected CUDA keep worker failure: {e}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+
+    def allocation_status(self) -> Optional[Exception]:
+        """
+        Return fatal worker failure captured after startup, if any.
+
+        The reference assignment/read is thread-safe for CPython's GIL model.
+        """
+        return self._failure_exc
 
     # ------------------------------------------------------------------
     # Workload implementation

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -42,6 +42,7 @@ class MacMGPUController(BaseGPUController):
 
         self._stop_evt: Optional[threading.Event] = None
         self._thread: Optional[threading.Thread] = None
+        self._failure_exc: Optional[Exception] = None
         self._num_elements: Optional[int] = None
 
     def keep(self) -> None:
@@ -49,6 +50,7 @@ class MacMGPUController(BaseGPUController):
             logger.warning("rank %s: keep thread already running", self.rank)
             return
 
+        self._failure_exc = None
         self._num_elements = int(self.vram_to_keep)
         if self._num_elements <= 0:
             raise ValueError("vram_to_keep must be positive")
@@ -66,7 +68,9 @@ class MacMGPUController(BaseGPUController):
         thread = self._thread
         if thread is not None and not thread.is_alive():
             stop_evt = self._stop_evt
-            if stop_evt is not None and stop_evt.is_set():
+            if (stop_evt is not None and stop_evt.is_set()) or getattr(
+                self, "_failure_exc", None
+            ) is not None:
                 torch.mps.empty_cache()
                 gc.collect()
                 self._thread = None
@@ -114,14 +118,18 @@ class MacMGPUController(BaseGPUController):
     def _keep_loop(self) -> None:
         stop_evt = self._stop_evt
         if stop_evt is None:
-            logger.error("rank %s: stop event not initialized", self.rank)
+            self._failure_exc = RuntimeError(
+                f"rank {self.rank}: stop event not initialized"
+            )
+            logger.error("%s", self._failure_exc)
             return
 
         num_elements = self._num_elements if self._num_elements is not None else 0
         if num_elements <= 0:
-            logger.error(
-                "rank %s: invalid vram_to_keep=%s", self.rank, self.vram_to_keep
+            self._failure_exc = RuntimeError(
+                f"rank {self.rank}: invalid vram_to_keep={self.vram_to_keep}"
             )
+            logger.error("%s", self._failure_exc)
             return
 
         tensor = None
@@ -145,10 +153,23 @@ class MacMGPUController(BaseGPUController):
                 break
             except RuntimeError as exc:
                 logger.error("rank %s: failed to allocate tensor: %s", self.rank, exc)
-                torch.mps.empty_cache()
-                gc.collect()
-                if stop_evt.wait(self.interval):
-                    return
+                if "out of memory" in str(exc).lower():
+                    torch.mps.empty_cache()
+                    gc.collect()
+                    if stop_evt.wait(self.interval):
+                        return
+                    continue
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
 
         if tensor is None:
             logger.error("rank %s: failed to allocate tensor, exiting loop", self.rank)
@@ -170,12 +191,28 @@ class MacMGPUController(BaseGPUController):
                 if "out of memory" in str(exc).lower():
                     torch.mps.empty_cache()
                     gc.collect()
-                if stop_evt.wait(self.interval):
-                    break
-            except Exception:
-                logger.exception("rank %s: unexpected error", self.rank)
-                if stop_evt.wait(self.interval):
-                    break
+                    if stop_evt.wait(self.interval):
+                        break
+                    continue
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+
+    def allocation_status(self) -> Optional[Exception]:
+        """
+        Return fatal worker failure captured after startup, if any.
+
+        The reference assignment/read is thread-safe for CPython's GIL model.
+        """
+        return self._failure_exc
 
     @torch.no_grad()
     def _run_batch(self, tensor: torch.Tensor) -> None:

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -36,6 +36,14 @@ class _StopAfterWaits:
         return self.stopped
 
 
+class _StopWaitForbidden:
+    def is_set(self):
+        return False
+
+    def wait(self, _timeout):
+        raise AssertionError("fatal worker failures should stop immediately")
+
+
 def test_negative_busy_threshold_disables_backoff_without_gpu():
     assert CudaGPUController._should_run_batch(0, -1) is True
     assert CudaGPUController._should_run_batch(100, -1) is True
@@ -150,6 +158,216 @@ def test_cuda_negative_busy_threshold_allocates_even_when_busy(monkeypatch):
 
     assert len(allocations) == 1
     assert ctrl._stop_evt.wait_calls == 1
+
+
+def test_cuda_records_unexpected_post_start_worker_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(cuda_module.torch, "rand", lambda *args, **kwargs: object())
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_batch(_matrix):
+        raise ValueError("fatal compute exploded")
+
+    monkeypatch.setattr(ctrl, "_run_relu_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected CUDA keep worker failure: fatal compute exploded"
+    )
+
+
+def test_cuda_records_post_start_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(cuda_module.torch, "rand", lambda *args, **kwargs: object())
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_batch(_matrix):
+        raise RuntimeError("device-side assert")
+
+    monkeypatch.setattr(ctrl, "_run_relu_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error) == "rank 0: unexpected CUDA keep worker failure: device-side assert"
+    )
+
+
+def test_cuda_records_unexpected_post_start_allocation_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise ValueError("allocator corrupted")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error) == "rank 0: unexpected CUDA keep worker failure: allocator corrupted"
+    )
+
+
+def test_cuda_records_post_start_allocation_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("illegal memory access")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected CUDA keep worker failure: illegal memory access"
+    )
+
+
+def test_cuda_retries_post_start_allocation_oom_without_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAfterOneWait()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("CUDA out of memory")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    assert ctrl.allocation_status() is None
+    assert ctrl._stop_evt.wait_calls == 1
+
+
+def test_cuda_retries_steady_state_oom_without_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAfterOneWait()
+
+    cache_calls = []
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(
+        cuda_module.torch.cuda, "empty_cache", lambda: cache_calls.append("empty_cache")
+    )
+    monkeypatch.setattr(cuda_module.torch, "rand", lambda *args, **kwargs: object())
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_batch(_matrix):
+        raise RuntimeError("CUDA out of memory")
+
+    monkeypatch.setattr(ctrl, "_run_relu_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    assert ctrl.allocation_status() is None
+    assert ctrl._stop_evt.wait_calls == 1
+    assert cache_calls == ["empty_cache"]
+
+
+def test_cuda_records_invalid_post_start_num_elements_without_startup_errors(
+    monkeypatch,
+):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl.vram_to_keep = 0
+    ctrl._num_elements = 0
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: invalid vram_to_keep=0"
 
 
 @pytest.mark.skipif(

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -180,6 +180,29 @@ def test_global_runtime_error_reports_first_child_allocation_failure():
     assert str(error) == "rank 1: allocation retries exhausted"
 
 
+def test_global_runtime_error_preserves_rank_prefixed_child_failure():
+    child_error = RuntimeError(
+        "rank 0: unexpected CUDA keep worker failure: device-side assert"
+    )
+
+    class DummyController:
+        rank = 0
+
+        @staticmethod
+        def allocation_status():
+            return child_error
+
+    controller = GlobalGPUController.__new__(GlobalGPUController)
+    controller.controllers = [DummyController()]
+
+    error = controller.runtime_error()
+
+    assert error is child_error
+    assert (
+        str(error) == "rank 0: unexpected CUDA keep worker failure: device-side assert"
+    )
+
+
 def test_global_runtime_error_ignores_healthy_or_unreported_controllers():
     class ControllerWithoutHealthHook:
         rank = 0

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -215,6 +215,25 @@ def test_macm_records_post_start_allocation_runtime_error_as_failure(monkeypatch
     )
 
 
+def test_macm_records_invalid_post_start_num_elements_as_failure():
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.vram_to_keep = 0
+    ctrl._num_elements = 0
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: invalid vram_to_keep=0"
+
+
 def test_macm_retries_post_start_allocation_oom_without_failure(monkeypatch):
     import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
 

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -31,6 +31,14 @@ class _StopAfterWaits:
         return self.stopped
 
 
+class _StopWaitForbidden:
+    def is_set(self):
+        return False
+
+    def wait(self, _timeout):
+        raise AssertionError("fatal worker failures should stop immediately")
+
+
 def test_macm_unknown_utilization_backs_off_when_threshold_enabled():
     assert MacMGPUController._should_run_batch(None, 10) is False
 
@@ -91,3 +99,192 @@ def test_macm_negative_busy_threshold_allocates_with_unavailable_telemetry(
 
     assert len(allocations) == 1
     assert ctrl._stop_evt.wait_calls == 1
+
+
+def test_macm_records_unexpected_post_start_worker_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(macm_module.torch, "rand", lambda *args, **kwargs: object())
+
+    def fail_batch(_tensor):
+        raise ValueError("fatal compute exploded")
+
+    monkeypatch.setattr(ctrl, "_run_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected MPS keep worker failure: fatal compute exploded"
+    )
+
+
+def test_macm_records_post_start_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(macm_module.torch, "rand", lambda *args, **kwargs: object())
+
+    def fail_batch(_tensor):
+        raise RuntimeError("mps backend exploded")
+
+    monkeypatch.setattr(ctrl, "_run_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error) == "rank 0: unexpected MPS keep worker failure: mps backend exploded"
+    )
+
+
+def test_macm_records_unexpected_post_start_allocation_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    def fail_allocation(*args, **kwargs):
+        raise ValueError("allocator corrupted")
+
+    monkeypatch.setattr(macm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error) == "rank 0: unexpected MPS keep worker failure: allocator corrupted"
+    )
+
+
+def test_macm_records_post_start_allocation_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("mps allocation exploded")
+
+    monkeypatch.setattr(macm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected MPS keep worker failure: mps allocation exploded"
+    )
+
+
+def test_macm_retries_post_start_allocation_oom_without_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAfterOneWait()
+
+    cache_calls = []
+
+    monkeypatch.setattr(
+        macm_module.torch.mps,
+        "empty_cache",
+        lambda: cache_calls.append("empty_cache"),
+    )
+    monkeypatch.setattr(
+        "keep_gpu.single_gpu_controller.macm_gpu_controller.gc.collect",
+        lambda: cache_calls.append("gc.collect"),
+    )
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("MPS out of memory")
+
+    monkeypatch.setattr(macm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    assert ctrl.allocation_status() is None
+    assert ctrl._stop_evt.wait_calls == 1
+    assert cache_calls == ["empty_cache", "gc.collect"]
+
+
+def test_macm_retries_steady_state_oom_without_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAfterOneWait()
+
+    cache_calls = []
+
+    monkeypatch.setattr(
+        macm_module.torch.mps,
+        "empty_cache",
+        lambda: cache_calls.append("empty_cache"),
+    )
+    monkeypatch.setattr(
+        "keep_gpu.single_gpu_controller.macm_gpu_controller.gc.collect",
+        lambda: cache_calls.append("gc.collect"),
+    )
+    monkeypatch.setattr(macm_module.torch, "rand", lambda *args, **kwargs: object())
+
+    def fail_batch(_tensor):
+        raise RuntimeError("MPS out of memory")
+
+    monkeypatch.setattr(ctrl, "_run_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    assert ctrl.allocation_status() is None
+    assert ctrl._stop_evt.wait_calls == 1
+    assert cache_calls == ["empty_cache", "gc.collect"]

--- a/tests/single_gpu_controller/test_release_contract.py
+++ b/tests/single_gpu_controller/test_release_contract.py
@@ -140,6 +140,52 @@ def test_release_cleans_cache_after_timed_out_worker_later_exits(
     assert controller._stop_evt is None
 
 
+@pytest.mark.parametrize("stop_evt", [None, threading.Event()])
+@pytest.mark.parametrize(
+    ("controller_cls", "cache_path"),
+    [
+        (
+            CudaGPUController,
+            "keep_gpu.single_gpu_controller.cuda_gpu_controller.torch.cuda.empty_cache",
+        ),
+        (
+            MacMGPUController,
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.torch.mps.empty_cache",
+        ),
+    ],
+)
+def test_release_cleans_dead_runtime_failed_cuda_mps_worker(
+    monkeypatch, controller_cls, cache_path, stop_evt
+):
+    controller = controller_cls.__new__(controller_cls)
+    controller.rank = 0
+    controller.interval = 0.01
+    thread = ControllableThread()
+    thread.alive = False
+    controller._thread = thread
+    controller._stop_evt = stop_evt
+    controller._failure_exc = RuntimeError("worker failed")
+
+    cache_calls = []
+    monkeypatch.setattr(cache_path, lambda: cache_calls.append("empty_cache"))
+    if controller_cls is MacMGPUController:
+        monkeypatch.setattr(
+            "keep_gpu.single_gpu_controller.macm_gpu_controller.gc.collect",
+            lambda: cache_calls.append("gc.collect"),
+        )
+
+    controller.release()
+
+    expected_calls = (
+        ["empty_cache", "gc.collect"]
+        if controller_cls is MacMGPUController
+        else ["empty_cache"]
+    )
+    assert cache_calls == expected_calls
+    assert controller._thread is None
+    assert controller._stop_evt is None
+
+
 @pytest.mark.parametrize(
     ("controller_cls", "cache_path", "logger_path", "extra_attrs"),
     [


### PR DESCRIPTION
## Summary
- retain CUDA/MPS post-start worker failures through allocation_status(), including non-OOM allocation and steady-state RuntimeError failures
- preserve recoverable OOM retry/backoff behavior with explicit no-GPU regression tests
- clean dead runtime-failed CUDA/MPS workers during release and document the runtime-health contract in AGENTS.md and docs/plans

## Verification
- PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_runtime_error_as_failure tests/cuda_controller/test_throttle.py::test_cuda_records_post_start_allocation_runtime_error_as_failure tests/cuda_controller/test_throttle.py::test_cuda_retries_post_start_allocation_oom_without_failure tests/cuda_controller/test_throttle.py::test_cuda_retries_steady_state_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_records_post_start_allocation_runtime_error_as_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_post_start_allocation_oom_without_failure tests/macm_controller/test_macm_backoff.py::test_macm_retries_steady_state_oom_without_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_cuda_mps_worker tests/global_controller/global_keep_test.py::test_global_runtime_error_preserves_rank_prefixed_child_failure -q (`13 passed`)
- PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/macm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q (`58 passed, 10 skipped`)
- PYTHONPATH=$PWD/src pytest tests -q (`558 passed, 11 skipped`)
- PYTHONPATH=$PWD/src mkdocs build (passed; existing Material notice and unnav'd plan-page list)
- pre-commit run --all-files (passed)
- git diff --check (passed)

## Local Review
- Spec review: no P0/P1/P2/P3 findings; OOM retry gap verified closed
- Quality review: no P0/P1/P2/P3 findings; focused runtime-health shard passed read-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime health reporting for CUDA and MPS GPU controllers so fatal post-start failures are now surfaced to the main service status.
  * Improved release handling to clear GPU cache and reset state when a controller has failed.

* **Bug Fixes**
  * Kept out-of-memory situations on a retry path without marking the service as failed.
  * Preserved existing error details when a child controller reports a runtime failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->