### PR TITLE
[rocm] fix: retain runtime worker failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,10 +154,10 @@ This file defines how coding agents should work in this repository.
   deferred allocation behavior, not a runtime failure.
 - Controller runtime-health hooks used by service status must stay non-blocking
   and read-only because status refresh runs under the session lock.
-- CUDA and MPS controllers must retain fatal post-start worker failures by way of
-  `allocation_status()` so `GlobalGPUController.runtime_error()` can move
-  service status to `runtime_failed`; normal busy/unknown telemetry backoff and
-  out-of-memory allocation `RuntimeError` retries are not runtime failures.
+- CUDA, ROCm, and MPS controllers must retain fatal post-start worker failures
+  by way of `allocation_status()` so `GlobalGPUController.runtime_error()` can
+  move service status to `runtime_failed`; normal busy/unknown telemetry backoff
+  and out-of-memory allocation `RuntimeError` retries are not runtime failures.
   Non-OOM allocation or steady-state `RuntimeError` failures after startup must
   be retained as runtime failures.
 - Single-GPU `keep()` must not report success until fatal backend startup setup

--- a/docs/plans/rocm-runtime-failure-retention.md
+++ b/docs/plans/rocm-runtime-failure-retention.md
@@ -1,0 +1,80 @@
+# ROCm Runtime Failure Retention Plan
+
+## Background
+
+CUDA and MPS controllers retain unexpected post-start worker failures in
+`_failure_exc`, which lets `GlobalGPUController.runtime_error()` and the service
+status path report `state="runtime_failed"` instead of leaving a dead or broken
+worker looking active.
+
+ROCm has the same health hook shape, but its loop still treats non-OOM
+post-start `RuntimeError`s and unexpected worker exceptions as sleep-and-retry
+conditions. A dead ROCm worker with `_failure_exc` is also not cleaned by
+`release()` unless the stop event was already set.
+
+## Goal
+
+Make ROCm runtime-failure behavior match the shared controller contract: OOM
+allocation/backoff remains retryable, while non-OOM worker failures are retained
+and dead failed workers release cache/state cleanly.
+
+## Solution
+
+- Add RED coverage for ROCm non-OOM allocation and steady-state worker failures.
+- Add RED release-contract coverage for dead ROCm workers with retained failures.
+- Update the ROCm worker loop to record unexpected fatal failures in
+  `_failure_exc` and return, preserving OOM retry behavior.
+- Update ROCm `release()` to clear cache/state when a retained failed worker is
+  already dead, matching CUDA/MPS.
+- Update `AGENTS.md` so future controller work treats ROCm as part of the shared
+  runtime-failure contract.
+
+## Tasks
+
+- [x] Write failing ROCm tests for non-OOM allocation failure, steady-state
+      `RuntimeError`, and unexpected worker exception retention.
+- [x] Write failing release-contract test for dead runtime-failed ROCm worker
+      cleanup.
+- [x] Implement the minimal ROCm controller changes.
+- [x] Update `AGENTS.md` and this plan with verification evidence.
+- [x] Run targeted ROCm/controller tests.
+- [x] Run broader tests, docs build, pre-commit, and whitespace checks.
+- [x] Request local subagent code review and resolve findings before PR.
+- [ ] Open PR, resolve hosted comments/checks, squash merge, and clean the
+      worktree/branches.
+
+## Verification Log
+
+- Baseline before edits:
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with 56 passed, 1 skipped.
+- RED after adding regression tests:
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_unexpected_post_start_worker_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_runtime_error_as_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_allocation_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_worker -q`
+  failed with five ROCm-specific failures: fatal worker paths called
+  `stop_evt.wait()` instead of retaining `_failure_exc`, and dead failed ROCm
+  release skipped cache cleanup.
+- GREEN after implementation:
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_unexpected_post_start_worker_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_runtime_error_as_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_allocation_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_worker -q`
+  passed with 9 passed.
+- Local subagent reviewers found one remaining gap: non-`RuntimeError`
+  exceptions in ROCm's post-start initial allocation loop could still exit the
+  worker without `_failure_exc`. Added
+  `test_rocm_records_unexpected_post_start_allocation_failure` and the matching
+  fatal-retention branch. The repaired focused command
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_unexpected_post_start_allocation_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_unexpected_post_start_worker_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_runtime_error_as_failure tests/rocm_controller/test_rocm_backoff.py::test_rocm_records_post_start_allocation_runtime_error_as_failure tests/single_gpu_controller/test_release_contract.py::test_release_cleans_dead_runtime_failed_worker -q`
+  passed with 10 passed.
+- Focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q`
+  passed with 62 passed, 1 skipped after the local review fix.
+- Broader affected tests:
+  `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller tests/mcp tests/utilities/test_gpu_info.py -q`
+  passed with 298 passed, 2 skipped before the review fix.
+- Full suite after the local review fix:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 574 passed, 11 skipped.
+- Docs/hooks/whitespace after the local review fix:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan notices; `pre-commit run --all-files` passed; `git diff
+  --check` passed.
+- Local subagent re-review approved after verifying the prior non-`RuntimeError`
+  initial-allocation gap was resolved; only the stale plan count above was
+  noted and fixed.

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -126,7 +126,9 @@ class RocmGPUController(BaseGPUController):
             thread = self._thread
             if thread is not None and not thread.is_alive():
                 stop_evt = self._stop_evt
-                if stop_evt is not None and stop_evt.is_set():
+                if (stop_evt is not None and stop_evt.is_set()) or getattr(
+                    self, "_failure_exc", None
+                ) is not None:
                     torch.cuda.empty_cache()
                     self._thread = None
                     self._stop_evt = None
@@ -255,6 +257,12 @@ class RocmGPUController(BaseGPUController):
                     ),
                     exc,
                 )
