### PR TITLE
[rocm] fix: hide unstartable listed devices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,16 @@ This file defines how coding agents should work in this repository.
 - Treat public `gpu_ids` as visible device ordinals after user-supplied CUDA or ROCm visibility filtering. Do not rewrite visibility masks inside KeepGPU command paths; reject explicit CUDA/ROCm ordinals outside the current visible device count before starting keep workers.
 - Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` numeric/UUID tokens to the correct NVML handle. If that mapping is malformed, duplicate/equivalent, ambiguous, or unsupported, return `None` without partial NVML handle queries so eco-safe backoff applies instead of falling back to a possibly wrong physical index.
 - Keep ROCm telemetry aligned with visible ROCm ordinals: resolve `ROCR_VISIBLE_DEVICES` as the base mask and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. If the mapping is malformed, conflicting, unsupported, or out of range, return unavailable utilization rather than querying a guessed SMI index.
-- Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus` must expose `id` as the visible ordinal users can pass as `gpu_ids`; physical/vendor identifiers belong in explicit metadata fields such as `physical_id` and must not be accepted implicitly as selection IDs. CUDA NVML records must only be returned when Torch CUDA can address the same visible ordinal set; do not advertise NVML-only devices that controller startup cannot use.
+- Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus`
+  must expose `id` as the visible ordinal users can pass as `gpu_ids`;
+  physical/vendor identifiers belong in explicit metadata fields such as
+  `physical_id` and must not be accepted implicitly as selection IDs. CUDA NVML
+  records must only be returned when Torch CUDA can address the same visible
+  ordinal set; do not advertise NVML-only devices that controller startup
+  cannot use. ROCm records must likewise be limited to visible ordinals that
+  `torch.cuda.set_device()` can select; nullable ROCm memory fields mean memory
+  telemetry is unavailable after successful selection, not that the device is
+  unstartable.
 - Keep GPU listing platform precedence aligned with controller platform
   detection: HIP/ROCm torch builds must prefer ROCm listing over NVML CUDA
   listing, and must not fall back to NVML CUDA records when torch's active

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ Flags that matter:
   - `keep-gpu service-stop`: stop the ownership-verified auto-started local daemon.
   - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
     `id` is the visible ordinal accepted by `--gpu-ids`; optional
-    `physical_id`/`uuid` fields are metadata only. CUDA devices are listed only
-    when Torch CUDA can start the same visible ordinal set; NVML-only inventory
-    is hidden instead of producing unusable `gpu_ids`.
+    `physical_id`/`uuid` fields are metadata only. CUDA and ROCm devices are
+    listed only when Torch can select the same visible ordinal; NVML-only or
+    unselectable ROCm inventory is hidden instead of producing unusable
+    `gpu_ids`.
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
     that tools such as `jq` can parse directly. Malformed JSON-RPC service
@@ -176,7 +177,7 @@ to zero devices.
   curl http://127.0.0.1:8765/health
   curl http://127.0.0.1:8765/api/sessions
   ```
-- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. On CUDA, NVML records are returned only when Torch CUDA can address the same visible ordinal set, so NVML-only devices are not advertised as startable. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Public numeric session inputs must stay finite and bounded: interval values are positive seconds, including fractional seconds, capped by the runtime wait limit, and VRAM byte-equivalent values are capped at 1 PiB. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
+- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. On CUDA, NVML records are returned only when Torch CUDA can address the same visible ordinal set, so NVML-only devices are not advertised as startable. On ROCm, records are returned only when Torch can select the visible ordinal; nullable memory fields mean memory telemetry is unavailable after successful selection. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Public numeric session inputs must stay finite and bounded: interval values are positive seconds, including fractional seconds, capped by the runtime wait limit, and VRAM byte-equivalent values are capped at 1 PiB. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
 - Supported REST route/method failures remain machine-readable: validation
   errors use JSON `400` responses, unknown API routes use JSON `404`, and
   unexpected service/runtime failures use JSON `500` instead of closing the

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -123,7 +123,11 @@ CUDA fallback, even if NVML is available on the host.
 GPU listing follows the same precedence. On HIP/ROCm torch builds, `list_gpus`
 prefers ROCm records and ROCm SMI metadata instead of returning NVML CUDA records
 first on mixed hosts. If ROCm SMI is unavailable, listing falls back to
-torch's HIP-backed device records rather than NVML CUDA records.
+torch's HIP-backed device records rather than NVML CUDA records. ROCm records
+are emitted only for visible ordinals that `torch.cuda.set_device()` can select,
+so list output does not advertise GPU IDs that controller startup cannot use.
+Memory probing remains best-effort after selection succeeds; nullable ROCm
+memory fields mean unavailable telemetry, not a startability failure.
 On non-HIP CUDA builds, NVML records are returned only when Torch CUDA reports a
 matching positive visible-device count and each visible ordinal can be selected
 with `torch.cuda.set_device()`. If that NVML/Torch trust check fails, listing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,10 +100,11 @@ keep-gpu --interval 120 --gpu-ids 0 --vram 1GiB
   (seconds), including fractional values such as `0.5`. Values above the
   Python runtime wait limit are rejected.
 - `--gpu-ids` limits the job to a subset of visible device ordinals. Set
-  `CUDA_VISIBLE_DEVICES` before starting KeepGPU if you need physical-device
-  filtering. In service mode, `keep-gpu list-gpus` and the dashboard show these
-  same start-compatible visible ordinals as GPU IDs; physical metadata is only
-  informational.
+  `CUDA_VISIBLE_DEVICES` on CUDA, or `ROCR_VISIBLE_DEVICES` with a matching
+  `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay on ROCm, before starting
+  KeepGPU if you need physical-device filtering. In service mode,
+  `keep-gpu list-gpus` and the dashboard show these same start-compatible
+  visible ordinals as GPU IDs; physical metadata is only informational.
 - `--vram` accepts human-readable sizes or bare bytes; KeepGPU allocates one
   tensor of that size. Byte-equivalent values above 1 PiB are rejected.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -83,9 +83,11 @@ keep-gpu list-gpus
 The `id` field in this output is the visible ordinal to pass to `--gpu-ids`.
 On CUDA, NVML telemetry is listed only when Torch CUDA can start the same
 visible ordinal set; NVML-only devices are hidden rather than advertised as
-usable selections. `status`, `stop`, and `list-gpus` print JSON objects, including
-`{"error": "..."}` for service/runtime errors after CLI parsing succeeds, that
-can be parsed directly with `jq` or a single `json.loads()` call.
+usable selections. On ROCm, listed records are limited to visible ordinals that
+Torch can select; nullable memory fields mean memory telemetry is unavailable
+after selection succeeds. `status`, `stop`, and `list-gpus` print JSON objects,
+including `{"error": "..."}` for service/runtime errors after CLI parsing
+succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes are reported as JSON error objects instead
 of empty success results. Invalid service endpoints are also reported as JSON
 errors before any RPC or stop-all fallback runs.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -174,6 +174,9 @@ only; clients should not send those metadata values as `gpu_ids`.
 On CUDA, NVML records are exposed only when Torch CUDA can start the same
 visible ordinal set, so NVML-only devices are omitted instead of advertised as
 usable session targets.
+On ROCm, records are emitted only for visible ordinals that Torch can select;
+nullable memory fields mean memory telemetry is unavailable after successful
+selection.
 On ROCm, `physical_id` is included only when KeepGPU can safely resolve
 `ROCR_VISIBLE_DEVICES` and one matching HIP/CUDA overlay to a ROCm SMI index;
 otherwise utilization is reported as unavailable rather than guessed.

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -3,9 +3,10 @@
 Embed KeepGPU directly inside orchestration scripts so GPUs stay warm only for
 the stages you choose.
 
-For global sessions and telemetry helpers, public CUDA IDs are Torch-startable
-visible ordinals. NVML may add utilization and vendor metadata, but NVML-only
-devices are not exposed as `gpu_ids` targets when Torch CUDA cannot start them.
+For global sessions and telemetry helpers, public CUDA/ROCm IDs are
+Torch-startable visible ordinals. NVML or ROCm SMI may add utilization and
+vendor metadata, but metadata-only or unselectable devices are not exposed as
+`gpu_ids` targets.
 
 ## Keep a single GPU while you do CPU work
 

--- a/docs/plans/rocm-startable-listing.md
+++ b/docs/plans/rocm-startable-listing.md
@@ -1,0 +1,60 @@
+# ROCm Startable Listing Plan
+
+## Background
+
+`list_gpus` exposes `id` as the visible ordinal users can pass to `gpu_ids`.
+ROCm controller startup, however, fails synchronously when
+`torch.cuda.set_device(rank)` fails. The ROCm listing path currently catches
+that same failure together with nullable memory probing, then still emits a
+record with `memory_total=None` and `memory_used=None`.
+
+## Goal
+
+Keep ROCm GPU inventory honest: do not advertise a visible ordinal that the
+ROCm controller cannot select during startup.
+
+## Solution
+
+- Add a regression test where ROCm Torch reports two visible devices but
+  `torch.cuda.set_device(1)` fails.
+- Make `_query_rocm()` treat `set_device(idx)` failure as an unstartable visible
+  ordinal and skip that record.
+- Keep `mem_get_info()` best-effort after a successful `set_device()`, so
+  nullable memory still represents telemetry unavailability rather than startup
+  impossibility.
+- Update docs and `AGENTS.md` to state that ROCm listings follow the same
+  startability contract as keep/start APIs.
+
+## Tasks
+
+- [x] Add RED regression coverage in `tests/utilities/test_gpu_info.py`.
+- [x] Implement the minimal `_query_rocm()` control-flow split.
+- [x] Update `docs/concepts/architecture.md` and `AGENTS.md`.
+- [x] Align README, CLI, Python API, MCP, and REST docs with the ROCm
+  start-compatible listing contract.
+- [x] Run targeted GPU info and ROCm/controller tests.
+- [x] Run broad verification, pre-commit, docs build, and diff check.
+- [ ] Create a PR, run local subagent review, resolve review feedback, and
+  squash merge only after hosted checks/comments are clean.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_rocm_hides_unstartable_visible_ordinals -q`
+  failed because listing returned `[0, 1]` instead of `[0]`.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_rocm_hides_unstartable_visible_ordinals -q`
+  passed.
+- Focused:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/rocm_controller/test_rocm_backoff.py tests/rocm_controller/test_rocm_utilization.py -q`
+  passed with 56 passed, 1 skipped.
+- Targeted:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/rocm_controller tests/global_controller/test_contract.py -q`
+  passed with 97 passed, 1 skipped.
+- Full:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 576 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan-page notices.
+- Hygiene:
+  `pre-commit run --all-files` and `git diff --check` passed.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,7 +11,9 @@ empty, duplicate, or out-of-range list is invalid, and startup raises
 metadata such as `physical_id`, but those fields are not accepted as selection
 IDs. On CUDA, NVML telemetry records are returned only when Torch CUDA can start
 the same visible ordinal set, so NVML-only devices are not exposed as public
-`gpu_ids`.
+`gpu_ids`. On ROCm, telemetry records are returned only for visible ordinals
+that Torch can select; nullable memory fields mean memory telemetry is
+unavailable after successful selection.
 
 `GlobalGPUController` validates local constructor inputs (`gpu_ids`, `interval`,
 `busy_threshold`, and `vram_to_keep`) before platform or hardware probing.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,10 +99,12 @@ ordinals accepted by `--gpu-ids` and service `gpu_ids`; optional `physical_id`
 or `uuid` fields are metadata only. The output is a directly parseable JSON
 object. On CUDA, NVML records are listed only when Torch CUDA can start the same
 visible ordinal set; NVML-only devices are hidden rather than advertised as
-usable `gpu_ids`. Service/runtime errors after CLI parsing succeeds are reported
-as `{"error": "..."}`. Malformed JSON-RPC service envelopes are reported as JSON
-error objects instead of empty success results. Invalid endpoint values are
-reported as JSON errors before RPC.
+usable `gpu_ids`. On ROCm, listed records are limited to visible ordinals that
+Torch can select; nullable memory fields mean memory telemetry is unavailable
+after selection succeeds. Service/runtime errors after CLI parsing succeeds are
+reported as `{"error": "..."}`. Malformed JSON-RPC service envelopes are
+reported as JSON error objects instead of empty success results. Invalid
+endpoint values are reported as JSON errors before RPC.
 
 ### `keep-gpu service-stop`
 
@@ -133,7 +135,7 @@ failures remain `-32603 Internal error`.
 | Endpoint | Method | Purpose |
 | --- | --- | --- |
 | `/health` | GET | Service liveness probe. |
-| `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unsupported fields are `null`; the dashboard treats unavailable utilization as `n/a`, not `0%`). |
+| `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unselectable CUDA/ROCm records are omitted; unsupported fields are `null`; the dashboard treats unavailable utilization as `n/a`, not `0%`). |
 | `/api/sessions` | GET | Tracked keep sessions, including `state="starting"` during startup, `state="runtime_failed"` plus `last_error` for retained worker failures, and `state`/`last_error` for in-progress or failed stops. |
 | `/api/sessions/{job_id}` | GET | One session status, including `state` and `last_error` when active, starting, runtime-failed, or retained after stop problems. |
 | `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -218,6 +218,12 @@ def _query_rocm() -> List[Dict[str, Any]]:
         # Use torch to enumerate devices for names/memory
         count = torch.cuda.device_count() if torch.cuda.is_available() else 0
         for idx in range(count):
+            try:
+                torch.cuda.set_device(idx)
+            except Exception as exc:
+                logger.debug("ROCm visible ordinal %s is not startable: %s", idx, exc)
+                continue
+
             physical_id = resolve_rocm_visible_rank_to_smi_index(
                 idx,
                 monitor_count=monitor_count,
@@ -231,7 +237,6 @@ def _query_rocm() -> List[Dict[str, Any]]:
                     logger.debug("ROCm util query failed for %s: %s", physical_id, exc)
 
             try:
-                torch.cuda.set_device(idx)
                 free, total = torch.cuda.mem_get_info()
                 used = total - free
             except Exception:

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest
@@ -64,10 +66,17 @@ class MultiGPUDummyNVML:
 
 
 class DummyTorchCudaROCm:
-    def __init__(self, count: int = 2):
+    def __init__(
+        self,
+        count: int = 2,
+        *,
+        set_device_errors: "dict[int, Exception] | None" = None,
+    ):
         self.count = count
         self.current = 0
+        self.set_device_attempts: list[int] = []
         self.set_devices: list[int] = []
+        self.set_device_errors = set_device_errors or {}
 
     @staticmethod
     def is_available():
@@ -80,6 +89,9 @@ class DummyTorchCudaROCm:
         return self.count
 
     def set_device(self, idx):
+        self.set_device_attempts.append(idx)
+        if idx in self.set_device_errors:
+            raise self.set_device_errors[idx]
         self.set_devices.append(idx)
         self.current = idx
 
@@ -162,12 +174,16 @@ def _install_rocm_gpu_info_mocks(
     count: int = 2,
     util_by_index: dict[int, int] | None = None,
     smi_count: int = 8,
+    set_device_errors: "dict[int, Exception] | None" = None,
 ):
     monkeypatch.setitem(sys.modules, "pynvml", None)
     dummy_rocm = DummyROCMSMI(util_by_index=util_by_index, count=smi_count)
     monkeypatch.setitem(sys.modules, "rocm_smi", dummy_rocm)
 
-    dummy_cuda = DummyTorchCudaROCm(count=count)
+    dummy_cuda = DummyTorchCudaROCm(
+        count=count,
+        set_device_errors=set_device_errors,
+    )
     dummy_torch = type(
         "T",
         (),
@@ -435,6 +451,30 @@ def test_get_gpu_info_rocm_composes_rocr_base_and_hip_visible_mask(monkeypatch):
     assert [info["utilization"] for info in infos] == [94]
     assert dummy_rocm.queried_indexes == [4]
     assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_hides_unstartable_visible_ordinals(monkeypatch):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_rocm, dummy_cuda = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        count=2,
+        util_by_index={0: 70, 1: 91},
+        set_device_errors={1: RuntimeError("cannot select rocm:1")},
+    )
+
+    infos = gpu_info.get_gpu_info()
+
+    assert [info["id"] for info in infos] == [0]
+    assert [info["visible_id"] for info in infos] == [0]
+    assert [info["physical_id"] for info in infos] == [0]
+    assert [info["name"] for info in infos] == ["ROCm 0"]
+    assert [info["utilization"] for info in infos] == [70]
+    assert dummy_rocm.queried_indexes == [0]
+    assert dummy_rocm.shutdown_calls == 1
+    assert dummy_cuda.set_device_attempts == [0, 1, 0]
+    assert dummy_cuda.set_devices == [0, 0]
 
 
 def test_get_gpu_info_rocm_unresolved_mask_keeps_visible_records_without_utilization(


### PR DESCRIPTION
## Summary
- hide ROCm visible ordinals from GPU listings when Torch cannot select them with set_device
- keep ROCm memory telemetry nullable when memory probing fails after successful selection
- align AGENTS, README, CLI/Python/MCP/REST docs with the CUDA/ROCm start-compatible listing contract

## Local review
- Local subagent review completed before PR
- Minor test-hardening comment resolved by recording failed set_device attempts
- Re-review found no remaining Critical, Important, or Minor issues

## Verification
- RED: PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_rocm_hides_unstartable_visible_ordinals -q failed because listing returned [0, 1] instead of [0]
- GREEN: PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_rocm_hides_unstartable_visible_ordinals -q -> 1 passed
- PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py -q -> 28 passed, 1 skipped
- PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/rocm_controller/test_rocm_backoff.py tests/rocm_controller/test_rocm_utilization.py -q -> 56 passed, 1 skipped
- PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/rocm_controller tests/global_controller/test_contract.py -q -> 97 passed, 1 skipped
- PYTHONPATH=$PWD/src pytest tests -q -> 576 passed, 11 skipped
- PYTHONPATH=$PWD/src mkdocs build -> passed with existing Material warning and unnav'd plan notices
- pre-commit run --all-files -> passed
- git diff --check -> passed