### PR TITLE
[mcp] fix: bound stops for starting sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,9 @@ This file defines how coding agents should work in this repository.
 - Stop requests must not miss starting sessions. Targeted stops wait for the
   matching startup before returning `not found`; stop-all records its initial
   active/starting boundary first, waits only for starts in that boundary, and
-  never includes later starts.
+  never includes later starts. After waiting, targeted stops must release only
+  the session observed before the wait or the settled session matching the
+  captured starting params, not a later same-`job_id` replacement.
 - Stop requests waiting on starting sessions must be bounded. If startup does
   not settle within the stop wait budget, return the normal additive timeout
   payload and remember the cancellation so a later successful startup is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,14 @@ This file defines how coding agents should work in this repository.
 - Non-force `keep-gpu service-stop` must require a reachable service and a successful status/RPC check before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
-- Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
+- Stop requests must not miss starting sessions. Targeted stops wait for the
+  matching startup before returning `not found`; stop-all records its initial
+  active/starting boundary first, waits only for starts in that boundary, and
+  never includes later starts.
+- Stop requests waiting on starting sessions must be bounded. If startup does
+  not settle within the stop wait budget, return the normal additive timeout
+  payload and remember the cancellation so a later successful startup is
+  released quietly instead of becoming a surprise active keeper.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Dashboard telemetry must display unavailable utilization as unknown/`n/a`, not

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ to zero devices.
   visible with `state` and `last_error`.
 - Status and stop requests both account for in-progress starts: status reports
   them as `starting`, and stop waits for startup to settle so a session is not
-  reported as missing or skipped by stop-all.
+  reported as missing or skipped by stop-all. That startup wait is bounded; if
+  it times out, the stop response includes the job in `timed_out`, the job may
+  remain `starting`, and the service remembers the cancellation so a later
+  successful startup is released quietly.
 - Stop-all only covers sessions active or already starting when that request
   begins; later concurrent starts belong to a later stop request.
 - Stop-all releases independent sessions concurrently and reports outcomes in

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -99,9 +99,13 @@ Elementwise keep-alive batches:
   session snapshot, while aggregating results in deterministic snapshot order.
 - Service session state is intentionally conservative: `status` shows reserved
   jobs as `state="starting"` while controller startup is in progress, and
-  `stop_keep` removes a session only after release succeeds. Timed-out sessions
-  stay visible as `state="stopping"` until the background release finishes;
-  failed releases stay visible as `state="stop_failed"` with `last_error`.
+  `stop_keep` removes a session only after release succeeds. Stop requests wait
+  for starting jobs within a bounded budget; if that wait times out, the
+  response uses `timed_out`, the job can remain visible as `state="starting"`,
+  and the service remembers the cancellation so a later successful startup is
+  released quietly. Timed-out releases stay visible as `state="stopping"` until
+  the background release finishes; failed releases stay visible as
+  `state="stop_failed"` with `last_error`.
 - After startup, terminal worker runtime or allocation failures are surfaced as
   `state="runtime_failed"` with `last_error`. The retained session remains
   visible and can still be stopped. Busy-GPU or unavailable-telemetry deferral is

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -158,10 +158,13 @@ job id only appears in `stopped` after cleanup has completed within the stop
 request timeout.
 
 If `stop_keep` arrives while a matching session is still starting, the service
-waits for startup to settle before deciding whether the job exists. Stop-all
-requests also wait for in-progress starts before taking their session snapshot.
-For stop-all, starts that begin after that request's initial snapshot are not
-stopped by that request.
+waits for startup to settle before deciding whether the job exists. This wait
+is bounded: if startup does not settle within the stop wait budget, the response
+uses the normal `timed_out` field and the service remembers the cancellation so
+the session is released quietly if startup later succeeds. Stop-all requests
+also wait for in-progress starts from their initial snapshot, with the same
+bounded timeout behavior. For stop-all, starts that begin after that request's
+initial snapshot are not stopped by that request.
 Stop-all releases the sessions in its snapshot concurrently and aggregates
 results in deterministic snapshot order using the same additive fields.
 

