### PR TITLE
[cli] fix: return json for invalid service ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ This file defines how coding agents should work in this repository.
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`
   objects for invalid endpoints, not tracebacks.
+- JSON-output service commands (`status`, `stop`, `list-gpus`) must parse
+  `--port` through command-level validation so non-integer values return the
+  shared structured `{"error": "port must be an integer between 1 and 65535"}`
+  object instead of Typer/Click usage text.
 - CLI service daemon ownership checks must require known PID identity
   components. A PID record with `uid` or `start_time` missing or `null`, or a
   current process probe that cannot recover either value, is not ownership

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Flags that matter:
   - `keep-gpu serve`: run local service (HTTP + dashboard).
   - `keep-gpu start`: create keep session and return immediately.
     Service endpoint flags are validated locally: `--host` must be a DNS
-    hostname or IPv4 address, and `--port` must be in `1..65535`.
+    hostname or IPv4 address, and `--port` must be an integer in `1..65535`.
   - `keep-gpu status`: inspect tracked sessions, including in-progress or failed releases.
   - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
     The two stop targets are mutually exclusive; passing both returns a JSON
@@ -100,8 +100,9 @@ Flags that matter:
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
     that tools such as `jq` can parse directly. Malformed JSON-RPC service
-    envelopes and invalid service endpoints are reported as those JSON error
-    objects instead of empty success results or tracebacks.
+    envelopes and invalid service endpoints, including non-integer ports, are
+    reported as those JSON error objects instead of empty success results or
+    tracebacks.
 
 ## Embed in Python
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -32,7 +32,7 @@ Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
 fail without creating daemon runtime files or issuing RPC. Service endpoint
 flags are validated the same way: `--host` must be a DNS hostname or IPv4
-address, and `--port` must be in `1..65535`.
+address, and `--port` must be an integer in `1..65535`.
 Omit `--gpu-ids` to use all visible GPUs; an explicit empty or whitespace-only
 value is invalid.
 `--interval` must be finite, positive, and within the Python runtime wait
@@ -89,8 +89,9 @@ after selection succeeds. `status`, `stop`, and `list-gpus` print JSON objects,
 including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes are reported as JSON error objects instead
-of empty success results. Invalid service endpoints are also reported as JSON
-errors before any RPC or stop-all fallback runs.
+of empty success results. Invalid service endpoints, including non-integer
+ports, are also reported as JSON errors before any RPC or stop-all fallback
+runs.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/plans/cli-json-port-errors.md
+++ b/docs/plans/cli-json-port-errors.md
@@ -1,0 +1,74 @@
+# CLI JSON Port Errors Plan
+
+## Background
+
+`keep-gpu status`, `keep-gpu stop --all`, and `keep-gpu list-gpus` are
+JSON-output commands. Invalid endpoint values should therefore return a single
+machine-readable `{"error": "..."}` object before RPC or stop-all fallback
+logic runs. Non-integer `--port` tokens were rejected by Typer/Click before the
+command body, producing usage text and exit code 2 instead of the established
+JSON error contract.
+
+## Goal
+
+Keep JSON-output service commands directly parseable even when users or agents
+pass malformed port values.
+
+## Solution
+
+- Add command-level regression coverage for non-integer `--port` values on
+  `status`, `stop --all`, and `list-gpus`.
+- Let JSON-output commands receive the raw port token and route it through the
+  shared endpoint validator.
+- Extend the shared service port validator to parse string tokens and return the
+  normalized integer port after the existing range check.
+- Document that non-integer and out-of-range ports on JSON-output commands are
+  reported as structured JSON errors before service side effects.
+
+## Tasks
+
+- [x] Reproduce the current plain-text Click usage error for
+      `keep-gpu status --port abc`.
+- [x] Add RED tests for non-integer `--port` on JSON-output service commands.
+- [x] Implement shared string port parsing for JSON-output command paths.
+- [x] Update `AGENTS.md`, README, CLI guide/reference, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
+      and clean the worktree.
+
+## Verification
+
+- Symptom reproduction:
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli status --port abc` returned Click
+  usage text with exit code 2 before the fix.
+- RED regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback -q`
+  failed with three exit-code assertions (`2 == 1`), showing that Click rejected
+  each command before JSON rendering.
+- GREEN focused regression:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback -q`
+  passed with `3 passed`.
+- GREEN CLI service shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with
+  `148 passed`.
+- Live symptom check:
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli status --port abc`,
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli stop --all --port abc`, and
+  `PYTHONPATH=$PWD/src python -m keep_gpu.cli list-gpus --port abc` each
+  returned a single `{"error": "port must be an integer between 1 and 65535"}`
+  JSON object with exit code 1.
+- Focused CLI gate:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q`
+  passed with `162 passed`.
+- Full no-GPU-safe gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `597 passed, 11 skipped`.
+- Docs and hygiene:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's existing
+  Material warning and unnav'd plan notices; `pre-commit run --all-files`
+  passed; and `git diff --check` passed.
+- Local subagent review:
+  The reviewer found no critical, important, or minor issues, reran the live
+  non-integer port checks, reran the focused regression, and marked the branch
+  ready to merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,7 +35,7 @@ Starts local KeepGPU service (HTTP + JSON-RPC + dashboard).
 | Option | Default | Description |
 | --- | --- | --- |
 | `--host` | `127.0.0.1` | Service bind host. Must be a DNS hostname or IPv4 address. |
-| `--port` | `8765` | Service port in `1..65535`. |
+| `--port` | `8765` | Service port as an integer in `1..65535`. |
 
 ### `keep-gpu start`
 
@@ -54,7 +54,7 @@ GPUs; explicit empty or whitespace-only values are invalid.
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact; invalid values are rejected before auto-start. |
-| `--port` | `8765` | Service port to contact; must be in `1..65535`. |
+| `--port` | `8765` | Service port to contact; must be an integer in `1..65535`. |
 | `--auto-start/--no-auto-start` | `--auto-start` | Auto-start local service if unavailable. |
 
 ### `keep-gpu status`
@@ -62,7 +62,7 @@ GPUs; explicit empty or whitespace-only values are invalid.
 | Option | Description |
 | --- | --- |
 | `--job-id` | Optional non-empty URL-path-safe session id; omit to list all tracked sessions, including in-progress starts, in-progress releases, or failed releases. Invalid explicit IDs are rejected locally before RPC. |
-| `--host`, `--port` | Service host/port. Invalid endpoint values are rejected locally and printed as JSON errors before RPC. |
+| `--host`, `--port` | Service host/port. Invalid endpoint values, including non-integer or out-of-range ports, are rejected locally and printed as JSON errors before RPC. |
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
@@ -78,7 +78,7 @@ runtime failure.
 | --- | --- |
 | `--job-id` | Stop one non-empty URL-path-safe session id. Invalid explicit IDs are rejected locally before RPC or stop-all fallback. |
 | `--all` | Stop all sessions. |
-| `--host`, `--port` | Service host/port. Invalid endpoint values are rejected locally and printed as JSON errors before RPC or stop-all fallback. |
+| `--host`, `--port` | Service host/port. Invalid endpoint values, including non-integer or out-of-range ports, are rejected locally and printed as JSON errors before RPC or stop-all fallback. |
 
 `--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
 error before any RPC or stop-all fallback runs.
