### PR TITLE
[controllers] fix: validate rank type before device count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ This file defines how coding agents should work in this repository.
 - Direct single-GPU controllers must validate cheap public constructor inputs
   before backend availability probes or device selection. For Mac M, validate
   `rank`, `busy_threshold`, and `iterations` before checking MPS availability.
+  For CUDA and ROCm, reject non-integer `rank` values before calling
+  `torch.cuda.device_count()`.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.

--- a/docs/plans/rank-type-before-device-count.md
+++ b/docs/plans/rank-type-before-device-count.md
@@ -1,0 +1,60 @@
+# Rank Type Before Device Count Plan
+
+## Background
+
+Direct CUDA and ROCm controllers call
+`validate_visible_rank(rank, torch.cuda.device_count())`. Python evaluates
+`torch.cuda.device_count()` before `validate_visible_rank()` can reject
+non-integer public ranks. If the CUDA runtime probe fails, invalid inputs such
+as `rank="0"` can be masked by a backend error instead of the shared
+`TypeError("rank must be an integer")` contract.
+
+## Goal
+
+Reject non-integer direct-controller ranks before CUDA/ROCm backend device-count
+probing, while preserving visible-count checks for plain integer ranks.
+
+## Solution
+
+- Add a shared rank type validator that returns the normalized plain integer
+  rank or raises `TypeError("rank must be an integer")`.
+- Call that helper in CUDA and ROCm constructors before
+  `torch.cuda.device_count()`.
+- Keep the existing `validate_visible_rank(rank, visible_count)` range contract
+  after the device count is known.
+- Update tests and docs so the ordering is explicit.
+
+## Tasks
+
+- [x] Add RED tests for rank type validation before device-count probing.
+- [x] Implement shared rank type validation and use it in CUDA/ROCm controllers.
+- [x] Update `AGENTS.md`, API docs, and this plan.
+- [x] Run targeted tests, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
+      and clean the worktree.
+
+## Verification
+
+- RED utility boundary:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py::test_validate_rank_type_accepts_plain_integer_rank tests/utilities/test_session_config.py::test_validate_rank_type_rejects_non_plain_integer_rank tests/global_controller/test_contract.py::test_direct_cuda_rocm_controllers_reject_non_integer_ranks_before_device_count -q`
+  first failed during import because `validate_rank_type` did not exist.
+- RED controller ordering:
+  after adding the shared helper, the same command failed with six controller
+  cases because `torch.cuda.device_count()` still ran before non-integer ranks
+  could be rejected.
+- GREEN focused rank ordering:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py::test_validate_rank_type_accepts_plain_integer_rank tests/utilities/test_session_config.py::test_validate_rank_type_rejects_non_plain_integer_rank tests/global_controller/test_contract.py::test_direct_cuda_rocm_controllers_reject_non_integer_ranks_before_device_count -q`
+  passed with 10 passed.
+- GREEN targeted controller/utilities:
+  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/global_controller/test_contract.py tests/cuda_controller tests/rocm_controller -q`
+  passed with 143 passed, 5 skipped.
+- FULL: `PYTHONPATH=$PWD/src pytest tests -q` passed with 614 passed,
+  11 skipped.
+- DOCS: `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's
+  existing Material warning and unnav'd plan notices.
+- HYGIENE: `pre-commit run --all-files` passed.
+- CHECK: `git diff --check` passed with no output.
+- REVIEW: local subagent review found no critical, important, or minor issues,
+  reran `git diff --check`, and marked the branch ready to merge.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,7 +32,8 @@ ordinals. CUDA and ROCm ranks must be plain integers within
 must be the plain integer `0`. Non-integer ranks raise `TypeError`, and negative
 or out-of-range ranks raise `ValueError` during construction, before KeepGPU
 creates a `torch.device`, checks backend availability, calls backend device
-selection, starts a worker, or queries telemetry.
+selection, starts a worker, or queries telemetry. CUDA and ROCm call
+`torch.cuda.device_count()` only after the rank is known to be a plain integer.
 
 CUDA telemetry resolves visible ordinals through `CUDA_VISIBLE_DEVICES` before
 querying NVML; malformed, duplicate/equivalent, ambiguous, or out-of-range

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -15,6 +15,7 @@ from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
     validate_positive_integer,
+    validate_rank_type,
     validate_visible_rank,
 )
 
@@ -81,6 +82,7 @@ class CudaGPUController(BaseGPUController):
             relu_iterations, "relu_iterations"
         )
         self.busy_threshold = validate_busy_threshold(busy_threshold)
+        rank = validate_rank_type(rank)
         rank = validate_visible_rank(rank, torch.cuda.device_count())
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -12,6 +12,7 @@ from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
     validate_positive_integer,
+    validate_rank_type,
     validate_visible_rank,
 )
 from keep_gpu.utilities.rocm_visibility import resolve_rocm_visible_rank_to_smi_index
@@ -45,6 +46,7 @@ class RocmGPUController(BaseGPUController):
                 max_allocation_retries, "max_allocation_retries"
             )
         )
+        rank = validate_rank_type(rank)
         rank = validate_visible_rank(rank, torch.cuda.device_count())
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -66,6 +66,13 @@ def validate_positive_integer(value: Any, name: str) -> int:
     return value
 
 
+def validate_rank_type(rank: Any) -> int:
+    """Validate a public single-GPU rank type before backend probing."""
+    if not _is_plain_int(rank):
+        raise TypeError("rank must be an integer")
+    return rank
+
+
 def validate_visible_rank(rank: Any, visible_count: Any) -> int:
     """Validate a public single-GPU visible device ordinal."""
     if not _is_plain_int(rank):

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -71,6 +71,26 @@ def test_direct_cuda_rocm_controllers_reject_non_integer_ranks(
         controller(rank=rank, vram_to_keep=4)
 
 
+@pytest.mark.parametrize("rank", [1.5, True, "0"])
+@pytest.mark.parametrize(
+    "controller",
+    [
+        CudaGPUController,
+        RocmGPUController,
+    ],
+)
+def test_direct_cuda_rocm_controllers_reject_non_integer_ranks_before_device_count(
+    monkeypatch, controller, rank
+):
+    def fail_device_count():
+        raise AssertionError("device_count should not run for invalid rank type")
+
+    monkeypatch.setattr(torch.cuda, "device_count", fail_device_count)
+
+    with pytest.raises(TypeError, match="rank must be an integer"):
+        controller(rank=rank, vram_to_keep=4)
+
+
 @pytest.mark.parametrize("rank", [-1, 1])
 @pytest.mark.parametrize(
     "controller",

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -9,6 +9,7 @@ from keep_gpu.utilities.session_config import (
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
+    validate_rank_type,
     validate_visible_rank,
 )
 
@@ -56,6 +57,16 @@ def test_validate_gpu_ids_rejects_duplicates():
 
 def test_validate_visible_rank_accepts_visible_ordinal():
     assert validate_visible_rank(1, 2) == 1
+
+
+def test_validate_rank_type_accepts_plain_integer_rank():
+    assert validate_rank_type(0) == 0
+
+
+@pytest.mark.parametrize("rank", [True, 1.5, "1"])
+def test_validate_rank_type_rejects_non_plain_integer_rank(rank):
+    with pytest.raises(TypeError, match="rank must be an integer"):
+        validate_rank_type(rank)
 
 
 @pytest.mark.parametrize("rank", [True, 1.5, "1"])


### PR DESCRIPTION
# Rank Type Before Device Count Plan

## Background

Direct CUDA and ROCm controllers call
`validate_visible_rank(rank, torch.cuda.device_count())`. Python evaluates
`torch.cuda.device_count()` before `validate_visible_rank()` can reject
non-integer public ranks. If the CUDA runtime probe fails, invalid inputs such
as `rank="0"` can be masked by a backend error instead of the shared
`TypeError("rank must be an integer")` contract.

## Goal

Reject non-integer direct-controller ranks before CUDA/ROCm backend device-count
probing, while preserving visible-count checks for plain integer ranks.

## Solution

- Add a shared rank type validator that returns the normalized plain integer
  rank or raises `TypeError("rank must be an integer")`.
- Call that helper in CUDA and ROCm constructors before
  `torch.cuda.device_count()`.
- Keep the existing `validate_visible_rank(rank, visible_count)` range contract
  after the device count is known.
- Update tests and docs so the ordering is explicit.

## Tasks

- [x] Add RED tests for rank type validation before device-count probing.
- [x] Implement shared rank type validation and use it in CUDA/ROCm controllers.
- [x] Update `AGENTS.md`, API docs, and this plan.
- [x] Run targeted tests, full tests, docs build, pre-commit, and
      `git diff --check`.
- [x] Run local subagent code review before PR.
- [ ] Open PR, resolve review comments, wait for clean checks, squash merge,
      and clean the worktree.

## Verification

- RED utility boundary:
  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py::test_validate_rank_type_accepts_plain_integer_rank tests/utilities/test_session_config.py::test_validate_rank_type_rejects_non_plain_integer_rank tests/global_controller/test_contract.py::test_direct_cuda_rocm_controllers_reject_non_integer_ranks_before_device_count -q`
  first failed during import because `validate_rank_type` did not exist.
- RED controller ordering:
  after adding the shared helper, the same command failed with six controller
  cases because `torch.cuda.device_count()` still ran before non-integer ranks
  could be rejected.
- GREEN focused rank ordering:
  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py::test_validate_rank_type_accepts_plain_integer_rank tests/utilities/test_session_config.py::test_validate_rank_type_rejects_non_plain_integer_rank tests/global_controller/test_contract.py::test_direct_cuda_rocm_controllers_reject_non_integer_ranks_before_device_count -q`
  passed with 10 passed.
- GREEN targeted controller/utilities:
  `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/global_controller/test_contract.py tests/cuda_controller tests/rocm_controller -q`
  passed with 143 passed, 5 skipped.
- FULL: `PYTHONPATH=$PWD/src pytest tests -q` passed with 614 passed,
  11 skipped.
- DOCS: `PYTHONPATH=$PWD/src mkdocs build` passed with the repository's
  existing Material warning and unnav'd plan notices.
- HYGIENE: `pre-commit run --all-files` passed.
- CHECK: `git diff --check` passed with no output.
- REVIEW: local subagent review found no critical, important, or minor issues,
  reran `git diff --check`, and marked the branch ready to merge.