--- a/docs/plans/stop-starting-session-timeout.md
+++ b/docs/plans/stop-starting-session-timeout.md
@@ -1,0 +1,106 @@
+# Stop Starting Session Timeout Plan
+
+## Background
+
+`stop_keep(job_id)` and `stop_keep()` intentionally wait for in-progress
+`start_keep()` calls so stop requests do not miss sessions that are still
+starting. The wait is currently unbounded. If controller construction or
+`keep()` hangs, stop requests can block indefinitely, leaving users unable to
+cancel a stuck startup and keeping custom job IDs reserved.
+
+## Goal
+
+Keep the no-missed-starts contract for normal slow startups while bounding stop
+requests when startup does not settle. If a stop request times out while a job
+is still starting, the eventual completed startup should still be released
+automatically.
+
+## Solution
+
+- Add bounded waiting for starting jobs in targeted stop and stop-all paths.
+- Return the existing additive timeout payload (`timed_out`, `message`) when a
+  requested starting job does not settle before the startup-stop wait budget.
+- Track timed-out stop requests for starting jobs. If such a startup later
+  completes successfully, immediately trigger a quiet background stop so a
+  timed-out cancellation does not leave a surprise active keeper.
+- Preserve existing behavior for slow startups that settle within the wait
+  budget: the original stop request releases the session and reports it in
+  `stopped`.
+- Scope stop-all to the active/starting boundary captured when the stop-all
+  request begins. Use session/parameter identity so a later session that reuses
+  the same `job_id` is not released by the older stop-all request.
+- Bind remembered post-timeout cleanup to the `Session` object created by the
+  timed-out startup so a delayed quiet cleanup cannot stop a later replacement
+  using the same custom `job_id`.
+- Keep failed startups clearing reservations and pending-stop markers.
+- Update `AGENTS.md`, MCP/CLI docs, and this plan.
+
+## Tasks
+
+- [x] Add RED tests for targeted stop and stop-all timing out while startup is
+      stuck without hanging the test process.
+- [x] Add GREEN coverage that a timed-out stop request is honored after startup
+      eventually completes.
+- [x] Add regression coverage that stop-all does not stop sessions started after
+      its initial boundary, including same-`job_id` reuse.
+- [x] Add regression coverage that delayed remembered cleanup does not stop a
+      later same-`job_id` replacement after the original session was removed.
+- [x] Implement bounded startup wait and pending-stop handoff.
+- [x] Update `AGENTS.md`, MCP/CLI docs, and this plan.
+- [x] Run focused tests, MCP shard, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve all review comments/checks, squash merge, and clean the
+      worktree.
+
+## Verification
+
+- RED and GREEN focused tests:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes -q`
+  first failed with all stop threads still alive after the short test wait
+  budget. After implementation, the expanded focused shard
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
+  passed with `7 passed`.
+- MCP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `183 passed`.
+- Full no-GPU-safe gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `625 passed, 11 skipped`.
+- Docs and hygiene:
+  Initial `pre-commit run --all-files` reformatted `src/keep_gpu/mcp/server.py`
+  and `tests/mcp/test_server.py`; after rerunning the focused, MCP, and full
+  test shards, the post-review focused shard including the stop-all snapshot
+  race regression passed with `8 passed`, `PYTHONPATH=$PWD/src pytest tests/mcp -q`
+  passed with `184 passed`, and `PYTHONPATH=$PWD/src pytest tests -q` passed
+  with `626 passed, 11 skipped`.
+- Same-`job_id` reuse regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_reused_job_id_started_after_snapshot -q`
+  failed under the older job-id-only active snapshot filter with
+  `stopped == ['reused-job', 'starting-job']`. Restoring the identity-based
+  active snapshot made the same command pass with `1 passed`.
+- Delayed cleanup same-`job_id` reuse regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed -q`
+  failed before the identity-bound cleanup helper because the replacement
+  controller was released. After binding cleanup to the original `Session`, the
+  same command passed with `1 passed`.
+- Current post-review gates:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_session_started_after_snapshot_even_if_it_completes tests/mcp/test_server.py::test_stop_all_does_not_stop_reused_job_id_started_after_snapshot tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
+  plus `tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed`
+  passed with `10 passed`; `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed
+  with `186 passed`; `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `628 passed, 11 skipped`; `PYTHONPATH=$PWD/src mkdocs build`,
+  `pre-commit run --all-files`, and `git diff --check` passed.
+- Local subagent review:
+  The reviewer found a stop-all snapshot race where a session that started
+  after stop-all began but completed before the original starting job settled
+  could be stopped by that request, plus stale README/architecture docs. Added
+  a regression for the race, limited stop-all release work to the initial
+  snapshot, and updated the stale docs.
+  A later review found a same-`job_id` reuse variant and stale
+  AGENTS/CLI wording; the current changes add that regression, keep active
+  snapshot membership identity-based, and clarify that stop-all records its
+  boundary before waiting.
+  Final local reviewers found one more same-`job_id` race on delayed
+  remembered cleanup; the current changes add the deterministic regression and
+  route pending cleanup through an expected-session helper.
+  The final local reviewer reported no Critical or Important findings after
+  that fix.

--- a/docs/plans/stop-starting-session-timeout.md
+++ b/docs/plans/stop-starting-session-timeout.md
@@ -32,6 +32,9 @@ automatically.
 - Bind remembered post-timeout cleanup to the `Session` object created by the
   timed-out startup so a delayed quiet cleanup cannot stop a later replacement
   using the same custom `job_id`.
+- Bind targeted stop release to the session observed before the startup wait, or
+  to the settled session whose params match the captured starting job, so a stop
+  request cannot release a later same-`job_id` replacement.
 - Keep failed startups clearing reservations and pending-stop markers.
 - Update `AGENTS.md`, MCP/CLI docs, and this plan.
 
@@ -45,6 +48,8 @@ automatically.
       its initial boundary, including same-`job_id` reuse.
 - [x] Add regression coverage that delayed remembered cleanup does not stop a
       later same-`job_id` replacement after the original session was removed.
+- [x] Add CodeRabbit follow-up regression coverage that targeted stop does not
+      stop a later same-`job_id` replacement after the wait window.
 - [x] Implement bounded startup wait and pending-stop handoff.
 - [x] Update `AGENTS.md`, MCP/CLI docs, and this plan.
 - [x] Run focused tests, MCP shard, full tests, docs build, pre-commit, and
@@ -82,12 +87,19 @@ automatically.
   failed before the identity-bound cleanup helper because the replacement
   controller was released. After binding cleanup to the original `Session`, the
   same command passed with `1 passed`.
+- Targeted stop same-`job_id` reuse regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_does_not_stop_reused_job_id_after_wait_window -q`
+  failed before the CodeRabbit follow-up because the replacement controller was
+  released and the result had no `job_id not found` message. After passing the
+  captured expected session into `_stop_current_session()`, the same command
+  passed with `1 passed`.
+- CodeRabbit follow-up focused shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_session_started_after_snapshot_even_if_it_completes tests/mcp/test_server.py::test_stop_all_does_not_stop_reused_job_id_started_after_snapshot tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed tests/mcp/test_server.py::test_stop_keep_does_not_stop_reused_job_id_after_wait_window tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
+  passed with `11 passed`.
 - Current post-review gates:
-  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_session_started_after_snapshot_even_if_it_completes tests/mcp/test_server.py::test_stop_all_does_not_stop_reused_job_id_started_after_snapshot tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
-  plus `tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed`
-  passed with `10 passed`; `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed
-  with `186 passed`; `PYTHONPATH=$PWD/src pytest tests -q` passed with
-  `628 passed, 11 skipped`; `PYTHONPATH=$PWD/src mkdocs build`,
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `187 passed`;
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `629 passed, 11 skipped`; `PYTHONPATH=$PWD/src mkdocs build`,
   `pre-commit run --all-files`, and `git diff --check` passed.
 - Local subagent review:
   The reviewer found a stop-all snapshot race where a session that started
@@ -104,3 +116,6 @@ automatically.
   route pending cleanup through an expected-session helper.
   The final local reviewer reported no Critical or Important findings after
   that fix.
+  CodeRabbit later found the targeted-stop variant of the same identity race;
+  the current changes add the regression, use the existing expected-session
+  helper for targeted stops, and document the guard in `AGENTS.md`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,10 +85,13 @@ runtime failure.
 
 `--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
 error before any RPC or stop-all fallback runs.
-Stop waits for in-progress starts to settle before returning `not found` or
-taking the stop-all snapshot, so starting sessions are not silently skipped.
-For `--all`, starts that begin after that command's initial snapshot are not
-stopped by that command.
+Targeted stop waits for a matching in-progress start to settle before returning
+`not found`, so starting sessions are not silently skipped. That wait is
+bounded; if startup does not settle in time, the response includes the job in
+`timed_out`, and the service remembers the cancellation so a later successful
+startup is released quietly. For `--all`, the service records the initial
+active/starting boundary first, waits only for starting jobs in that boundary,
+and does not stop later starts.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
 The output is a directly parseable JSON object, including `{"error": "..."}` for

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -34,6 +34,7 @@ import sys
 import uuid
 import argparse
 import threading
+import time
 import mimetypes
 from http.server import BaseHTTPRequestHandler
 from socketserver import TCPServer, ThreadingMixIn
@@ -75,6 +76,7 @@ JSONRPC_INTERNAL_ERROR = -32603
 JSONRPC_STARTUP_UNAVAILABLE = -32000
 MCP_ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
 MCP_ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
+STARTUP_STOP_WAIT_TIMEOUT_SECONDS = 10.0
 
 MCP_TOOLS: List[Dict[str, Any]] = [
     {
@@ -201,10 +203,31 @@ class KeepGPUServer:
         self._sessions: Dict[str, Session] = {}
         self._starting_job_ids: set[str] = set()
         self._starting_params: Dict[str, Dict[str, Any]] = {}
+        self._pending_stop_job_ids: set[str] = set()
+        self._startup_stop_wait_timeout_s = STARTUP_STOP_WAIT_TIMEOUT_SECONDS
         self._sessions_lock = threading.RLock()
         self._sessions_cond = threading.Condition(self._sessions_lock)
         self._controller_factory = controller_factory or GlobalGPUController
         atexit.register(self.shutdown)
+
+    def _wait_for_starting_jobs_or_mark_pending(
+        self, starting_snapshot: Dict[str, Dict[str, Any]]
+    ) -> set[str]:
+        deadline = time.monotonic() + self._startup_stop_wait_timeout_s
+        with self._sessions_lock:
+            while True:
+                still_starting = {
+                    job_id
+                    for job_id, params in starting_snapshot.items()
+                    if self._starting_params.get(job_id) is params
+                }
+                if not still_starting:
+                    return set()
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._pending_stop_job_ids.update(still_starting)
+                    return still_starting
+                self._sessions_cond.wait(remaining)
 
     @staticmethod
     def _release_with_timeout(
@@ -310,6 +333,7 @@ class KeepGPUServer:
             with self._sessions_lock:
                 self._starting_job_ids.discard(job_id)
                 self._starting_params.pop(job_id, None)
+                self._pending_stop_job_ids.discard(job_id)
                 self._sessions_cond.notify_all()
             if isinstance(exc, InvalidVisibleGPUSelectionError):
                 raise SessionInputError(str(exc)) from exc
@@ -320,11 +344,24 @@ class KeepGPUServer:
         with self._sessions_lock:
             self._starting_job_ids.discard(job_id)
             params = self._starting_params.pop(job_id, params)
-            self._sessions[job_id] = Session(
+            pending_stop = job_id in self._pending_stop_job_ids
+            self._pending_stop_job_ids.discard(job_id)
+            session = Session(
                 controller=controller,
                 params=params,
             )
+            self._sessions[job_id] = session
             self._sessions_cond.notify_all()
+        if pending_stop:
+            threading.Thread(
+                target=self._stop_current_session,
+                kwargs={
+                    "job_id": job_id,
+                    "quiet": True,
+                    "expected_session": session,
+                },
+                daemon=True,
+            ).start()
         logger.info("Started keep session %s on GPUs %s", job_id, gpu_ids)
         return {"job_id": job_id}
 
@@ -391,6 +428,56 @@ class KeepGPUServer:
         self._mark_session(job_id, session, "stop_failed", message)
         logger.warning("Delayed release failed for keep session %s: %s", job_id, error)
 
+    def _stop_current_session(
+        self,
+        job_id: str,
+        quiet: bool = False,
+        expected_session: Optional[Session] = None,
+    ) -> Optional[Dict[str, Any]]:
+        with self._sessions_lock:
+            session = self._sessions.get(job_id)
+            if expected_session is not None and session is not expected_session:
+                return self._empty_stop_result()
+            if session is None:
+                return None
+            if session.state == "stopping":
+                result = self._empty_stop_result()
+                result["timed_out"].append(job_id)
+                return self._finalize_stop_result(result)
+            session.state = "stopping"
+            session.last_error = None
+
+        result = self._empty_stop_result()
+        try:
+            released = self._release_with_timeout(
+                session.controller,
+                on_late_result=lambda error: self._finalize_late_release(
+                    job_id, session, error
+                ),
+            )
+        except Exception as exc:
+            error = str(exc)
+            self._mark_session(job_id, session, "stop_failed", error)
+            result["failed"].append(job_id)
+            result["errors"][job_id] = error
+            if not quiet:
+                logger.warning("Failed to stop keep session %s: %s", job_id, exc)
+            return self._finalize_stop_result(result)
+        if not quiet:
+            if released:
+                logger.info("Stopped keep session %s", job_id)
+            else:
+                logger.warning("Timed out while stopping keep session %s", job_id)
+        if released:
+            with self._sessions_lock:
+                if self._sessions.get(job_id) is session:
+                    self._sessions.pop(job_id, None)
+            result["stopped"].append(job_id)
+            return self._finalize_stop_result(result)
+        self._mark_stop_timeout(job_id, session)
+        result["timed_out"].append(job_id)
+        return self._finalize_stop_result(result)
+
     def stop_keep(
         self, job_id: Optional[str] = None, quiet: bool = False
     ) -> Dict[str, Any]:
@@ -411,65 +498,51 @@ class KeepGPUServer:
         job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is not None:
             with self._sessions_lock:
-                while job_id in self._starting_job_ids:
-                    self._sessions_cond.wait()
-                session = self._sessions.get(job_id)
-                if session and session.state == "stopping":
-                    result = self._empty_stop_result()
-                    result["timed_out"].append(job_id)
-                    return self._finalize_stop_result(result)
-                if session:
-                    session.state = "stopping"
-                    session.last_error = None
-            if session:
+                starting_params = self._starting_params.get(job_id)
+                starting_snapshot = (
+                    {job_id: starting_params} if starting_params is not None else {}
+                )
+            timed_out_starting = self._wait_for_starting_jobs_or_mark_pending(
+                starting_snapshot
+            )
+            if job_id in timed_out_starting:
                 result = self._empty_stop_result()
-                try:
-                    released = self._release_with_timeout(
-                        session.controller,
-                        on_late_result=lambda error: self._finalize_late_release(
-                            job_id, session, error
-                        ),
-                    )
-                except Exception as exc:
-                    error = str(exc)
-                    self._mark_session(job_id, session, "stop_failed", error)
-                    result["failed"].append(job_id)
-                    result["errors"][job_id] = error
-                    if not quiet:
-                        logger.warning(
-                            "Failed to stop keep session %s: %s", job_id, exc
-                        )
-                    return self._finalize_stop_result(result)
-                if not quiet:
-                    if released:
-                        logger.info("Stopped keep session %s", job_id)
-                    else:
-                        logger.warning(
-                            "Timed out while stopping keep session %s", job_id
-                        )
-                if released:
-                    with self._sessions_lock:
-                        if self._sessions.get(job_id) is session:
-                            self._sessions.pop(job_id, None)
-                    result["stopped"].append(job_id)
-                    return self._finalize_stop_result(result)
-                self._mark_stop_timeout(job_id, session)
                 result["timed_out"].append(job_id)
                 return self._finalize_stop_result(result)
+            stop_result = self._stop_current_session(job_id, quiet=quiet)
+            if stop_result is not None:
+                return stop_result
             result = self._empty_stop_result()
             result["message"] = "job_id not found"
             return result
 
         with self._sessions_lock:
-            starting_to_wait_for = set(self._starting_job_ids)
-            while starting_to_wait_for & self._starting_job_ids:
-                self._sessions_cond.wait()
-            session_items = list(self._sessions.items())
+            starting_snapshot = dict(self._starting_params)
+            initial_session_items = list(self._sessions.items())
+        timed_out_starting = self._wait_for_starting_jobs_or_mark_pending(
+            starting_snapshot
+        )
+        with self._sessions_lock:
+            session_items = [
+                (job_id, session)
+                for job_id, session in initial_session_items
+                if self._sessions.get(job_id) is session
+            ]
+            session_items.extend(
+                (job_id, session)
+                for job_id, params in starting_snapshot.items()
+                if job_id not in timed_out_starting
+                for session in [self._sessions.get(job_id)]
+                if session is not None and session.params is params
+            )
             releasable_items = []
             release_outcomes: List[Dict[str, Any]] = [
                 {} for _job_id, _session in session_items
             ]
             result = self._empty_stop_result()
+            for starting_job_id in starting_snapshot:
+                if starting_job_id in timed_out_starting:
+                    result["timed_out"].append(starting_job_id)
             for index, (job_id, session) in enumerate(session_items):
                 if session.state == "stopping":
                     release_outcomes[index] = {"state": "timed_out"}

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -437,7 +437,7 @@ class KeepGPUServer:
         with self._sessions_lock:
             session = self._sessions.get(job_id)
             if expected_session is not None and session is not expected_session:
-                return self._empty_stop_result()
+                return None
             if session is None:
                 return None
             if session.state == "stopping":
@@ -499,6 +499,7 @@ class KeepGPUServer:
         if job_id is not None:
             with self._sessions_lock:
                 starting_params = self._starting_params.get(job_id)
+                expected_session = self._sessions.get(job_id)
                 starting_snapshot = (
                     {job_id: starting_params} if starting_params is not None else {}
                 )
@@ -509,7 +510,21 @@ class KeepGPUServer:
                 result = self._empty_stop_result()
                 result["timed_out"].append(job_id)
                 return self._finalize_stop_result(result)
-            stop_result = self._stop_current_session(job_id, quiet=quiet)
+            if starting_params is not None:
+                with self._sessions_lock:
+                    expected_session = self._sessions.get(job_id)
+                    if (
+                        expected_session is not None
+                        and expected_session.params is not starting_params
+                    ):
+                        expected_session = None
+            if expected_session is None:
+                result = self._empty_stop_result()
+                result["message"] = "job_id not found"
+                return result
+            stop_result = self._stop_current_session(
+                job_id, quiet=quiet, expected_session=expected_session
+            )
             if stop_result is not None:
                 return stop_result
             result = self._empty_stop_result()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1493,6 +1493,427 @@ def test_stop_all_waits_only_for_sessions_starting_at_snapshot(monkeypatch):
     server.stop_keep("second-job")
 
 
+def test_stop_all_does_not_stop_session_started_after_snapshot_even_if_it_completes(
+    monkeypatch,
+):
+    first_keep_entered = threading.Event()
+    first_keep_release = threading.Event()
+    stop_waiting_for_startup = threading.Event()
+    second_controller = {}
+    start_results = {}
+    stop_result = {}
+
+    class SlowFirstController(DummyController):
+        def keep(self):
+            self.kept = True
+            first_keep_entered.set()
+            first_keep_release.wait(timeout=1.0)
+
+    class FastSecondController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            second_controller["value"] = self
+
+    def factory(**kwargs):
+        if kwargs.get("gpu_ids") == [1]:
+            return FastSecondController(**kwargs)
+        return SlowFirstController(**kwargs)
+
+    server = KeepGPUServer(controller_factory=cast(Any, factory))
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    first_start_thread = threading.Thread(
+        target=lambda: start_results.update(
+            first=server.start_keep(job_id="first-job", gpu_ids=[0])
+        )
+    )
+    first_start_thread.start()
+    assert first_keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+    assert stop_waiting_for_startup.wait(timeout=1.0)
+
+    start_results["second"] = server.start_keep(job_id="second-job", gpu_ids=[1])
+    assert server.status("second-job")["active"] is True
+
+    first_keep_release.set()
+    first_start_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert start_results["first"] == {"job_id": "first-job"}
+    assert start_results["second"] == {"job_id": "second-job"}
+    assert stop_result["value"]["stopped"] == ["first-job"]
+    assert second_controller["value"].released is False
+    assert server.status("first-job")["active"] is False
+    assert server.status("second-job")["active"] is True
+    server.stop_keep("second-job")
+
+
+def test_stop_all_does_not_stop_reused_job_id_started_after_snapshot(monkeypatch):
+    starting_keep_entered = threading.Event()
+    starting_keep_release = threading.Event()
+    stop_waiting_for_startup = threading.Event()
+    controllers_by_gpu = {}
+    start_results = {}
+    stop_result = {}
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            gpu_key = tuple(kwargs.get("gpu_ids") or [])
+            controllers_by_gpu.setdefault(gpu_key, []).append(self)
+
+    class BlockingStartController(TrackingController):
+        def keep(self):
+            self.kept = True
+            starting_keep_entered.set()
+            starting_keep_release.wait(timeout=1.0)
+
+    def factory(**kwargs):
+        if kwargs.get("gpu_ids") == [2]:
+            return BlockingStartController(**kwargs)
+        return TrackingController(**kwargs)
+
+    server = KeepGPUServer(controller_factory=cast(Any, factory))
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    start_results["old"] = server.start_keep(job_id="reused-job", gpu_ids=[0])
+    old_controller = controllers_by_gpu[(0,)][0]
+
+    starting_thread = threading.Thread(
+        target=lambda: start_results.update(
+            starting=server.start_keep(job_id="starting-job", gpu_ids=[2])
+        )
+    )
+    starting_thread.start()
+    assert starting_keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+    assert stop_waiting_for_startup.wait(timeout=1.0)
+
+    targeted_stop = server.stop_keep("reused-job")
+    assert targeted_stop["stopped"] == ["reused-job"]
+    assert old_controller.released is True
+
+    start_results["new"] = server.start_keep(job_id="reused-job", gpu_ids=[1])
+    new_controller = controllers_by_gpu[(1,)][0]
+    assert server.status("reused-job")["active"] is True
+
+    starting_keep_release.set()
+    starting_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert start_results["old"] == {"job_id": "reused-job"}
+    assert start_results["starting"] == {"job_id": "starting-job"}
+    assert start_results["new"] == {"job_id": "reused-job"}
+    assert stop_result["value"]["stopped"] == ["starting-job"]
+    assert new_controller.released is False
+    assert server.status("starting-job")["active"] is False
+    assert server.status("reused-job")["active"] is True
+    server.stop_keep("reused-job")
+
+
+def test_stop_keep_times_out_waiting_for_stuck_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep(job_id="starting-job"))
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert "Timed out" in stop_result["value"]["message"]
+        assert server.status("starting-job")["state"] == "starting"
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_stop_all_times_out_waiting_for_stuck_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert "Timed out" in stop_result["value"]["message"]
+        assert server.status("starting-job")["state"] == "starting"
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep(job_id="starting-job"))
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert controllers[0].released is False
+
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        assert start_result["value"] == {"job_id": "starting-job"}
+        assert _wait_until(lambda: server.status("starting-job")["active"] is False)
+        assert controllers[0].released is True
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+
+def test_pending_stop_does_not_stop_reused_job_id_after_original_removed(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    controllers_by_gpu = {}
+    deferred_threads = []
+    start_result = {}
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            gpu_key = tuple(kwargs.get("gpu_ids") or [])
+            controllers_by_gpu.setdefault(gpu_key, []).append(self)
+
+    class BlockingStartController(TrackingController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    def factory(**kwargs):
+        if kwargs.get("gpu_ids") == [0]:
+            return BlockingStartController(**kwargs)
+        return TrackingController(**kwargs)
+
+    server = KeepGPUServer(controller_factory=cast(Any, factory))
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    real_thread = threading.Thread
+
+    class DeferredThread:
+        def __init__(self, target, kwargs):
+            self._target = target
+            self._kwargs = kwargs
+
+        def start(self):
+            deferred_threads.append(self)
+
+        def run(self):
+            self._target(**self._kwargs)
+
+    def thread_factory(*args, **kwargs):
+        target = kwargs.get("target")
+        target_kwargs = kwargs.get("kwargs") or {}
+        if (
+            target_kwargs.get("job_id") == "race-job"
+            and target_kwargs.get("quiet") is True
+        ):
+            return DeferredThread(target, target_kwargs)
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(server_module.threading, "Thread", thread_factory)
+
+    start_thread = real_thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="race-job", gpu_ids=[0])
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    timed_out_stop = server.stop_keep(job_id="race-job")
+    assert timed_out_stop["timed_out"] == ["race-job"]
+
+    keep_release.set()
+    start_thread.join(timeout=1.0)
+    assert start_result["value"] == {"job_id": "race-job"}
+    assert len(deferred_threads) == 1
+
+    old_controller = controllers_by_gpu[(0,)][0]
+    stop_original = server.stop_keep("race-job")
+    assert stop_original["stopped"] == ["race-job"]
+    assert old_controller.released is True
+
+    replacement_start = server.start_keep(job_id="race-job", gpu_ids=[1])
+    replacement_controller = controllers_by_gpu[(1,)][0]
+    assert replacement_start == {"job_id": "race-job"}
+    assert server.status("race-job")["active"] is True
+
+    deferred_threads[0].run()
+
+    assert replacement_controller.released is False
+    assert server.status("race-job")["active"] is True
+    server.stop_keep("race-job")
+
+
+def test_timed_out_stop_all_of_starting_session_releases_after_startup_completes(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert controllers[0].released is False
+
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        assert start_result["value"] == {"job_id": "starting-job"}
+        assert _wait_until(lambda: server.status("starting-job")["active"] is False)
+        assert controllers[0].released is True
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+
 def test_stop_keep_returns_timeout_payload(monkeypatch):
     server = make_server()
     job_id = server.start_keep()["job_id"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1860,6 +1860,52 @@ def test_pending_stop_does_not_stop_reused_job_id_after_original_removed(
     server.stop_keep("race-job")
 
 
+def test_stop_keep_does_not_stop_reused_job_id_after_wait_window(monkeypatch):
+    controllers_by_gpu = {}
+    start_results = {}
+    intercept_wait = True
+
+    class TrackingController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            gpu_key = tuple(kwargs.get("gpu_ids") or [])
+            controllers_by_gpu.setdefault(gpu_key, []).append(self)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
+    )
+
+    start_results["old"] = server.start_keep(job_id="race-job", gpu_ids=[0])
+    old_controller = controllers_by_gpu[(0,)][0]
+    original_wait = server._wait_for_starting_jobs_or_mark_pending
+
+    def replace_job_id_during_wait(starting_snapshot):
+        nonlocal intercept_wait
+        if not intercept_wait:
+            return original_wait(starting_snapshot)
+        intercept_wait = False
+        result = original_wait(starting_snapshot)
+        stop_original = server.stop_keep("race-job")
+        assert stop_original["stopped"] == ["race-job"]
+        start_results["new"] = server.start_keep(job_id="race-job", gpu_ids=[1])
+        return result
+
+    monkeypatch.setattr(
+        server, "_wait_for_starting_jobs_or_mark_pending", replace_job_id_during_wait
+    )
+
+    stop_result = server.stop_keep("race-job")
+
+    replacement_controller = controllers_by_gpu[(1,)][0]
+    assert start_results["old"] == {"job_id": "race-job"}
+    assert start_results["new"] == {"job_id": "race-job"}
+    assert old_controller.released is True
+    assert stop_result["message"] == "job_id not found"
+    assert replacement_controller.released is False
+    assert server.status("race-job")["active"] is True
+    server.stop_keep("race-job")
+
+
 def test_timed_out_stop_all_of_starting_session_releases_after_startup_completes(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Bound stop waits for sessions stuck in `starting` and return the existing additive `timed_out` payload instead of hanging forever.
- Remember timed-out cancellation requests and quietly release the original session if startup later succeeds, without stopping same-`job_id` replacements.
- Scope stop-all to its initial active/starting boundary and update README, MCP/CLI docs, architecture notes, AGENTS guidance, and the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_session_started_after_snapshot_even_if_it_completes tests/mcp/test_server.py::test_stop_all_does_not_stop_reused_job_id_started_after_snapshot tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
- `PYTHONPATH=$PWD/src pytest tests/mcp -q`
- `PYTHONPATH=$PWD/src pytest tests -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check`

## Local Review
- Local subagent review completed; final reviewer reported no Critical or Important findings after the delayed-cleanup same-`job_id` race fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop requests now wait briefly for in-progress starts to finish before deciding a session is unavailable.
  * Stop-all now uses the same bounded wait behavior for sessions that are still starting.

* **Bug Fixes**
  * Improved handling of stop requests during startup to avoid missed or accidental stops.
  * Sessions that finish starting after a timed-out stop are now released quietly.

* **Documentation**
  * Updated user-facing docs to explain the new stop timing, timeout, and stop-all snapshot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->