### PR TITLE
[compat] fix: postpone pep604 annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
+- Python files that use PEP 604 annotations such as `X | Y` must include
+  `from __future__ import annotations` while the project tooling targets
+  Python 3.8.
 
 ### Git Hygiene & Security
 

--- a/docs/plans/py38-postponed-annotations.md
+++ b/docs/plans/py38-postponed-annotations.md
@@ -1,0 +1,81 @@
+# Python 3.8 Annotation Compatibility Plan
+
+## Background
+
+Project formatting/linting targets Python 3.8, but a few modules use PEP 604
+union annotations without `from __future__ import annotations`. On Python
+3.8/3.9 those annotations can be evaluated at import time and fail before users
+reach KeepGPU's platform detection, controllers, or tests.
+
+## Goal
+
+Keep modules with PEP 604 annotations import-compatible with the configured
+Python 3.8 target by requiring postponed annotations where that syntax appears.
+
+## Solution
+
+- Add a static regression test that finds Python files containing PEP 604 union
+  annotations without `from __future__ import annotations`.
+- Add the future import to the small set of affected source/test modules.
+- Update `AGENTS.md` so future edits keep Python 3.8-targeted annotations safe.
+
+## Tasks
+
+- [x] Add RED compatibility test.
+- [x] Add postponed annotations to affected files.
+- [x] Update `AGENTS.md`.
+- [x] Run targeted compatibility tests.
+- [x] Run broader verification.
+- [ ] Commit, push, PR, local review, hosted review, and squash merge only after
+  all comments/checks are resolved.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_annotation_compat.py -q` failed with
+  `src/keep_gpu/utilities/platform_manager.py`,
+  `tests/rocm_controller/test_rocm_utilization.py`, and
+  `tests/utilities/test_gpu_monitor.py` as offenders.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_annotation_compat.py -q` passed.
+- Targeted:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py -q`
+  passed with 41 passed.
+- Compile:
+  `python -m py_compile src/keep_gpu/utilities/platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py`
+  passed.
+- Reviewer RED:
+  after broadening the guard to AST-detect any PEP 604 union in annotations,
+  `PYTHONPATH=$PWD/src pytest tests/test_annotation_compat.py -q` failed with
+  `src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py`,
+  `src/keep_gpu/single_gpu_controller/macm_gpu_controller.py`,
+  `src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py`, and
+  `src/keep_gpu/utilities/logger.py` as additional offenders.
+- Reviewer GREEN:
+  after adding future annotations to those additional offenders,
+  `PYTHONPATH=$PWD/src pytest tests/test_annotation_compat.py -q` passed.
+- Reviewer targeted:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_platform_manager.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py tests/cuda_controller tests/rocm_controller tests/macm_controller -q`
+  passed with 68 passed, 9 skipped.
+- Reviewer compile:
+  `python -m py_compile src/keep_gpu/utilities/platform_manager.py src/keep_gpu/utilities/logger.py src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py src/keep_gpu/single_gpu_controller/macm_gpu_controller.py tests/utilities/test_gpu_monitor.py tests/rocm_controller/test_rocm_utilization.py tests/test_annotation_compat.py`
+  passed.
+- Local review:
+  the reviewer found `_has_future_annotations()` could falsely flag a valid
+  file when another `__future__` import preceded `annotations`; a RED helper
+  regression failed, then passed after scanning the full top-of-file future
+  import block.
+- Hosted review:
+  accepted Gemini's `_annotation_nodes()` simplification using `ast.arg`;
+  rejected the whole-body `__future__` scan because `ast.parse()` accepts
+  misplaced future imports, then added a regression that keeps misplaced
+  annotations imports from being treated as valid. Accepted CodeRabbit's tracked
+  repository-wide scan and `Annotated` metadata false-positive findings with
+  regressions for both.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 583 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan-page notices.
+- Hygiene:
+  `pre-commit run --all-files` and `git diff --check` passed.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 import time
 from typing import Optional

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gc
 import threading
 import time

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 import time
 from typing import Optional

--- a/src/keep_gpu/utilities/logger.py
+++ b/src/keep_gpu/utilities/logger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys

--- a/src/keep_gpu/utilities/platform_manager.py
+++ b/src/keep_gpu/utilities/platform_manager.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
-import sys
 import platform
+import sys
 from enum import Enum
 from typing import Callable, List, Tuple
 

--- a/tests/rocm_controller/test_rocm_utilization.py
+++ b/tests/rocm_controller/test_rocm_utilization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from keep_gpu.single_gpu_controller import rocm_gpu_controller as rocm_module

