### PR TITLE
[macm] fix: validate inputs before mps probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,9 @@ This file defines how coding agents should work in this repository.
   `interval`, `busy_threshold`, `vram_to_keep`) before calling
   `get_platform()` or other hardware/backend probes. Visible-count checks for
   explicit IDs still happen after platform/device discovery.
+- Direct single-GPU controllers must validate cheap public constructor inputs
+  before backend availability probes or device selection. For Mac M, validate
+  `rank`, `busy_threshold`, and `iterations` before checking MPS availability.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.

--- a/docs/plans/macm-input-validation.md
+++ b/docs/plans/macm-input-validation.md
@@ -1,0 +1,67 @@
+# Mac M Input Validation Plan
+
+## Background
+
+`MacMGPUController` checks `rank != 0` and probes
+`torch.backends.mps.is_available()` before all cheap public constructor inputs
+are validated. On non-MPS hosts, invalid `busy_threshold` values can therefore
+surface as a hardware availability error instead of the public validation error.
+The rank check also treats `False` as `0`, because `False != 0` is false.
+
+## Goal
+
+Make direct Mac M controller construction fail for invalid public inputs before
+any MPS hardware/backend probe, matching the CUDA and ROCm controller contract.
+
+## Solution
+
+- Add no-GPU-safe regression tests showing invalid `busy_threshold`, invalid
+  rank types, and out-of-range ranks fail before `torch.backends.mps.is_available`
+  is called.
+- Validate `busy_threshold`, `iterations`, and `rank` before the MPS
+  availability probe.
+- Use the shared `validate_visible_rank(rank, 1)` helper for Mac M rank
+  validation so `False`, strings, floats, negative values, and non-zero ranks
+  use the same public errors as other direct controllers.
+- Update API docs and `AGENTS.md` to include the direct Mac M controller in the
+  cheap-input-before-backend-probe contract.
+
+## Tasks
+
+- [x] Add RED constructor validation tests under `tests/macm_controller/`.
+- [x] Implement centralized Mac M constructor validation before MPS probing.
+- [x] Update `AGENTS.md`, API docs, and this plan.
+- [x] Run targeted tests required for this validation fix.
+- [x] Run full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
+      and clean the worktree.
+
+## Verification
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects'`
+  failed with 6 failures on the old implementation. Invalid
+  `busy_threshold=101` and `rank=False` reached the forbidden MPS availability
+  probe; invalid rank values `"0"`, `1.5`, `-1`, and `1` raised the old
+  Mac-specific rank error instead of the shared rank validation contract.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects'`
+  passed: 6 passed, 11 deselected in 1.46s.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/macm_controller/test_macm_basic.py tests/global_controller/test_contract.py -q`
+  passed: 59 passed, 4 skipped in 1.68s.
+- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/global_controller/test_contract.py -q`
+  passed: 59 passed in 1.44s.
+- GREEN after integration:
+  `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects or preserves_unavailable_mps_runtime_error'`
+  passed with 7 passed, 11 deselected.
+- GREEN after integration:
+  `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/macm_controller/test_macm_basic.py tests/global_controller/test_contract.py -q`
+  passed with 59 passed, 4 skipped.
+- FULL: `PYTHONPATH=$PWD/src pytest tests -q` passed with 604 passed,
+  11 skipped.
+- DOCS: `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's
+  existing Material warning and unnav'd plan notices.
+- HYGIENE: `pre-commit run --all-files` passed.
+- CHECK: `git diff --check` passed with no output.
+- REVIEW: local subagent review found no critical, important, or minor issues
+  and marked the branch ready to merge.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,12 +26,13 @@ default. Public interval values must be finite positive seconds, including
 fractional seconds, capped by the Python runtime wait limit, and public VRAM
 byte-equivalent values must be no more than 1 PiB.
 
-Direct CUDA/ROCm controller `rank` values are public visible device ordinals.
-They must be plain integers within `0..torch.cuda.device_count()-1` in the
-current process environment. Non-integer ranks raise `TypeError`, and negative
+Direct CUDA, ROCm, and Mac M controller `rank` values are public visible device
+ordinals. CUDA and ROCm ranks must be plain integers within
+`0..torch.cuda.device_count()-1` in the current process environment; Mac M ranks
+must be the plain integer `0`. Non-integer ranks raise `TypeError`, and negative
 or out-of-range ranks raise `ValueError` during construction, before KeepGPU
-creates a `torch.device`, calls backend device selection, starts a worker, or
-queries telemetry.
+creates a `torch.device`, checks backend availability, calls backend device
+selection, starts a worker, or queries telemetry.
 
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
 querying NVML; malformed, duplicate/equivalent, ambiguous, or out-of-range

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -14,6 +14,7 @@ from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
     validate_positive_integer,
+    validate_visible_rank,
 )
 
 logger = setup_logger(__name__)
@@ -30,15 +31,15 @@ class MacMGPUController(BaseGPUController):
         iterations: int = 5000,
     ):
         super().__init__(vram_to_keep=vram_to_keep, interval=interval)
-        if rank != 0:
-            raise ValueError("MPS only supports device 0; rank must be 0")
+        busy_threshold = validate_busy_threshold(busy_threshold)
         iterations = validate_positive_integer(iterations, "iterations")
+        rank = validate_visible_rank(rank, 1)
         if not torch.backends.mps.is_available():
             raise RuntimeError("PyTorch MPS backend is not available")
 
         self.rank = rank
         self.device = torch.device("mps")
-        self.busy_threshold = validate_busy_threshold(busy_threshold)
+        self.busy_threshold = busy_threshold
         self.iterations = iterations
         self.platform = ComputingPlatform.MACM
 

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -1,3 +1,5 @@
+import pytest
+
 from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
 
 
@@ -37,6 +39,65 @@ class _StopWaitForbidden:
 
     def wait(self, _timeout):
         raise AssertionError("fatal worker failures should stop immediately")
+
+
+def _forbid_mps_availability_probe(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    def fail_probe():
+        raise AssertionError("MPS availability should not be probed")
+
+    monkeypatch.setattr(macm_module.torch.backends.mps, "is_available", fail_probe)
+
+
+def test_macm_constructor_rejects_invalid_busy_threshold_before_mps_probe(
+    monkeypatch,
+):
+    _forbid_mps_availability_probe(monkeypatch)
+
+    with pytest.raises(
+        ValueError,
+        match="busy_threshold must be -1 or an integer between 0 and 100",
+    ):
+        MacMGPUController(busy_threshold=101)
+
+
+@pytest.mark.parametrize("rank", [False, "0", 1.5])
+def test_macm_constructor_rejects_invalid_rank_types_before_mps_probe(
+    monkeypatch,
+    rank,
+):
+    _forbid_mps_availability_probe(monkeypatch)
+
+    with pytest.raises(TypeError, match="rank must be an integer"):
+        MacMGPUController(rank=rank)
+
+
+@pytest.mark.parametrize("rank", [-1, 1])
+def test_macm_constructor_rejects_out_of_range_rank_before_mps_probe(
+    monkeypatch,
+    rank,
+):
+    _forbid_mps_availability_probe(monkeypatch)
+
+    with pytest.raises(
+        ValueError,
+        match=f"rank must be a visible device ordinal less than 1; got {rank}",
+    ):
+        MacMGPUController(rank=rank)
+
+
+def test_macm_constructor_preserves_unavailable_mps_runtime_error(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: False,
+    )
+
+    with pytest.raises(RuntimeError, match="PyTorch MPS backend is not available"):
+        MacMGPUController(rank=0, busy_threshold=25, iterations=1)
 
 
 def test_macm_unknown_utilization_backs_off_when_threshold_enabled():

--- a/tests/macm_controller/test_macm_basic.py
+++ b/tests/macm_controller/test_macm_basic.py
@@ -54,7 +54,10 @@ def test_macm_controller_context_manager():
 
 
 def test_macm_controller_invalid_rank():
-    with pytest.raises(ValueError, match="MPS only supports device 0"):
+    with pytest.raises(
+        ValueError,
+        match="rank must be a visible device ordinal less than 1; got 1",
+    ):
         MacMGPUController(
             rank=1,
             interval=0.05,


### PR DESCRIPTION
# Mac M Input Validation Plan

## Background

`MacMGPUController` checks `rank != 0` and probes
`torch.backends.mps.is_available()` before all cheap public constructor inputs
are validated. On non-MPS hosts, invalid `busy_threshold` values can therefore
surface as a hardware availability error instead of the public validation error.
The rank check also treats `False` as `0`, because `False != 0` is false.

## Goal

Make direct Mac M controller construction fail for invalid public inputs before
any MPS hardware/backend probe, matching the CUDA and ROCm controller contract.

## Solution

- Add no-GPU-safe regression tests showing invalid `busy_threshold`, invalid
  rank types, and out-of-range ranks fail before `torch.backends.mps.is_available`
  is called.
- Validate `busy_threshold`, `iterations`, and `rank` before the MPS
  availability probe.
- Use the shared `validate_visible_rank(rank, 1)` helper for Mac M rank
  validation so `False`, strings, floats, negative values, and non-zero ranks
  use the same public errors as other direct controllers.
- Update API docs and `AGENTS.md` to include the direct Mac M controller in the
  cheap-input-before-backend-probe contract.

## Tasks

- [x] Add RED constructor validation tests under `tests/macm_controller/`.
- [x] Implement centralized Mac M constructor validation before MPS probing.
- [x] Update `AGENTS.md`, API docs, and this plan.
- [x] Run targeted tests required for this validation fix.
- [x] Run full tests, docs build, pre-commit, and
      `git diff --check`.
- [x] Run local subagent code review before PR.
- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
      and clean the worktree.

## Verification

- RED: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects'`
  failed with 6 failures on the old implementation. Invalid
  `busy_threshold=101` and `rank=False` reached the forbidden MPS availability
  probe; invalid rank values `"0"`, `1.5`, `-1`, and `1` raised the old
  Mac-specific rank error instead of the shared rank validation contract.
- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects'`
  passed: 6 passed, 11 deselected in 1.46s.
- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/macm_controller/test_macm_basic.py tests/global_controller/test_contract.py -q`
  passed: 59 passed, 4 skipped in 1.68s.
- GREEN: `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/global_controller/test_contract.py -q`
  passed: 59 passed in 1.44s.
- GREEN after integration:
  `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q -k 'constructor_rejects or preserves_unavailable_mps_runtime_error'`
  passed with 7 passed, 11 deselected.
- GREEN after integration:
  `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/macm_controller/test_macm_basic.py tests/global_controller/test_contract.py -q`
  passed with 59 passed, 4 skipped.
- FULL: `PYTHONPATH=$PWD/src pytest tests -q` passed with 604 passed,
  11 skipped.
- DOCS: `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's
  existing Material warning and unnav'd plan notices.
- HYGIENE: `pre-commit run --all-files` passed.
- CHECK: `git diff --check` passed with no output.
- REVIEW: local subagent review found no critical, important, or minor issues
  and marked the branch ready to merge.
