### PR TITLE
[mcp] fix: propagate tool internal errors

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -91,9 +91,13 @@ conditions, such as an unsupported controller platform or no usable visible
 GPUs, return `-32000` with the startup message. Unexpected server failures use
 `-32603 Internal error`.
 
-MCP `tools/call` responses keep protocol envelopes successful. If a tool cannot
-start because hardware or the platform is unavailable, the response contains
-`result.isError=true` and the startup-unavailable text in the tool content.
+MCP `tools/call` responses keep protocol envelopes successful for normal tool
+results, public tool-input validation failures, and expected hardware/platform
+startup-unavailable failures. Those tool-level failures return
+`result.isError=true` with the message in tool content. Protocol shape errors,
+such as unknown tools, still return JSON-RPC errors such as `-32602`, and
+unexpected internal controller/runtime failures return JSON-RPC
+`-32603 Internal error`.
 
 For supported REST route/method calls, service errors stay parseable. Public
 validation failures return JSON `400` responses, unknown API routes return JSON

--- a/docs/plans/mcp-tool-internal-errors.md
+++ b/docs/plans/mcp-tool-internal-errors.md
@@ -1,0 +1,72 @@
+# MCP Tool Internal Errors Plan
+
+## Background
+
+Direct JSON-RPC keeps public validation and startup-unavailable failures separate
+from unexpected server failures. MCP `tools/call`, however, currently catches
+every exception from KeepGPU tool execution and returns a successful JSON-RPC
+response with `result.isError=true`.
+
+That hides arbitrary controller/runtime failures as tool-level content instead
+of surfacing the JSON-RPC `-32603 Internal error` envelope documented for
+unexpected server failures.
+
+## Goal
+
+Keep MCP tool envelopes honest: expected startup-unavailable failures remain MCP
+tool errors (`result.isError=true`), while unexpected internal failures return
+JSON-RPC `-32603` like direct JSON-RPC.
+
+## Solution
+
+- Add RED coverage for `tools/call` when a KeepGPU method raises an unexpected
+  `RuntimeError`.
+- Preserve existing `SessionStartupUnavailable` behavior as
+  `result.isError=true`.
+- Preserve existing public tool-input validation behavior as
+  `result.isError=true`, while protocol shape errors such as unknown tools still
+  return JSON-RPC `-32602`.
+- Let other unexpected exceptions propagate to `_handle_request()`, which already
+  converts them to JSON-RPC `-32603`.
+- Update verification evidence in this plan; AGENTS/docs already state the
+  target contract.
+
+## Tasks
+
+- [x] Write failing MCP `tools/call` internal-error regression test.
+- [x] Implement the minimal exception split in `_mcp_call_tool()`.
+- [x] Run focused MCP tests and broader verification.
+- [x] Run local subagent review and resolve findings before PR.
+- [ ] Open PR, resolve hosted comments/checks, squash merge, and clean the
+      worktree/branches.
+
+## Verification Log
+
+- Baseline before edits:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  passed with 169 passed.
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_tools_call_unexpected_failure_returns_jsonrpc_internal_error -q`
+  failed because the unexpected controller failure returned a successful
+  `result.isError=true` response.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_mcp_tools_call_unexpected_failure_returns_jsonrpc_internal_error tests/mcp/test_server.py::test_mcp_tools_call_startup_unavailable_returns_tool_error tests/mcp/test_server.py::test_mcp_tools_call_rejects_oversized_integer_vram_as_tool_error tests/mcp/test_server.py::test_mcp_tools_call_unknown_tool_returns_protocol_error -q`
+  passed with 4 passed after preserving validation/tool errors and propagating
+  unexpected failures.
+- Focused MCP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q`
+  passed with 170 passed.
+- Broader affected tests:
+  `PYTHONPATH=$PWD/src pytest tests/mcp tests/utilities/test_gpu_info.py tests/global_controller -q`
+  passed with 249 passed, 2 skipped.
+- Docs/hooks/whitespace:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan notices; `pre-commit run --all-files` passed; `git diff
+  --check` passed.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 575 passed, 11 skipped.
+- Local subagent review found that `docs/guides/mcp.md` still implied every
+  `tools/call` failure kept a successful protocol envelope. Updated the guide to
+  distinguish normal results, validation failures, startup-unavailable tool
+  errors, protocol shape errors, and unexpected internal JSON-RPC `-32603`
+  failures.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -684,7 +684,9 @@ def _mcp_call_tool(server: KeepGPUServer, params: Dict[str, Any]) -> Dict[str, A
         raise JSONRPCError(JSONRPC_INVALID_PARAMS, f"Unknown tool: {name}")
     try:
         return _mcp_tool_result(_call_keepgpu_method(server, name, arguments))
-    except Exception as exc:
+    except JSONRPCError as exc:
+        if exc.code not in (JSONRPC_INVALID_PARAMS, JSONRPC_STARTUP_UNAVAILABLE):
+            raise
         return _mcp_tool_result(str(exc), True)
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -902,6 +902,31 @@ def test_mcp_tools_call_startup_unavailable_returns_tool_error():
     assert server.status()["active_jobs"] == []
 
 
+def test_mcp_tools_call_unexpected_failure_returns_jsonrpc_internal_error():
+    def failing_factory(**kwargs):
+        raise RuntimeError("controller exploded")
+
+    server = KeepGPUServer(controller_factory=cast(Any, failing_factory))
+    req = {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/call",
+        "params": {
+            "name": "start_keep",
+            "arguments": {"job_id": "tool-internal-error", "gpu_ids": [0]},
+        },
+    }
+
+    resp = _handle_request(server, req)
+
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] == 5
+    assert "result" not in resp
+    assert resp["error"]["code"] == JSONRPC_INTERNAL_ERROR
+    assert "controller exploded" in resp["error"]["message"]
+    assert server.status()["active_jobs"] == []
+
+
 def test_mcp_tools_call_unknown_tool_returns_protocol_error():
     server = make_server()
     req = {


### PR DESCRIPTION
## Summary
- keep MCP `tools/call` tool-level `isError=true` responses for validation and expected startup-unavailable failures
- let unexpected controller/runtime failures propagate to JSON-RPC `-32603 Internal error`
- document the MCP error-envelope split and add the implementation plan/evidence

## Local Review
- Local subagent review found stale MCP guide wording; fixed and re-reviewed cleanly

## Verification
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> 170 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp tests/utilities/test_gpu_info.py tests/global_controller -q` -> 249 passed, 2 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 575 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed (known Material warning and unnav'd plan notices)
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how MCP tool-call errors are reported, including when errors appear in tool results versus JSON-RPC responses.

* **Bug Fixes**
  * Improved error handling so unexpected internal failures now return a proper JSON-RPC internal error instead of being treated like normal tool errors.
  * Preserved existing handling for validation and startup-unavailable cases.

* **Tests**
  * Added coverage to verify unexpected failures return the expected JSON-RPC error and do not leave active sessions open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->