### PR TITLE
[mcp] fix: return 405 for known wrong methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ This file defines how coding agents should work in this repository.
   `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
   JSON `405 Method Not Allowed` responses with `Allow`, and unknown `/api/*`
   routes return structured JSON `404 Unknown endpoint` responses.
+- Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)
+  must call the shared unsupported-method helper before local unknown-endpoint
+  404 branches, so known paths never regress to 404 or body-parse errors solely
+  because the wrong implemented verb was used.
 - `/rpc` is a POST-only JSON-RPC endpoint; `GET /rpc` must return structured
   JSON `405 Method Not Allowed` with `Allow: POST` and must never serve the
   dashboard/static fallback.

--- a/docs/plans/http-implemented-method-405-routing.md
+++ b/docs/plans/http-implemented-method-405-routing.md
@@ -1,0 +1,58 @@
+# HTTP Implemented-Method 405 Routing Plan
+
+## Background
+
+The MCP HTTP handler already has a shared unsupported-method helper that returns
+structured JSON `405 Method Not Allowed` responses with an `Allow` header for
+known routes. That helper is used for BaseHTTPRequestHandler-generated
+unsupported verbs and for `GET /rpc`, but `do_POST()` and `do_DELETE()` can still
+fall through to local `404 Unknown endpoint` branches when the path is known but
+the implemented verb is not allowed.
+
+## Goal
+
+Known HTTP routes must return the same structured JSON `405` response whenever a
+client uses a wrong method, including wrong methods that are implemented by the
+server class. Unknown `/api/*` routes must keep returning structured JSON `404`
+responses.
+
+## Solution
+
+- Add RED REST/RPC tests for `POST` and `DELETE` against known routes that do
+  not allow those methods.
+- Route known-but-wrong methods in `do_POST()` and `do_DELETE()` through the
+  existing `_send_api_rpc_unsupported_method_response()` helper before reading
+  request bodies or returning local unknown-endpoint `404`s.
+- Update `AGENTS.md` with the implemented-handler maintenance rule.
+
+## Tasks
+
+- [x] Create an isolated `.worktrees/codex/http-unsupported-method-routing`
+  branch from latest `origin/main`.
+- [x] Add RED tests for implemented handlers returning `404` on known wrong
+  methods.
+- [x] Implement the minimal handler routing fix.
+- [x] Run targeted MCP HTTP tests.
+- [x] Run broader verification, docs build, and pre-commit.
+- [x] Request local subagent review and resolve findings.
+- [ ] Open a PR, resolve hosted review comments, wait for green checks, squash
+  merge, and clean up the worktree/branches.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_implemented_handlers_reject_known_wrong_methods_with_json_405 -q`
+  failed with all seven parametrized cases returning `404` instead of `405`.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_implemented_handlers_reject_known_wrong_methods_with_json_405 -q`
+  passed with 7 passed.
+- MCP:
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with 177 passed.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 590 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan-page notices.
+- Local review:
+  a local subagent review found no Critical, Important, or Minor issues and
+  recommended marking this checklist item complete before PR publication.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -848,6 +848,12 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             return True
         return False
 
+    def _send_known_route_unsupported_method_response(self, path: str) -> bool:
+        allowed_methods = self._allowed_methods_for_path(path)
+        if allowed_methods is None or self.command in allowed_methods:
+            return False
+        return self._send_api_rpc_unsupported_method_response()
+
     def send_error(self, code, message=None, explain=None):  # noqa: ANN001, N802
         if int(code) == 501 and self._send_api_rpc_unsupported_method_response():
             return
@@ -980,6 +986,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if self._send_known_route_unsupported_method_response(path):
+                return
             if path not in ("/api/sessions", "/", "/rpc"):
                 self._json_response(404, {"error": {"message": "Unknown endpoint"}})
                 return
@@ -1083,6 +1091,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if self._send_known_route_unsupported_method_response(path):
+                return
             server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]
             if path == "/api/sessions":
                 if self._reject_session_route_components(parsed):

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -216,6 +216,41 @@ def test_http_rpc_rejects_unsupported_options_with_json_405():
     }
 
 
+@pytest.mark.parametrize(
+    ("method", "path", "allowed_methods", "data"),
+    [
+        ("POST", "/health", {"GET"}, b"{bad json"),
+        ("POST", "/api/gpus", {"GET"}, b"{bad json"),
+        ("POST", "/api/sessions/demo", {"GET", "DELETE"}, b"{bad json"),
+        ("DELETE", "/", {"GET", "POST"}, None),
+        ("DELETE", "/health", {"GET"}, None),
+        ("DELETE", "/api/gpus", {"GET"}, None),
+        ("DELETE", "/rpc", {"POST"}, None),
+    ],
+)
+def test_http_implemented_handlers_reject_known_wrong_methods_with_json_405(
+    method, path, allowed_methods, data
+):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(method, f"{base}{path}", data)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 405
+    assert headers.get("content-type") == "application/json"
+    assert _allow_methods(headers) == allowed_methods
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Method not allowed"}
+    }
+
+
 def test_http_rpc_get_rejects_with_json_405_instead_of_static_fallback():
     server = make_server()
     httpd, thread, base = _start_http_server(server)


### PR DESCRIPTION
## Summary
- route known REST/RPC paths with wrong implemented methods through the shared JSON 405 helper
- add regression coverage for `POST`/`DELETE` wrong-method cases, including invalid POST bodies
- document the implemented-handler routing contract in AGENTS.md and a plan note

## Local review
- local subagent reviewed `origin/main..HEAD`
- final local result: Critical none, Important none, Minor none

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_implemented_handlers_reject_known_wrong_methods_with_json_405 -q` failed with seven 404 responses
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_implemented_handlers_reject_known_wrong_methods_with_json_405 -q` -> 7 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 177 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 590 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unlisted plan notices
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed
