### PR TITLE
[mcp] fix: reject rpc get with json 405

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ This file defines how coding agents should work in this repository.
   `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
   JSON `405 Method Not Allowed` responses with `Allow`, and unknown `/api/*`
   routes return structured JSON `404 Unknown endpoint` responses.
+- `/rpc` is a POST-only JSON-RPC endpoint; `GET /rpc` must return structured
+  JSON `405 Method Not Allowed` with `Allow: POST` and must never serve the
+  dashboard/static fallback.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/plans/rpc-get-method-json-error.md
+++ b/docs/plans/rpc-get-method-json-error.md
@@ -1,0 +1,65 @@
+# RPC GET Method JSON Error Plan
+
+## Background
+
+The HTTP MCP service documents `/rpc` as a JSON-RPC compatibility endpoint for
+`POST` requests. The method classifier currently lists `/rpc` as allowing both
+`GET` and `POST`, while `do_GET()` has no dedicated `/rpc` branch. As a result,
+`GET /rpc` can fall through to the dashboard/static fallback and return HTML.
+
+## Goal
+
+Make `GET /rpc` return a machine-readable JSON `405 Method Not Allowed` response
+with `Allow: POST`, while preserving `POST /rpc` JSON-RPC behavior and `GET /`
+dashboard/static behavior.
+
+## Solution
+
+- Add RED regression coverage for `GET /rpc`.
+- Keep a guard proving `GET /` still serves dashboard/static content.
+- Make `/rpc` POST-only in the allowed-method classifier.
+- Route `GET /rpc` through the existing structured JSON `405` helper instead of
+  the static fallback.
+- Add an explicit durable invariant to `AGENTS.md` if the current guidance does
+  not name the `/rpc` GET/static fallback case.
+
+## Tasks
+
+- [x] Add RED regression tests in `tests/mcp/test_http_api.py`.
+- [x] Run the focused RED test and confirm it fails because `GET /rpc` returns
+      dashboard/static content instead of JSON `405`.
+- [x] Implement the narrow server fix in `src/keep_gpu/mcp/server.py`.
+- [x] Update `AGENTS.md` with the explicit `/rpc` GET invariant.
+- [x] Run focused GREEN tests.
+- [x] Run targeted MCP HTTP/API tests.
+- [x] Run `mkdocs build`, `pre-commit run --all-files`, and `git diff --check`.
+- [x] Run full `pytest` if cheap enough; otherwise record why it was skipped.
+- [x] Resolve local review feedback by adding explicit `HEAD /rpc` 405 coverage.
+
+## Verification Log
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_rpc_rejects_unsupported_options_with_json_405 tests/mcp/test_http_api.py::test_http_rpc_get_rejects_with_json_405_instead_of_static_fallback -q`
+  failed with 2 failures. `OPTIONS /rpc` returned `Allow: GET, POST` instead of
+  `Allow: POST`; `GET /rpc` returned HTTP `200` instead of JSON `405`.
+- GREEN focused:
+  the same command passed with 2 tests.
+- HTTP API shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with 67
+  tests, including `test_http_health_and_static_index` for the `GET /`
+  dashboard/static guard.
+- MCP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with 168 tests.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 561 tests and 11 skipped
+  after the local review follow-up.
+- Docs build:
+  `PYTHONPATH=$PWD/src mkdocs build` passed. It emitted the existing Material
+  for MkDocs warning and unnav'd docs notices, including this plan page.
+- Hooks:
+  `pre-commit run --all-files` passed.
+- Whitespace:
+  `git diff --check` passed.
+- Local review follow-up:
+  added `test_http_rpc_head_rejects_with_json_405_and_empty_body` so `HEAD /rpc`
+  stays JSON-routed with `Allow: POST` and an empty body.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -819,7 +819,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         if path == "/":
             return ("GET", "POST")
         if path == "/rpc":
-            return ("GET", "POST")
+            return ("POST",)
         return None
 
     def _send_api_rpc_unsupported_method_response(self) -> bool:
@@ -933,6 +933,10 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if path == "/rpc":
+                self._send_api_rpc_unsupported_method_response()
+                return
+
             server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
             if path == "/health":
                 self._json_response(200, {"ok": True})

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -209,11 +209,50 @@ def test_http_rpc_rejects_unsupported_options_with_json_405():
 
     assert status == 405
     assert headers.get("content-type") == "application/json"
-    assert _allow_methods(headers) == {"GET", "POST"}
+    assert _allow_methods(headers) == {"POST"}
     assert b"<html" not in body.lower()
     assert json.loads(body.decode("utf-8")) == {
         "error": {"message": "Method not allowed"}
     }
+
+
+def test_http_rpc_get_rejects_with_json_405_instead_of_static_fallback():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("GET", f"{base}/rpc")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == {"POST"}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Method not allowed"}
+    }
+
+
+def test_http_rpc_head_rejects_with_json_405_and_empty_body():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}/rpc")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == {"POST"}
+    assert body == b""
 
 
 @pytest.mark.parametrize("method", ["PUT", "OPTIONS"])


### PR DESCRIPTION
## Summary
- Make `/rpc` POST-only in the MCP HTTP method classifier.
- Return structured JSON `405 Method Not Allowed` with `Allow: POST` for `GET /rpc`, `HEAD /rpc`, and unsupported `/rpc` methods instead of serving dashboard/static HTML.
- Add regression coverage plus AGENTS and plan documentation for the `/rpc` invariant.

## Test Plan
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_rpc_rejects_unsupported_options_with_json_405 tests/mcp/test_http_api.py::test_http_rpc_get_rejects_with_json_405_instead_of_static_fallback tests/mcp/test_http_api.py::test_http_rpc_head_rejects_with_json_405_and_empty_body -q`
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q`
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp -q`
- [x] `PYTHONPATH=$PWD/src pytest tests -q`
- [x] `PYTHONPATH=$PWD/src mkdocs build`
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Local Review
- [x] API/protocol local subagent review: ready to merge; HEAD coverage suggestion resolved.
- [x] Reliability/regression local subagent review: ready to merge.
- [x] Follow-up local subagent review after amended HEAD coverage: ready to merge.