+                if "out of memory" not in str(exc).lower():
+                    self._failure_exc = RuntimeError(
+                        f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
+                    )
+                    logger.exception("%s", self._failure_exc)
+                    return
                 if (
                     self.max_allocation_retries is not None
                     and attempts >= self.max_allocation_retries
@@ -266,6 +274,12 @@ class RocmGPUController(BaseGPUController):
                     return
                 if stop_evt.wait(self.interval):
                     return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
 
         if tensor is None:
             logger.error("rank %s: failed to allocate tensor, exiting loop", self.rank)
@@ -288,12 +302,20 @@ class RocmGPUController(BaseGPUController):
             except RuntimeError as exc:
                 if "out of memory" in str(exc).lower():
                     torch.cuda.empty_cache()
-                if stop_evt.wait(self.interval):
-                    break
-            except Exception:
-                logger.exception("rank %s: unexpected error", self.rank)
-                if stop_evt.wait(self.interval):
-                    break
+                    if stop_evt.wait(self.interval):
+                        break
+                    continue
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
+            except Exception as exc:
+                self._failure_exc = RuntimeError(
+                    f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
+                )
+                logger.exception("%s", self._failure_exc)
+                return
 
     def allocation_status(self) -> Optional[Exception]:
         """

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -152,6 +152,14 @@ class _StopAfterWaits:
         return self.stopped
 
 
+class _StopWaitForbidden:
+    def is_set(self):
+        return False
+
+    def wait(self, _timeout):
+        raise AssertionError("fatal worker failures should stop immediately")
+
+
 def test_rocm_unknown_utilization_backs_off_when_threshold_enabled():
     assert RocmGPUController._should_run_batch(None, 10) is False
 
@@ -284,3 +292,132 @@ def test_rocm_negative_busy_threshold_allocates_even_when_busy(monkeypatch):
 
     assert len(allocations) == 1
     assert ctrl._stop_evt.wait_calls == 1
+
+
+def test_rocm_records_unexpected_post_start_worker_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(rocm_module.torch, "rand", lambda *args, **kwargs: object())
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_batch(_tensor):
+        raise ValueError("fatal compute exploded")
+
+    monkeypatch.setattr(ctrl, "_run_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected ROCm keep worker failure: fatal compute exploded"
+    )
+
+
+def test_rocm_records_post_start_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(rocm_module.torch, "rand", lambda *args, **kwargs: object())
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_batch(_tensor):
+        raise RuntimeError("rocm backend exploded")
+
+    monkeypatch.setattr(ctrl, "_run_batch", fail_batch)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected ROCm keep worker failure: rocm backend exploded"
+    )
+
+
+def test_rocm_records_post_start_allocation_runtime_error_as_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("rocm allocation exploded")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected ROCm keep worker failure: rocm allocation exploded"
+    )
+
+
+def test_rocm_records_unexpected_post_start_allocation_failure(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise ValueError("allocator corrupted")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop()
+
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error) == "rank 0: unexpected ROCm keep worker failure: allocator corrupted"
+    )

--- a/tests/single_gpu_controller/test_release_contract.py
+++ b/tests/single_gpu_controller/test_release_contract.py
@@ -142,20 +142,27 @@ def test_release_cleans_cache_after_timed_out_worker_later_exits(
 
 @pytest.mark.parametrize("stop_evt", [None, threading.Event()])
 @pytest.mark.parametrize(
-    ("controller_cls", "cache_path"),
+    ("controller_cls", "cache_path", "extra_attrs"),
     [
         (
             CudaGPUController,
             "keep_gpu.single_gpu_controller.cuda_gpu_controller.torch.cuda.empty_cache",
+            {},
+        ),
+        (
+            RocmGPUController,
+            "keep_gpu.single_gpu_controller.rocm_gpu_controller.torch.cuda.empty_cache",
+            {"_rocm_smi": None},
         ),
         (
             MacMGPUController,
             "keep_gpu.single_gpu_controller.macm_gpu_controller.torch.mps.empty_cache",
+            {},
         ),
     ],
 )
-def test_release_cleans_dead_runtime_failed_cuda_mps_worker(
-    monkeypatch, controller_cls, cache_path, stop_evt
+def test_release_cleans_dead_runtime_failed_worker(
+    monkeypatch, controller_cls, cache_path, extra_attrs, stop_evt
 ):
     controller = controller_cls.__new__(controller_cls)
     controller.rank = 0
@@ -165,6 +172,8 @@ def test_release_cleans_dead_runtime_failed_cuda_mps_worker(
     controller._thread = thread
     controller._stop_evt = stop_evt
     controller._failure_exc = RuntimeError("worker failed")
+    for name, value in extra_attrs.items():
+        setattr(controller, name, value)
 
     cache_calls = []
     monkeypatch.setattr(cache_path, lambda: cache_calls.append("empty_cache"))


### PR DESCRIPTION
## Summary
- retain ROCm non-OOM post-start allocation/compute failures in `allocation_status()` so service status can become `runtime_failed`
- keep ROCm OOM retry/backoff behavior intact
- clean dead runtime-failed ROCm workers on `release()`, matching CUDA/MPS lifecycle cleanup
- update `AGENTS.md` and add the ROCm runtime-failure plan/verification log

## Local Review
- Local spec/code-quality subagent review found a missing non-`RuntimeError` initial-allocation path; fixed with regression coverage
- Local re-review approved after confirming the finding and stale plan-count comment were resolved

## Verification
- `PYTHONPATH=$PWD/src pytest tests/rocm_controller tests/single_gpu_controller/test_release_contract.py tests/global_controller/global_keep_test.py -q` -> 62 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 574 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed (known Material warning and unnav'd plan notices)
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed
