### PR TITLE
[cli] fix: rollback failed auto-started service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,11 @@ This file defines how coding agents should work in this repository.
 - MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
   before socket bind, matching the CLI service endpoint contract.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
+- If `keep-gpu start` auto-starts a service daemon and the following
+  `start_keep` RPC returns expected startup-unavailable JSON-RPC code
+  `-32000` before creating a session, the CLI must best-effort stop that
+  just-created daemon. Do not stop already-running daemons, malformed success
+  payloads, or unrelated RPC failures.
 - Blocking-mode root CLI options (`--gpu-ids`, `--vram`,
   `--busy-threshold`/`--util-threshold`, hidden `--threshold`, and
   `--interval`) must be rejected when explicitly supplied before a service

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -28,6 +28,10 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 - follow-up status/stop command hints,
 - daemon shutdown hint (`keep-gpu service-stop`).
 
+If this invocation auto-starts the service but session creation fails with an
+expected startup-unavailable error before a session is created, `start`
+best-effort stops the just-created daemon so it does not remain idle.
+
 Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
 fail without creating daemon runtime files or issuing RPC. Service endpoint

--- a/docs/plans/start-autostart-rollback.md
+++ b/docs/plans/start-autostart-rollback.md
@@ -1,0 +1,63 @@
+# Start Auto-Start Rollback Plan
+
+## Background
+
+`keep-gpu start` can auto-start the local service daemon before it sends the
+`start_keep` JSON-RPC request. If that request then fails with the service's
+expected startup-unavailable error, such as no usable visible GPUs or an
+unsupported platform, no keep session exists but the just-created daemon keeps
+running. `_rpc_call()` currently drops the JSON-RPC `error.code`, so the CLI
+cannot distinguish expected startup-unavailable failures from arbitrary RPC
+errors.
+
+## Goal
+
+Keep service mode low-power and tidy by stopping a daemon that this exact
+`start` invocation auto-started when the requested session fails before
+creation with startup-unavailable JSON-RPC code `-32000`.
+
+## Solution
+
+- Preserve the JSON-RPC error code on `ServiceRPCError`.
+- Teach `keep-gpu start` to best-effort stop the just-created daemon only when
+  all of these are true:
+  - this command auto-started the service,
+  - `start_keep` returned `-32000`, and
+  - no successful session result was received.
+- Keep other RPC failures conservative: do not stop an already-running daemon,
+  and do not stop for malformed success payloads or unrelated RPC errors.
+- Document the lifecycle invariant in CLI docs and `AGENTS.md`.
+
+## Tasks
+
+- [x] Add RED tests for preserving JSON-RPC error codes and rolling back
+      startup-unavailable auto-starts.
+- [x] Confirm RED tests fail for the current implementation.
+- [x] Implement the minimal CLI error-code preservation and rollback logic.
+- [x] Update `AGENTS.md`, CLI guide/reference, and this plan.
+- [x] Run focused tests, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve all review comments/checks, squash merge, and clean the
+      worktree.
+
+## Verification
+
+- RED and GREEN tests:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_start_rolls_back_auto_started_service_on_startup_unavailable -q`
+  first failed with the expected missing `.code` attribute and missing rollback
+  stop call. After implementation, the expanded focused shard
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_start_rolls_back_auto_started_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_does_not_stop_auto_started_service_for_non_startup_rpc_error tests/test_cli_service_commands.py::test_start_does_not_stop_already_running_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_does_not_stop_auto_started_service_for_malformed_success_payload tests/test_cli_service_commands.py::test_start_rollback_stop_failure_preserves_startup_error -q`
+  passed with `6 passed`.
+- CLI service shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with
+  `153 passed`.
+- Full no-GPU-safe gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `619 passed, 11 skipped`.
+- Docs and hygiene:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan notices; `pre-commit run --all-files` passed; and
+  `git diff --check` passed.
+- Local subagent review:
+  The reviewer found no critical, important, or minor issues and marked the
+  branch ready to merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,6 +45,9 @@ Local input validation runs before service auto-start. Invalid `--vram`,
 `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, or `--port`
 values fail before daemon startup or RPC. Omit `--gpu-ids` to use all visible
 GPUs; explicit empty or whitespace-only values are invalid.
+If `start` auto-starts the service and the service then reports expected
+startup unavailability before creating a session, the CLI best-effort stops the
+just-created daemon instead of leaving it idle.
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -31,6 +31,7 @@ from keep_gpu.utilities.session_config import (
 
 DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
+JSONRPC_STARTUP_UNAVAILABLE = -32000
 SERVICE_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
 SERVICE_PORT_ERROR = "port must be an integer between 1 and 65535"
 ROOT_BLOCKING_OPTION_LABELS = {
@@ -59,6 +60,10 @@ class ServiceResponseError(RuntimeError):
 
 class ServiceRPCError(RuntimeError):
     """Raised when the local service returns a JSON-RPC error."""
+
+    def __init__(self, message: str, code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 def _runtime_dir() -> Path:
@@ -591,7 +596,10 @@ def _rpc_call(
             raise ServiceResponseError("Malformed JSON-RPC response: missing id")
         if response.get("id") not in (payload["id"], None):
             raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
-        raise ServiceRPCError(error.get("message", str(error)))
+        code = error.get("code")
+        if isinstance(code, bool) or not isinstance(code, int):
+            code = None
+        raise ServiceRPCError(error.get("message", str(error)), code=code)
     if response.get("id") != payload["id"]:
         raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
     if "result" not in response:
@@ -655,6 +663,20 @@ def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
                 "list_gpus", f"gpus[{index}] must be an object"
             )
     return result
+
+
+def _rollback_auto_started_service_on_startup_unavailable(
+    auto_started: bool, exc: ServiceRPCError, host: str, port: int
+) -> None:
+    if not auto_started or exc.code != JSONRPC_STARTUP_UNAVAILABLE:
+        return
+    try:
+        _stop_service_process(host, port)
+    except Exception:  # noqa: BLE001 - best-effort cleanup must not mask startup error
+        logger.debug(
+            "Failed to stop auto-started service after startup-unavailable error",
+            exc_info=True,
+        )
 
 
 def _is_service_unreachable_error(exc: RuntimeError) -> bool:
@@ -872,6 +894,7 @@ def start(
     Use `keep-gpu stop --job-id <id>` to release this session and
     `keep-gpu service-stop` to stop the local service daemon.
     """
+    auto_started = False
     try:
         host, port = _validate_cli_service_endpoint(host, port)
         interval = _validate_cli_interval(interval)
@@ -915,6 +938,12 @@ def start(
         console.print(
             "[dim]When all sessions are done, stop daemon with: keep-gpu service-stop[/dim]"
         )
+    except ServiceRPCError as exc:
+        _rollback_auto_started_service_on_startup_unavailable(
+            auto_started, exc, host, port
+        )
+        console.print(f"[bold red]Error: {exc}[/bold red]")
+        raise typer.Exit(code=1) from exc
     except (RuntimeError, typer.BadParameter) as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -942,8 +942,9 @@ def test_rpc_call_propagates_error_envelope_with_null_id(monkeypatch):
         },
     )
 
-    with pytest.raises(cli.ServiceRPCError, match="Parse error"):
+    with pytest.raises(cli.ServiceRPCError, match="Parse error") as exc_info:
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
+    assert exc_info.value.code == -32700
 
 
 def test_rpc_call_rejects_error_envelope_without_id_member(monkeypatch):
@@ -1152,6 +1153,123 @@ def test_start_prints_dashboard_and_stop_hints(monkeypatch):
     assert "keep-gpu status --job-id job-abc" in result.output
     assert "keep-gpu stop --job-id job-abc" in result.output
     assert "keep-gpu service-stop" in result.output
+
+
+def test_start_rolls_back_auto_started_service_on_startup_unavailable(monkeypatch):
+    stopped = []
+
+    def fake_ensure(host, port, auto_start=True):
+        return True
+
+    def fake_rpc(method, params, host, port):
+        raise cli.ServiceRPCError(
+            "No usable visible GPUs", code=cli.JSONRPC_STARTUP_UNAVAILABLE
+        )
+
+    def fake_stop(host, port):
+        stopped.append((host, port))
+        return True
+
+    monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop)
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "No usable visible GPUs" in result.output
+    assert stopped == [(cli.DEFAULT_SERVICE_HOST, cli.DEFAULT_SERVICE_PORT)]
+
+
+def test_start_does_not_stop_auto_started_service_for_non_startup_rpc_error(
+    monkeypatch,
+):
+    stopped = []
+
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            cli.ServiceRPCError("Internal error", code=-32603)
+        ),
+    )
+    monkeypatch.setattr(
+        cli, "_stop_service_process", lambda host, port: stopped.append((host, port))
+    )
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "Internal error" in result.output
+    assert stopped == []
+
+
+def test_start_does_not_stop_already_running_service_on_startup_unavailable(
+    monkeypatch,
+):
+    stopped = []
+
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            cli.ServiceRPCError(
+                "No usable visible GPUs", code=cli.JSONRPC_STARTUP_UNAVAILABLE
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        cli, "_stop_service_process", lambda host, port: stopped.append((host, port))
+    )
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "No usable visible GPUs" in result.output
+    assert stopped == []
+
+
+def test_start_does_not_stop_auto_started_service_for_malformed_success_payload(
+    monkeypatch,
+):
+    stopped = []
+
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: True)
+    monkeypatch.setattr(cli, "_rpc_call", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        cli, "_stop_service_process", lambda host, port: stopped.append((host, port))
+    )
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "start_keep result must include job_id" in result.output
+    assert stopped == []
+
+
+def test_start_rollback_stop_failure_preserves_startup_error(monkeypatch):
+    def fail_stop(host, port):
+        raise RuntimeError("stop failed")
+
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            cli.ServiceRPCError(
+                "No usable visible GPUs", code=cli.JSONRPC_STARTUP_UNAVAILABLE
+            )
+        ),
+    )
+    monkeypatch.setattr(cli, "_stop_service_process", fail_stop)
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "No usable visible GPUs" in result.output
+    assert "stop failed" not in result.output
 
 
 def test_service_stop_requires_managed_pid(monkeypatch):


### PR DESCRIPTION
## Summary
- Preserve JSON-RPC error codes on `ServiceRPCError`.
- Roll back a daemon that `keep-gpu start` auto-started when `start_keep` fails with startup-unavailable `-32000` before creating a session.
- Document the lifecycle invariant in AGENTS and CLI docs.

## Test Plan
- [x] RED targeted tests first failed for missing `.code` and missing rollback call.
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_start_rolls_back_auto_started_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_does_not_stop_auto_started_service_for_non_startup_rpc_error tests/test_cli_service_commands.py::test_start_does_not_stop_already_running_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_does_not_stop_auto_started_service_for_malformed_success_payload tests/test_cli_service_commands.py::test_start_rollback_stop_failure_preserves_startup_error -q`
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- [x] `PYTHONPATH=$PWD/src pytest tests -q`
- [x] `PYTHONPATH=$PWD/src mkdocs build`
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Local Review
- [x] Local subagent code review found no critical, important, or minor issues and marked the branch ready to merge.