@@ -104,7 +104,8 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
 reported as `{"error": "..."}`. Malformed JSON-RPC service envelopes are
 reported as JSON error objects instead of empty success results. Invalid
-endpoint values are reported as JSON errors before RPC.
+endpoint values, including non-integer or out-of-range ports, are reported as
+JSON errors before RPC.
 
 ### `keep-gpu service-stop`
 
@@ -114,7 +115,7 @@ ownership-verified stop operations.
 
 | Option | Description |
 | --- | --- |
-| `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be in `1..65535`. |
+| `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be an integer in `1..65535`. |
 | `--force` | Skip active-session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
 
 ## Service HTTP endpoints

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -328,13 +328,28 @@ def _validate_cli_service_host(host: str) -> str:
     return host
 
 
-def _validate_cli_service_port(port: int) -> int:
-    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+def _validate_cli_service_port(port: Any) -> int:
+    if isinstance(port, bool):
         raise typer.BadParameter(SERVICE_PORT_ERROR)
-    return port
+
+    if isinstance(port, int):
+        parsed_port = port
+    elif isinstance(port, str):
+        if not port or port.strip() != port:
+            raise typer.BadParameter(SERVICE_PORT_ERROR)
+        try:
+            parsed_port = int(port)
+        except ValueError:
+            raise typer.BadParameter(SERVICE_PORT_ERROR) from None
+    else:
+        raise typer.BadParameter(SERVICE_PORT_ERROR)
+
+    if not 1 <= parsed_port <= 65535:
+        raise typer.BadParameter(SERVICE_PORT_ERROR)
+    return parsed_port
 
 
-def _validate_cli_service_endpoint(host: str, port: int) -> Tuple[str, int]:
+def _validate_cli_service_endpoint(host: str, port: Any) -> Tuple[str, int]:
     return _validate_cli_service_host(host), _validate_cli_service_port(port)
 
 
