### PR TITLE
[cli] fix: require known daemon pid identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ This file defines how coding agents should work in this repository.
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`
   objects for invalid endpoints, not tracebacks.
+- CLI service daemon ownership checks must require known PID identity
+  components. A PID record with `uid` or `start_time` missing or `null`, or a
+  current process probe that cannot recover either value, is not ownership
+  verified and must not be signaled as a managed daemon.
 - MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
   before socket bind, matching the CLI service endpoint contract.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.

--- a/docs/plans/cli-pid-ownership-strict.md
+++ b/docs/plans/cli-pid-ownership-strict.md
@@ -1,0 +1,58 @@
+# CLI PID Ownership Strictness Plan
+
+## Background
+
+`keep-gpu service-stop --force` relies on a structured PID record before sending
+signals to a local daemon. The matcher requires `uid` and `start_time` keys, but
+it previously accepted records where either value was `null` when the live
+process probe also returned `None`. That makes an unknown identity compare equal
+to another unknown identity, which is too weak for daemon ownership.
+
+## Goal
+
+Only signal a service daemon when the PID record and the current process both
+have known matching identity components: command line, UID, and process start
+identity. Unknown recorded or current UID/start-time values must clear the stale
+record and avoid signaling the process.
+
+## Solution
+
+- Add RED tests for PID records created with unknown UID or unknown start-time
+  values.
+- Require non-`None` recorded and current UID/start-time values in
+  `_record_matches_running_process()`.
+- Update `AGENTS.md` with the ownership strictness rule.
+
+## Tasks
+
+- [x] Create an isolated `.worktrees/codex/cli-pid-ownership-strict` branch
+  from latest `origin/main`.
+- [x] Add RED ownership tests for unknown recorded PID identity components.
+- [x] Implement the minimal matcher strictness fix.
+- [x] Run targeted ownership tests.
+- [x] Run broader CLI/full verification, docs build, and pre-commit.
+- [x] Request local subagent review and resolve findings.
+- [ ] Open a PR, resolve hosted review comments, wait for green checks, squash
+  merge, and clean up the worktree/branches.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_recorded_identity_components tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_current_identity_components -q`
+  failed because records with `uid=None` or `start_time=None` still sent
+  SIGTERM/SIGKILL.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_recorded_identity_components tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_current_identity_components tests/test_cli_service_commands.py::test_stop_service_process_stops_matching_owned_daemon tests/test_cli_service_commands.py::test_stop_service_process_rechecks_ownership_before_sigkill tests/test_cli_service_commands.py::test_stop_service_process_confirms_sigkill_exit -q`
+  passed with 7 passed.
+- CLI service:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with
+  145 passed.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 594 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan-page notices.
+- Local review:
+  a local subagent review found no Critical or Important issues. The Minor test
+  hardening suggestion was addressed by asserting unverifiable records are
+  cleared in both new unknown-identity tests.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -474,12 +474,20 @@ def _record_matches_running_process(
         return False
 
     recorded_uid = record.get("uid")
+    if recorded_uid is None:
+        return False
     current_uid = _process_uid(pid)
+    if current_uid is None:
+        return False
     if recorded_uid != current_uid:
         return False
 
     recorded_start = record.get("start_time")
+    if recorded_start is None:
+        return False
     current_start = _process_start_identity(pid)
+    if current_start is None:
+        return False
     if recorded_start != current_start:
         return False
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1376,6 +1376,7 @@ def test_stop_service_process_requires_structured_ownership_record(
 
     assert stopped is False
     assert kills == []
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
 def test_stop_service_process_rejects_record_missing_identity(monkeypatch, tmp_path):
@@ -1403,6 +1404,7 @@ def test_stop_service_process_rejects_record_missing_identity(monkeypatch, tmp_p
 
     assert stopped is False
     assert kills == []
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
 def test_stop_service_process_rejects_unknown_current_start_identity(
@@ -1425,6 +1427,66 @@ def test_stop_service_process_rejects_unknown_current_start_identity(
 
     assert stopped is False
     assert kills == []
+
+
+@pytest.mark.parametrize(
+    ("uid", "start_time"),
+    [
+        (None, "12345"),
+        (1000, None),
+    ],
+)
+def test_stop_service_process_rejects_unknown_recorded_identity_components(
+    monkeypatch, tmp_path, uid, start_time
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: uid)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: start_time)
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
+@pytest.mark.parametrize(
+    ("current_uid", "current_start_time"),
+    [
+        (None, "12345"),
+        (1000, None),
+    ],
+)
+def test_stop_service_process_rejects_unknown_current_identity_components(
+    monkeypatch, tmp_path, current_uid, current_start_time
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: current_uid)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: current_start_time)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
 def test_stop_service_process_stops_matching_owned_daemon(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- reject PID ownership matches when recorded or current UID/start identity is unknown
- add regression coverage proving unverifiable records are cleared without sending signals
- document the stricter service daemon ownership contract in AGENTS.md and a plan note

## Local review
- local subagent reviewed `origin/main..HEAD`
- minor test-hardening suggestion was addressed
- final local result: Critical none, Important none, Minor none

## Verification
- RED: unknown recorded identity tests failed because `uid=None` / `start_time=None` records still sent SIGTERM/SIGKILL
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_recorded_identity_components tests/test_cli_service_commands.py::test_stop_service_process_rejects_unknown_current_identity_components -q` -> 4 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> 145 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 594 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unlisted plan notices
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed
