### PR TITLE
[mcp] fix: classify invalid visible gpu ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,10 @@ This file defines how coding agents should work in this repository.
   construction, before `torch.device`, backend `set_device`, telemetry, or keep
   worker startup can target an invalid ordinal.
 - Treat public `gpu_ids` as visible device ordinals after user-supplied CUDA or ROCm visibility filtering. Do not rewrite visibility masks inside KeepGPU command paths; reject explicit CUDA/ROCm ordinals outside the current visible device count before starting keep workers.
+- JSON-RPC and MCP tool `start_keep` requests with explicit `gpu_ids` outside
+  the current visible device count are public invalid-parameter errors
+  (`-32602` for direct JSON-RPC, MCP tool `isError=true`), not internal server
+  failures.
 - Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` numeric/UUID tokens to the correct NVML handle. If that mapping is malformed, duplicate/equivalent, ambiguous, or unsupported, return `None` without partial NVML handle queries so eco-safe backoff applies instead of falling back to a possibly wrong physical index.
 - Keep ROCm telemetry aligned with visible ROCm ordinals: resolve `ROCR_VISIBLE_DEVICES` as the base mask and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. If the mapping is malformed, conflicting, unsupported, or out of range, return unavailable utilization rather than querying a guessed SMI index.
 - Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus`

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -91,6 +91,11 @@ conditions, such as an unsupported controller platform or no usable visible
 GPUs, return `-32000` with the startup message. Unexpected server failures use
 `-32603 Internal error`.
 
+Explicit `gpu_ids` that are validly shaped but outside the service process's
+current visible GPU count are public validation failures. Direct JSON-RPC
+returns `-32602`, while MCP `tools/call` returns a tool result with
+`isError=true`.
+
 MCP `tools/call` responses keep protocol envelopes successful for normal tool
 results, public tool-input validation failures, and expected hardware/platform
 startup-unavailable failures. Those tool-level failures return

--- a/docs/plans/jsonrpc-gpu-ids-invalid-params.md
+++ b/docs/plans/jsonrpc-gpu-ids-invalid-params.md
@@ -1,0 +1,63 @@
+# JSON-RPC GPU IDs Invalid Params Plan
+
+## Background
+
+Direct JSON-RPC and MCP tool calls validate the shape of `gpu_ids` before
+controller startup, but explicit visible-ordinal overflow is currently detected
+inside `GlobalGPUController`. That controller raises a plain `ValueError`, so
+JSON-RPC direct calls report `-32603 Internal error` for a normal user input
+mistake. MCP `tools/call` likewise treats the same selection mistake as an
+unexpected protocol error instead of a tool-level input error.
+
+## Goal
+
+Classify explicit out-of-range visible `gpu_ids` as public invalid parameters
+for service entry points while preserving internal-error classification for
+arbitrary controller failures.
+
+## Solution
+
+- Add RED coverage for direct JSON-RPC `start_keep` with an out-of-range visible
+  CUDA ordinal returning `-32602 Invalid params`.
+- Add RED coverage for MCP `tools/call start_keep` returning a successful tool
+  envelope with `isError=true` for the same public input error.
+- Introduce a specific controller exception for invalid visible GPU selection
+  and map only that exception to `SessionInputError` in service startup.
+- Preserve the existing test that arbitrary controller `ValueError` remains
+  `-32603 Internal error`.
+- Update `AGENTS.md`, MCP guide docs, and this plan.
+
+## Tasks
+
+- [x] Add RED tests for direct JSON-RPC and MCP tool invalid visible ordinal
+      selection.
+- [x] Confirm RED tests fail with the current internal-error behavior.
+- [x] Implement the minimal controller exception and service mapping.
+- [x] Update `AGENTS.md`, MCP docs, and this plan.
+- [x] Run focused tests, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve all review comments/checks, squash merge, and clean the
+      worktree.
+
+## Verification
+
+- RED and GREEN focused tests:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_out_of_range_gpu_ids_returns_invalid_params tests/mcp/test_server.py::test_mcp_tools_call_out_of_range_gpu_ids_returns_tool_error tests/mcp/test_server.py::test_jsonrpc_start_keep_runtime_value_error_remains_internal_error -q`
+  first failed with direct JSON-RPC returning `-32603` and MCP `tools/call`
+  returning a protocol internal-error envelope. After implementation, the
+  focused shard including the existing arbitrary-controller-`ValueError`
+  regression passed with `3 passed`.
+- MCP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `179 passed`.
+- Full no-GPU-safe gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `621 passed, 11 skipped`.
+- Docs and hygiene:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan notices; `pre-commit run --all-files` passed after Black
+  formatted the new assertions; after rerunning focused and full tests,
+  `pre-commit run --all-files` and `git diff --check` passed.
+- Local subagent review:
+  The reviewer found no critical or important issues, identified this plan's
+  focused-test command mismatch as a minor reproducibility issue, and marked the
+  branch ready to merge after this documentation fix.

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -30,13 +30,17 @@ class UnsupportedControllerPlatformError(
     """The current platform cannot run the global GPU controller."""
 
 
+class InvalidVisibleGPUSelectionError(ValueError):
+    """Public gpu_ids selection is not valid for the visible device set."""
+
+
 def _resolve_visible_gpu_ids(gpu_ids: Optional[List[int]]) -> List[int]:
     visible_count = torch.cuda.device_count()
     if gpu_ids is None:
         return list(range(visible_count))
     invalid_ids = [gpu_id for gpu_id in gpu_ids if gpu_id >= visible_count]
     if invalid_ids:
-        raise ValueError(
+        raise InvalidVisibleGPUSelectionError(
             "gpu_ids must be visible device ordinals less than "
             f"{visible_count}; got {invalid_ids}"
         )
@@ -86,7 +90,7 @@ class GlobalGPUController:
             elif gpu_ids == [0]:
                 self.gpu_ids = gpu_ids
             else:
-                raise ValueError(
+                raise InvalidVisibleGPUSelectionError(
                     f"MACM platform only supports gpu_ids=[0] or None, got {gpu_ids}"
                 )
         elif self.computing_platform in (

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -46,6 +46,7 @@ from keep_gpu import __version__
 from keep_gpu.global_gpu_controller.global_gpu_controller import (
     ControllerStartupUnavailable,
     GlobalGPUController,
+    InvalidVisibleGPUSelectionError,
 )
 from keep_gpu.utilities.humanized_input import (
     PUBLIC_VRAM_MAX_BYTES,
@@ -310,6 +311,8 @@ class KeepGPUServer:
                 self._starting_job_ids.discard(job_id)
                 self._starting_params.pop(job_id, None)
                 self._sessions_cond.notify_all()
+            if isinstance(exc, InvalidVisibleGPUSelectionError):
+                raise SessionInputError(str(exc)) from exc
             if isinstance(exc, ControllerStartupUnavailable):
                 raise SessionStartupUnavailable(str(exc)) from exc
             raise

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -607,6 +607,32 @@ def test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code(monkeypatch):
         server.shutdown()
 
 
+def test_jsonrpc_start_keep_out_of_range_gpu_ids_returns_invalid_params(monkeypatch):
+    import torch
+
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "bad-visible-gpu", "gpu_ids": [99]},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
+        assert (
+            "gpu_ids must be visible device ordinals less than 1"
+            in resp["error"]["message"]
+        )
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
 def test_jsonrpc_cuda_worker_startup_failure_creates_no_active_session(monkeypatch):
     import torch
 
@@ -900,6 +926,39 @@ def test_mcp_tools_call_startup_unavailable_returns_tool_error():
     assert result["isError"] is True
     assert "No usable GPUs are available" in result["content"][0]["text"]
     assert server.status()["active_jobs"] == []
+
+
+def test_mcp_tools_call_out_of_range_gpu_ids_returns_tool_error(monkeypatch):
+    import torch
+
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    server = KeepGPUServer()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/call",
+        "params": {
+            "name": "start_keep",
+            "arguments": {"job_id": "tool-bad-visible-gpu", "gpu_ids": [99]},
+        },
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert resp["jsonrpc"] == "2.0"
+        assert resp["id"] == 5
+        assert "result" in resp
+        result = resp["result"]
+        assert result["isError"] is True
+        assert (
+            "gpu_ids must be visible device ordinals less than 1"
+            in result["content"][0]["text"]
+        )
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
 
 
 def test_mcp_tools_call_unexpected_failure_returns_jsonrpc_internal_error():


### PR DESCRIPTION
## Summary
- Add a specific visible GPU selection exception for public `gpu_ids` mistakes.
- Map out-of-range visible `gpu_ids` in service startup to invalid params while preserving internal errors for arbitrary controller failures.
- Document the direct JSON-RPC and MCP tool error contracts.

## Test Plan
- [x] RED focused tests first failed with direct JSON-RPC returning `-32603` and MCP `tools/call` returning an internal-error envelope.
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_out_of_range_gpu_ids_returns_invalid_params tests/mcp/test_server.py::test_mcp_tools_call_out_of_range_gpu_ids_returns_tool_error tests/mcp/test_server.py::test_jsonrpc_start_keep_runtime_value_error_remains_internal_error -q`
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp -q`
- [x] `PYTHONPATH=$PWD/src pytest tests -q`
- [x] `PYTHONPATH=$PWD/src mkdocs build`
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Local Review
- [x] Local subagent code review found no critical or important issues; the minor plan-command mismatch was fixed before this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `gpu_ids` validation so out-of-range visible GPU selections are reported as input errors instead of generic server failures.
  * JSON-RPC requests now return `Invalid params`, and MCP tool calls now return `isError=true` for these cases.

* **Bug Fixes**
  * Added clearer error handling for invalid GPU selections during startup.
  * Covered the new behavior with tests for both JSON-RPC and MCP flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->