@@ -909,7 +924,11 @@ def start(
 def status(
     job_id: Optional[str] = typer.Option(None, help="Session id to inspect."),
     host: str = typer.Option(DEFAULT_SERVICE_HOST, "--host", help="Service host."),
-    port: int = typer.Option(DEFAULT_SERVICE_PORT, "--port", help="Service port."),
+    port: str = typer.Option(
+        str(DEFAULT_SERVICE_PORT),
+        "--port",
+        help="Service port.",
+    ),
 ):
     """Show session status from KeepGPU local service."""
     try:
@@ -940,7 +959,11 @@ def stop(
         help="Stop all sessions.",
     ),
     host: str = typer.Option(DEFAULT_SERVICE_HOST, "--host", help="Service host."),
-    port: int = typer.Option(DEFAULT_SERVICE_PORT, "--port", help="Service port."),
+    port: str = typer.Option(
+        str(DEFAULT_SERVICE_PORT),
+        "--port",
+        help="Service port.",
+    ),
 ):
     """Stop one session or all sessions."""
     try:
@@ -970,7 +993,11 @@ def stop(
 @app.command("list-gpus")
 def list_gpus(
     host: str = typer.Option(DEFAULT_SERVICE_HOST, "--host", help="Service host."),
-    port: int = typer.Option(DEFAULT_SERVICE_PORT, "--port", help="Service port."),
+    port: str = typer.Option(
+        str(DEFAULT_SERVICE_PORT),
+        "--port",
+        help="Service port.",
+    ),
 ):
     """List GPU telemetry from local service."""
     try:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -575,6 +575,38 @@ def test_service_json_command_rejects_invalid_port_before_rpc(monkeypatch):
     assert called["rpc"] is False
 
 
+@pytest.mark.parametrize(
+    ("command", "called_key"),
+    [
+        (["status", "--port", "abc"], "rpc"),
+        (["stop", "--all", "--port", "abc"], "stop_all"),
+        (["list-gpus", "--port", "abc"], "rpc"),
+    ],
+)
+def test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback(
+    monkeypatch, command, called_key
+):
+    called = {"rpc": False, "stop_all": False}
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {}
+
+    def fake_stop_all(*args, **kwargs):
+        called["stop_all"] = True
+        return {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_all_sessions_with_fallback", fake_stop_all)
+
+    result = runner.invoke(cli.app, command)
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert payload["error"] == "port must be an integer between 1 and 65535"
+    assert called[called_key] is False
+
+
 def test_service_stop_rejects_invalid_host_before_daemon_operations(monkeypatch):
     called = {"available": False, "stop": False}
 


### PR DESCRIPTION
## Summary
- parse raw `--port` tokens inside JSON-output service commands so `status`, `stop --all`, and `list-gpus` return structured JSON errors for non-integer ports
- keep invalid endpoint values rejected before RPC or stop-all fallback
- update AGENTS.md, README, CLI guide/reference, and the implementation plan

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback -q` failed before the fix with exit-code 2 assertions
- [x] GREEN: same focused regression passed with `3 passed`
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with `148 passed`
- [x] live checks for `status --port abc`, `stop --all --port abc`, and `list-gpus --port abc` returned single JSON error objects with exit code 1
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` passed with `162 passed`
- [x] `PYTHONPATH=$PWD/src pytest tests -q` passed with `597 passed, 11 skipped`
- [x] `PYTHONPATH=$PWD/src mkdocs build` passed with existing Material warning and unnav'd plan notices
- [x] `pre-commit run --all-files` passed
- [x] `git diff --check` passed
- [x] local subagent code review found no critical, important, or minor issues and reran focused checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CLI service endpoint validation to handle port values more consistently across JSON-output commands.
  * Invalid ports now return a structured JSON error message instead of usage text.

* **Bug Fixes**
  * `status`, `stop --all`, and `list-gpus` now reject non-integer or out-of-range ports locally before any service call.
  * Updated validation to accept common port input formats while still enforcing the valid range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->