--- a/tests/test_annotation_compat.py
+++ b/tests/test_annotation_compat.py
@@ -1,0 +1,175 @@
+import ast
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _python_files():
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "--", "*.py"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    for relative_path in result.stdout.splitlines():
+        yield REPO_ROOT / relative_path
+
+
+def _has_future_annotations(tree: ast.Module) -> bool:
+    for index, node in enumerate(tree.body):
+        if (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+        ):
+            if isinstance(node.value.value, str):
+                continue
+        if not isinstance(node, ast.ImportFrom) or node.module != "__future__":
+            return False
+        if any(alias.name == "annotations" for alias in node.names):
+            return True
+    return False
+
+
+def _annotation_nodes(tree: ast.Module):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.returns is not None:
+                yield node.returns
+        elif isinstance(node, ast.arg):
+            if node.annotation is not None:
+                yield node.annotation
+        elif isinstance(node, ast.AnnAssign):
+            yield node.annotation
+
+
+def _uses_pep604_annotation(tree: ast.Module) -> bool:
+    for annotation in _annotation_nodes(tree):
+        if _contains_pep604_union(annotation):
+            return True
+    return False
+
+
+def _contains_pep604_union(node: ast.AST) -> bool:
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return True
+    if isinstance(node, ast.Subscript) and _is_annotated_name(node.value):
+        args = _subscript_args(node.slice)
+        if not args:
+            return False
+        return _contains_pep604_union(args[0])
+    return any(_contains_pep604_union(child) for child in ast.iter_child_nodes(node))
+
+
+def _is_annotated_name(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "Annotated"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "Annotated"
+    return False
+
+
+def _subscript_args(node: ast.AST):
+    if isinstance(node, ast.Index):
+        node = node.value
+    if isinstance(node, ast.Tuple):
+        return list(node.elts)
+    return [node]
+
+
+def test_python_files_include_tracked_python_outside_src_and_tests():
+    paths = {path.relative_to(REPO_ROOT) for path in _python_files()}
+
+    assert Path("docs/__init__.py") in paths
+
+
+def test_future_annotations_detection_allows_other_future_imports_first():
+    tree = ast.parse(
+        '"""module docstring"""\n'
+        "from __future__ import generator_stop\n"
+        "from __future__ import annotations\n"
+        "\n"
+        "def parse(value: str | None) -> str | None:\n"
+        "    return value\n"
+    )
+
+    assert _has_future_annotations(tree)
+
+
+def test_future_annotations_detection_rejects_misplaced_future_import():
+    tree = ast.parse(
+        "ready = True\n"
+        "from __future__ import annotations\n"
+        "\n"
+        "def parse(value: str | None) -> str | None:\n"
+        "    return value\n"
+    )
+
+    assert not _has_future_annotations(tree)
+
+
+def test_annotation_nodes_include_all_function_argument_forms():
+    tree = ast.parse(
+        "def parse(\n"
+        "    pos: str | None,\n"
+        "    /,\n"
+        "    normal: int | None,\n"
+        "    *items: float | None,\n"
+        "    kw: bool | None,\n"
+        "    **extras: bytes | None,\n"
+        ") -> str | None:\n"
+        "    value: dict[str, str] | None = None\n"
+        "    return str(value)\n"
+    )
+
+    pep604_annotations = 0
+    for annotation in _annotation_nodes(tree):
+        if any(
+            isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr)
+            for node in ast.walk(annotation)
+        ):
+            pep604_annotations += 1
+
+    assert pep604_annotations == 7
+
+
+def test_pep604_detector_ignores_annotated_metadata_bitor():
+    tree = ast.parse(
+        "from typing import Annotated\n"
+        "\n"
+        "class Flags:\n"
+        "    A = 1\n"
+        "    B = 2\n"
+        "\n"
+        "value: Annotated[int, Flags.A | Flags.B]\n"
+    )
+
+    assert not _uses_pep604_annotation(tree)
+
+
+def test_pep604_detector_counts_annotated_type_union():
+    tree = ast.parse(
+        "from typing import Annotated\n"
+        "\n"
+        "value: Annotated[int | str, 'metadata']\n"
+    )
+
+    assert _uses_pep604_annotation(tree)
+
+
+def test_pep604_annotations_are_postponed_for_py38_target():
+    offenders = []
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(path))
+        if not _uses_pep604_annotation(tree):
+            continue
+        if _has_future_annotations(tree):
+            continue
+        offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert offenders == [], "PEP 604 annotations need future annotations: " + ", ".join(
+        offenders
+    )

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import types
 
 from keep_gpu.utilities.gpu_monitor import NVMLMonitor


### PR DESCRIPTION
## Summary
- add an AST compatibility guard for PEP 604 annotations while project tooling targets Python 3.8
- add postponed annotations imports to affected controller, utility, and test modules
- document the compatibility rule in AGENTS.md and record the plan/review trail under docs/plans

## Local and hosted review
- local subagent reviewed `origin/main..HEAD`; final result: Critical none, Important none, Minor none
- local reviewer false-positive finding was fixed with a helper regression
- Gemini `_annotation_nodes()` simplification accepted with argument-form coverage
- Gemini whole-body `__future__` scan suggestion rejected because `ast.parse()` accepts misplaced future imports; regression added
- CodeRabbit tracked repository-wide scan and `Annotated` metadata false-positive findings accepted with regressions

## Verification
- `PYTHONPATH=$PWD/src pytest tests/test_annotation_compat.py -q` -> 7 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 583 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unlisted plan notices
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed