### PR TITLE
[mcp] fix: bound stops waiting on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ This file defines how coding agents should work in this repository.
   `torch.cuda.device_count()`.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
-- Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; stop requests must wait briefly for starting sessions so they are not missed, but the wait is bounded and timed-out starting-session stops must be honored with a quiet release after startup eventually completes. A session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; stop requests must wait briefly for starting sessions so they are not missed, but the wait is bounded and timed-out starting-session stops must be honored with an automatic background release after startup eventually completes. A session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Release paths must be idempotent after timeout: when a previously stopping
   worker has since died, perform backend cache cleanup and clear stale thread
   and stop-event state instead of returning early as not running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,9 +192,11 @@ This file defines how coding agents should work in this repository.
 - Non-force `keep-gpu service-stop` must require a reachable service and a successful status/RPC check before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
-- Stop requests must not miss starting sessions; wait briefly for startup to
-  settle before returning `not found` or taking a stop-all snapshot, and honor
-  timed-out starting-session stops after startup eventually completes.
+- Stop requests must not miss starting sessions; targeted stop waits briefly
+  for a matching start before returning `not found`, and stop-all records its
+  active and starting boundary before waiting only for starts in that boundary.
+  Timed-out starting-session stops must be honored after startup eventually
+  completes.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Dashboard telemetry must display unavailable utilization as unknown/`n/a`, not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ This file defines how coding agents should work in this repository.
   `torch.cuda.device_count()`.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
-- Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; stop requests must wait briefly for starting sessions so they are not missed, but the wait is bounded and timed-out starting-session stops must be honored with a quiet release after startup eventually completes. A session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Release paths must be idempotent after timeout: when a previously stopping
   worker has since died, perform backend cache cleanup and clear stale thread
   and stop-event state instead of returning early as not running.
@@ -192,7 +192,9 @@ This file defines how coding agents should work in this repository.
 - Non-force `keep-gpu service-stop` must require a reachable service and a successful status/RPC check before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
-- Stop requests must not miss starting sessions; wait for startup to settle before returning `not found` or taking a stop-all snapshot.
+- Stop requests must not miss starting sessions; wait briefly for startup to
+  settle before returning `not found` or taking a stop-all snapshot, and honor
+  timed-out starting-session stops after startup eventually completes.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Dashboard telemetry must display unavailable utilization as unknown/`n/a`, not

--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ to zero devices.
   `stopping` until background cleanup completes and `failed` sessions remain
   visible with `state` and `last_error`.
 - Status and stop requests both account for in-progress starts: status reports
-  them as `starting`, and stop waits for startup to settle so a session is not
-  reported as missing or skipped by stop-all.
+  them as `starting`, and stop waits briefly for startup to settle so a session
+  is not reported as missing or skipped by stop-all. If startup does not settle
+  within the stop wait budget, the response lists that job in `timed_out`; a
+  successful later startup is released in the background.
 - Stop-all only covers sessions active or already starting when that request
   begins; later concurrent starts belong to a later stop request.
 - Stop-all releases independent sessions concurrently and reports outcomes in

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -99,9 +99,12 @@ Elementwise keep-alive batches:
   session snapshot, while aggregating results in deterministic snapshot order.
 - Service session state is intentionally conservative: `status` shows reserved
   jobs as `state="starting"` while controller startup is in progress, and
-  `stop_keep` removes a session only after release succeeds. Timed-out sessions
-  stay visible as `state="stopping"` until the background release finishes;
-  failed releases stay visible as `state="stop_failed"` with `last_error`.
+  `stop_keep` waits briefly for startup to settle before returning missing or
+  stop-all results. Timed-out starting-session stops are remembered and, if
+  startup later succeeds, released in the background. Started sessions are
+  removed only after release succeeds. Timed-out sessions stay visible as
+  `state="stopping"` until the background release finishes; failed releases stay
+  visible as `state="stop_failed"` with `last_error`.
 - After startup, terminal worker runtime or allocation failures are surfaced as
   `state="runtime_failed"` with `last_error`. The retained session remains
   visible and can still be stopped. Busy-GPU or unavailable-telemetry deferral is

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -158,8 +158,12 @@ job id only appears in `stopped` after cleanup has completed within the stop
 request timeout.
 
 If `stop_keep` arrives while a matching session is still starting, the service
-waits for startup to settle before deciding whether the job exists. Stop-all
-requests also wait for in-progress starts before taking their session snapshot.
+waits briefly for startup to settle before deciding whether the job exists.
+Stop-all requests also wait briefly for in-progress starts before taking their
+session snapshot.
+If startup does not settle within the stop wait budget, the stop response lists
+that job in `timed_out`; when startup later completes successfully, the service
+quietly releases the session instead of leaving the keeper active.
 For stop-all, starts that begin after that request's initial snapshot are not
 stopped by that request.
 Stop-all releases the sessions in its snapshot concurrently and aggregates

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -159,8 +159,8 @@ request timeout.
 
 If `stop_keep` arrives while a matching session is still starting, the service
 waits briefly for startup to settle before deciding whether the job exists.
-Stop-all requests also wait briefly for in-progress starts before taking their
-session snapshot.
+Stop-all records the active and starting sessions in its initial snapshot, then
+waits briefly only for the starts in that snapshot.
 If startup does not settle within the stop wait budget, the stop response lists
 that job in `timed_out`; when startup later completes successfully, the service
 releases the session in the background instead of leaving the keeper active.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -163,7 +163,7 @@ Stop-all requests also wait briefly for in-progress starts before taking their
 session snapshot.
 If startup does not settle within the stop wait budget, the stop response lists
 that job in `timed_out`; when startup later completes successfully, the service
-quietly releases the session instead of leaving the keeper active.
+releases the session in the background instead of leaving the keeper active.
 For stop-all, starts that begin after that request's initial snapshot are not
 stopped by that request.
 Stop-all releases the sessions in its snapshot concurrently and aggregates

--- a/docs/plans/stop-starting-session-timeout.md
+++ b/docs/plans/stop-starting-session-timeout.md
@@ -21,7 +21,7 @@ automatically.
 - Return the existing additive timeout payload (`timed_out`, `message`) when a
   requested starting job does not settle before the startup-stop wait budget.
 - Track timed-out stop requests for starting jobs. If such a startup later
-  completes successfully, immediately trigger a quiet background stop so a
+  completes successfully, immediately trigger a logged background stop so a
   timed-out cancellation does not leave a surprise active keeper.
 - Preserve existing behavior for slow startups that settle within the wait
   budget: the original stop request releases the session and reports it in
@@ -39,6 +39,8 @@ automatically.
       startup settles between timeout classification and the session snapshot.
 - [x] Add GREEN coverage that a timed-out stop followed by startup failure clears
       pending-stop state before a later reuse of the same job ID.
+- [x] Add GREEN coverage that the pending-stop background release keeps normal
+      stop logging enabled.
 - [x] Implement bounded startup wait and pending-stop handoff.
 - [x] Update `AGENTS.md`, MCP/CLI docs, and this plan.
 - [x] Run focused tests, MCP shard, full tests, docs build, pre-commit, and
@@ -64,6 +66,11 @@ automatically.
   `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id -q`
   failed under a temporary mutation that removed pending-stop cleanup from the
   startup failure path, then passed with `1 passed` after restoring cleanup.
+- External review logging regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes -q`
+  failed under a temporary mutation that restored `quiet=True` on the background
+  pending-stop release, then passed with `1 passed` after normal logging was
+  restored.
 - Combined focused shard:
   `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
   passed with `8 passed`.
@@ -83,3 +90,7 @@ automatically.
   missing failed-start pending-stop coverage. These were addressed before PR.
   Reviewer re-check found no new must-fix issues; the only remaining note was
   to ensure this plan file is staged for the PR.
+- Hosted review:
+  Gemini Code Assist requested preserving logs for pending-stop background
+  releases. The background stop now uses normal logging, and docs refer to a
+  background release rather than a quiet release.

--- a/docs/plans/stop-starting-session-timeout.md
+++ b/docs/plans/stop-starting-session-timeout.md
@@ -1,0 +1,85 @@
+# Stop Starting Session Timeout Plan
+
+## Background
+
+`stop_keep(job_id)` and `stop_keep()` intentionally wait for in-progress
+`start_keep()` calls so stop requests do not miss sessions that are still
+starting. The wait is currently unbounded. If controller construction or
+`keep()` hangs, stop requests can block indefinitely, leaving users unable to
+cancel a stuck startup and keeping custom job IDs reserved.
+
+## Goal
+
+Keep the no-missed-starts contract for normal slow startups while bounding stop
+requests when startup does not settle. If a stop request times out while a job
+is still starting, the eventual completed startup should still be released
+automatically.
+
+## Solution
+
+- Add bounded waiting for starting jobs in targeted stop and stop-all paths.
+- Return the existing additive timeout payload (`timed_out`, `message`) when a
+  requested starting job does not settle before the startup-stop wait budget.
+- Track timed-out stop requests for starting jobs. If such a startup later
+  completes successfully, immediately trigger a quiet background stop so a
+  timed-out cancellation does not leave a surprise active keeper.
+- Preserve existing behavior for slow startups that settle within the wait
+  budget: the original stop request releases the session and reports it in
+  `stopped`.
+- Keep failed startups clearing reservations and pending-stop markers.
+- Update `AGENTS.md`, MCP/CLI docs, and this plan.
+
+## Tasks
+
+- [x] Add RED tests for targeted stop and stop-all timing out while startup is
+      stuck without hanging the test process.
+- [x] Add GREEN coverage that a timed-out stop request is honored after startup
+      eventually completes.
+- [x] Add GREEN coverage that stop-all does not duplicate a starting timeout if
+      startup settles between timeout classification and the session snapshot.
+- [x] Add GREEN coverage that a timed-out stop followed by startup failure clears
+      pending-stop state before a later reuse of the same job ID.
+- [x] Implement bounded startup wait and pending-stop handoff.
+- [x] Update `AGENTS.md`, MCP/CLI docs, and this plan.
+- [x] Run focused tests, MCP shard, full tests, docs build, pre-commit, and
+      `git diff --check`.
+- [x] Run local subagent code review before PR.
+- [ ] Open PR, resolve all review comments/checks, squash merge, and clean the
+      worktree.
+
+## Verification
+
+- RED and GREEN focused tests:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes -q`
+  first failed because stop threads remained blocked on the unbounded startup
+  wait. After implementation, this shard passed with `3 passed`, and the
+  existing slow-start preservation shard
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
+  passed with `3 passed`.
+- Race regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles -q`
+  first failed because `timed_out` contained `starting-job` twice. After the
+  release-loop guard, it passed with `1 passed`.
+- Failed-start pending-stop regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id -q`
+  failed under a temporary mutation that removed pending-stop cleanup from the
+  startup failure path, then passed with `1 passed` after restoring cleanup.
+- Combined focused shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
+  passed with `8 passed`.
+- MCP shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `184 passed`.
+- Full no-GPU-safe gate:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `626 passed, 11 skipped`.
+- Docs and hygiene:
+  `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
+  and unnav'd plan notices; `pre-commit run --all-files` passed; and
+  `git diff --check` passed. Installing the full stale
+  `requirements_dev.txt` failed on Python 3.12 because `watchdog==0.9.0`
+  imports the removed `imp` module, so the missing gate tools were installed
+  directly as `pre-commit mkdocs mkdocs-material mkdocstrings[python]`.
+- Local subagent review:
+  Reviewer found stale AGENTS wording, stale verification counts, and the
+  missing failed-start pending-stop coverage. These were addressed before PR.
+  Reviewer re-check found no new must-fix issues; the only remaining note was
+  to ensure this plan file is staged for the PR.

--- a/docs/plans/stop-starting-session-timeout.md
+++ b/docs/plans/stop-starting-session-timeout.md
@@ -23,6 +23,10 @@ automatically.
 - Track timed-out stop requests for starting jobs. If such a startup later
   completes successfully, immediately trigger a logged background stop so a
   timed-out cancellation does not leave a surprise active keeper.
+- Track immutable per-start tokens while waiting on startup so reusable custom
+  job IDs cannot let an older stop request affect a later start.
+- Bind pending-stop background cleanup to the original start token so a delayed
+  cleanup cannot release a replacement session that reused the same job ID.
 - Preserve existing behavior for slow startups that settle within the wait
   budget: the original stop request releases the session and reports it in
   `stopped`.
@@ -41,6 +45,12 @@ automatically.
       pending-stop state before a later reuse of the same job ID.
 - [x] Add GREEN coverage that the pending-stop background release keeps normal
       stop logging enabled.
+- [x] Add GREEN coverage that reused job IDs with different start tokens are not
+      attributed to an older startup wait.
+- [x] Add GREEN coverage that stop-all does not stop a session that starts and
+      completes after the initial stop-all snapshot.
+- [x] Add GREEN coverage that a stale pending-stop cleanup does not stop a
+      replacement session with the same job ID and a new start token.
 - [x] Implement bounded startup wait and pending-stop handoff.
 - [x] Update `AGENTS.md`, MCP/CLI docs, and this plan.
 - [x] Run focused tests, MCP shard, full tests, docs build, pre-commit, and
@@ -71,13 +81,25 @@ automatically.
   failed under a temporary mutation that restored `quiet=True` on the background
   pending-stop release, then passed with `1 passed` after normal logging was
   restored.
+- Start-token regressions:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_starting_wait_ignores_reused_job_id_with_different_start_token -q`
+  first failed before per-start token tracking existed, then passed with
+  `1 passed`. `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_does_not_stop_completed_session_started_after_snapshot -q`
+  passed with `1 passed`.
+- Token-bound background cleanup regression:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_pending_stop_release_does_not_stop_reused_job_id_with_new_token -q`
+  first failed before the token-bound internal stop helper existed, then passed
+  with `1 passed`.
+- Hosted review fix shard:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_pending_stop_release_does_not_stop_reused_job_id_with_new_token tests/mcp/test_server.py::test_stop_all_does_not_stop_completed_session_started_after_snapshot tests/mcp/test_server.py::test_starting_wait_ignores_reused_job_id_with_different_start_token tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles -q`
+  passed with `6 passed`.
 - Combined focused shard:
-  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q`
-  passed with `8 passed`.
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot tests/mcp/test_server.py::test_stop_all_does_not_stop_completed_session_started_after_snapshot tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_starting_wait_ignores_reused_job_id_with_different_start_token tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session -q`
+  passed with `10 passed`.
 - MCP shard:
-  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `184 passed`.
+  `PYTHONPATH=$PWD/src pytest tests/mcp -q` passed with `187 passed`.
 - Full no-GPU-safe gate:
-  `PYTHONPATH=$PWD/src pytest tests -q` passed with `626 passed, 11 skipped`.
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with `629 passed, 11 skipped`.
 - Docs and hygiene:
   `PYTHONPATH=$PWD/src mkdocs build` passed with the existing Material warning
   and unnav'd plan notices; `pre-commit run --all-files` passed; and
@@ -94,3 +116,10 @@ automatically.
   Gemini Code Assist requested preserving logs for pending-stop background
   releases. The background stop now uses normal logging, and docs refer to a
   background release rather than a quiet release.
+  CodeRabbit requested per-start tracking for reusable job IDs and deterministic
+  fake blockers in the concurrency tests. Local re-review then found the delayed
+  background cleanup also needed to keep the original start token, plus README
+  and architecture docs needed the bounded startup-stop behavior. These were
+  addressed before merge. A final local re-check clarified that stop-all docs
+  should describe the initial active/starting boundary before waiting; AGENTS,
+  MCP docs, and CLI docs were updated accordingly.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,11 +85,13 @@ runtime failure.
 
 `--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
 error before any RPC or stop-all fallback runs.
-Stop waits briefly for in-progress starts to settle before returning `not
-found` or taking the stop-all snapshot, so starting sessions are not silently
-skipped. If startup does not settle within the stop wait budget, the response
-lists that job in `timed_out`; when startup later completes successfully, the
-service releases the session in the background instead of leaving it active.
+Targeted stop waits briefly for a matching in-progress start to settle before
+returning `not found`, so starting sessions are not silently skipped. `--all`
+records its active and starting sessions first, then waits briefly only for the
+starts in that initial snapshot. If startup does not settle within the stop wait
+budget, the response lists that job in `timed_out`; when startup later completes
+successfully, the service releases the session in the background instead of
+leaving it active.
 For `--all`, starts that begin after that command's initial snapshot are not
 stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,8 +85,11 @@ runtime failure.
 
 `--job-id` and `--all` are mutually exclusive. Passing both returns a JSON
 error before any RPC or stop-all fallback runs.
-Stop waits for in-progress starts to settle before returning `not found` or
-taking the stop-all snapshot, so starting sessions are not silently skipped.
+Stop waits briefly for in-progress starts to settle before returning `not
+found` or taking the stop-all snapshot, so starting sessions are not silently
+skipped. If startup does not settle within the stop wait budget, the response
+lists that job in `timed_out`; when startup later completes successfully, the
+service quietly releases the session instead of leaving it active.
 For `--all`, starts that begin after that command's initial snapshot are not
 stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,7 +89,7 @@ Stop waits briefly for in-progress starts to settle before returning `not
 found` or taking the stop-all snapshot, so starting sessions are not silently
 skipped. If startup does not settle within the stop wait budget, the response
 lists that job in `timed_out`; when startup later completes successfully, the
-service quietly releases the session instead of leaving it active.
+service releases the session in the background instead of leaving it active.
 For `--all`, starts that begin after that command's initial snapshot are not
 stopped by that command.
 `--all` releases the sessions in its snapshot concurrently and prints results

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -349,7 +349,7 @@ class KeepGPUServer:
         if pending_stop:
             threading.Thread(
                 target=self.stop_keep,
-                kwargs={"job_id": job_id, "quiet": True},
+                kwargs={"job_id": job_id},
                 daemon=True,
             ).start()
         logger.info("Started keep session %s on GPUs %s", job_id, gpu_ids)

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -169,6 +169,7 @@ MCP_TOOLS: List[Dict[str, Any]] = [
 class Session:
     controller: GlobalGPUController
     params: Dict[str, Any]
+    start_token: str
     state: str = "active"
     last_error: Optional[str] = None
 
@@ -201,26 +202,33 @@ class KeepGPUServer:
         controller_factory: Optional[Callable[..., GlobalGPUController]] = None,
     ) -> None:
         self._sessions: Dict[str, Session] = {}
-        self._starting_job_ids: set[str] = set()
         self._starting_params: Dict[str, Dict[str, Any]] = {}
-        self._pending_stop_job_ids: set[str] = set()
+        self._starting_tokens: Dict[str, str] = {}
+        self._pending_stop_tokens: set[str] = set()
         self._startup_stop_wait_timeout_s = STARTUP_STOP_WAIT_TIMEOUT_SECONDS
         self._sessions_lock = threading.RLock()
         self._sessions_cond = threading.Condition(self._sessions_lock)
         self._controller_factory = controller_factory or GlobalGPUController
         atexit.register(self.shutdown)
 
-    def _wait_for_starting_jobs_or_mark_pending(self, job_ids: List[str]) -> set[str]:
+    def _wait_for_starting_jobs_or_mark_pending(
+        self, starting_tokens: Dict[str, str]
+    ) -> set[str]:
         deadline = time.monotonic() + self._startup_stop_wait_timeout_s
-        job_id_set = set(job_ids)
         with self._sessions_lock:
             while True:
-                still_starting = job_id_set & self._starting_job_ids
+                still_starting = {
+                    job_id
+                    for job_id, start_token in starting_tokens.items()
+                    if self._starting_tokens.get(job_id) == start_token
+                }
                 if not still_starting:
                     return set()
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    self._pending_stop_job_ids.update(still_starting)
+                    self._pending_stop_tokens.update(
+                        starting_tokens[job_id] for job_id in still_starting
+                    )
                     return still_starting
                 self._sessions_cond.wait(remaining)
 
@@ -304,6 +312,7 @@ class KeepGPUServer:
         job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is None:
             job_id = str(uuid.uuid4())
+        start_token = str(uuid.uuid4())
         params = {
             "gpu_ids": gpu_ids,
             "vram": vram,
@@ -311,10 +320,10 @@ class KeepGPUServer:
             "busy_threshold": busy_threshold,
         }
         with self._sessions_lock:
-            if job_id in self._sessions or job_id in self._starting_job_ids:
+            if job_id in self._sessions or job_id in self._starting_params:
                 raise SessionInputError(f"job_id {job_id} already exists")
-            self._starting_job_ids.add(job_id)
             self._starting_params[job_id] = params
+            self._starting_tokens[job_id] = start_token
 
         try:
             controller = self._controller_factory(
@@ -326,9 +335,10 @@ class KeepGPUServer:
             controller.keep()
         except Exception as exc:
             with self._sessions_lock:
-                self._starting_job_ids.discard(job_id)
                 self._starting_params.pop(job_id, None)
-                self._pending_stop_job_ids.discard(job_id)
+                failed_start_token = self._starting_tokens.pop(job_id, None)
+                if failed_start_token is not None:
+                    self._pending_stop_tokens.discard(failed_start_token)
                 self._sessions_cond.notify_all()
             if isinstance(exc, InvalidVisibleGPUSelectionError):
                 raise SessionInputError(str(exc)) from exc
@@ -337,23 +347,29 @@ class KeepGPUServer:
             raise
 
         with self._sessions_lock:
-            self._starting_job_ids.discard(job_id)
             params = self._starting_params.pop(job_id, params)
-            pending_stop = job_id in self._pending_stop_job_ids
-            self._pending_stop_job_ids.discard(job_id)
+            start_token = self._starting_tokens.pop(job_id, start_token)
+            pending_stop = start_token in self._pending_stop_tokens
+            self._pending_stop_tokens.discard(start_token)
             self._sessions[job_id] = Session(
                 controller=controller,
                 params=params,
+                start_token=start_token,
             )
             self._sessions_cond.notify_all()
         if pending_stop:
             threading.Thread(
-                target=self.stop_keep,
-                kwargs={"job_id": job_id},
+                target=self._stop_keep_for_start_token,
+                args=(job_id, start_token),
                 daemon=True,
             ).start()
         logger.info("Started keep session %s on GPUs %s", job_id, gpu_ids)
         return {"job_id": job_id}
+
+    def _stop_keep_for_start_token(
+        self, job_id: str, start_token: str
+    ) -> Dict[str, Any]:
+        return self.stop_keep(job_id=job_id, _expected_start_token=start_token)
 
     @staticmethod
     def _empty_stop_result() -> Dict[str, Any]:
@@ -419,7 +435,10 @@ class KeepGPUServer:
         logger.warning("Delayed release failed for keep session %s: %s", job_id, error)
 
     def stop_keep(
-        self, job_id: Optional[str] = None, quiet: bool = False
+        self,
+        job_id: Optional[str] = None,
+        quiet: bool = False,
+        _expected_start_token: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Stop one or all active keep sessions.
@@ -437,13 +456,34 @@ class KeepGPUServer:
         """
         job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is not None:
-            timed_out_starting = self._wait_for_starting_jobs_or_mark_pending([job_id])
+            with self._sessions_lock:
+                starting_token = self._starting_tokens.get(job_id)
+                if _expected_start_token is not None:
+                    starting_to_wait_for = (
+                        {job_id: _expected_start_token}
+                        if starting_token == _expected_start_token
+                        else {}
+                    )
+                else:
+                    starting_to_wait_for = (
+                        {job_id: starting_token} if starting_token is not None else {}
+                    )
+            timed_out_starting = self._wait_for_starting_jobs_or_mark_pending(
+                starting_to_wait_for
+            )
             if job_id in timed_out_starting:
                 result = self._empty_stop_result()
                 result["timed_out"].append(job_id)
                 return self._finalize_stop_result(result)
             with self._sessions_lock:
                 session = self._sessions.get(job_id)
+                expected_start_token = _expected_start_token or starting_token
+                if (
+                    session is not None
+                    and expected_start_token is not None
+                    and session.start_token != expected_start_token
+                ):
+                    session = None
                 if session and session.state == "stopping":
                     result = self._empty_stop_result()
                     result["timed_out"].append(job_id)
@@ -491,12 +531,21 @@ class KeepGPUServer:
             return result
 
         with self._sessions_lock:
-            starting_to_wait_for = list(self._starting_params)
+            starting_to_wait_for = dict(self._starting_tokens)
+            active_tokens_to_stop = {
+                job_id: session.start_token
+                for job_id, session in self._sessions.items()
+            }
         timed_out_starting = self._wait_for_starting_jobs_or_mark_pending(
             starting_to_wait_for
         )
         with self._sessions_lock:
-            session_items = list(self._sessions.items())
+            session_items = [
+                (job_id, session)
+                for job_id, session in self._sessions.items()
+                if active_tokens_to_stop.get(job_id) == session.start_token
+                or starting_to_wait_for.get(job_id) == session.start_token
+            ]
             releasable_items = []
             release_outcomes: List[Dict[str, Any]] = [
                 {} for _job_id, _session in session_items
@@ -754,13 +803,15 @@ def _prevalidate_rest_session_payload(
         )
     if "vram" in safe_payload:
         _validate_public_session_input(parse_vram_to_elements, safe_payload["vram"])
-    if "job_id" in safe_payload:
-        job_id = _validate_public_session_input(validate_job_id, safe_payload["job_id"])
-        safe_payload["job_id"] = job_id
-        if job_id is not None:
-            with server._sessions_lock:
-                if job_id in server._sessions or job_id in server._starting_job_ids:
-                    raise SessionInputError(f"job_id {job_id} already exists")
+        if "job_id" in safe_payload:
+            job_id = _validate_public_session_input(
+                validate_job_id, safe_payload["job_id"]
+            )
+            safe_payload["job_id"] = job_id
+            if job_id is not None:
+                with server._sessions_lock:
+                    if job_id in server._sessions or job_id in server._starting_params:
+                        raise SessionInputError(f"job_id {job_id} already exists")
     return safe_payload
 
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -34,6 +34,7 @@ import sys
 import uuid
 import argparse
 import threading
+import time
 import mimetypes
 from http.server import BaseHTTPRequestHandler
 from socketserver import TCPServer, ThreadingMixIn
@@ -75,6 +76,7 @@ JSONRPC_INTERNAL_ERROR = -32603
 JSONRPC_STARTUP_UNAVAILABLE = -32000
 MCP_ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
 MCP_ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
+STARTUP_STOP_WAIT_TIMEOUT_SECONDS = 10.0
 
 MCP_TOOLS: List[Dict[str, Any]] = [
     {
@@ -201,10 +203,26 @@ class KeepGPUServer:
         self._sessions: Dict[str, Session] = {}
         self._starting_job_ids: set[str] = set()
         self._starting_params: Dict[str, Dict[str, Any]] = {}
+        self._pending_stop_job_ids: set[str] = set()
+        self._startup_stop_wait_timeout_s = STARTUP_STOP_WAIT_TIMEOUT_SECONDS
         self._sessions_lock = threading.RLock()
         self._sessions_cond = threading.Condition(self._sessions_lock)
         self._controller_factory = controller_factory or GlobalGPUController
         atexit.register(self.shutdown)
+
+    def _wait_for_starting_jobs_or_mark_pending(self, job_ids: List[str]) -> set[str]:
+        deadline = time.monotonic() + self._startup_stop_wait_timeout_s
+        job_id_set = set(job_ids)
+        with self._sessions_lock:
+            while True:
+                still_starting = job_id_set & self._starting_job_ids
+                if not still_starting:
+                    return set()
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._pending_stop_job_ids.update(still_starting)
+                    return still_starting
+                self._sessions_cond.wait(remaining)
 
     @staticmethod
     def _release_with_timeout(
@@ -310,6 +328,7 @@ class KeepGPUServer:
             with self._sessions_lock:
                 self._starting_job_ids.discard(job_id)
                 self._starting_params.pop(job_id, None)
+                self._pending_stop_job_ids.discard(job_id)
                 self._sessions_cond.notify_all()
             if isinstance(exc, InvalidVisibleGPUSelectionError):
                 raise SessionInputError(str(exc)) from exc
@@ -320,11 +339,19 @@ class KeepGPUServer:
         with self._sessions_lock:
             self._starting_job_ids.discard(job_id)
             params = self._starting_params.pop(job_id, params)
+            pending_stop = job_id in self._pending_stop_job_ids
+            self._pending_stop_job_ids.discard(job_id)
             self._sessions[job_id] = Session(
                 controller=controller,
                 params=params,
             )
             self._sessions_cond.notify_all()
+        if pending_stop:
+            threading.Thread(
+                target=self.stop_keep,
+                kwargs={"job_id": job_id, "quiet": True},
+                daemon=True,
+            ).start()
         logger.info("Started keep session %s on GPUs %s", job_id, gpu_ids)
         return {"job_id": job_id}
 
@@ -410,9 +437,12 @@ class KeepGPUServer:
         """
         job_id = _validate_public_session_input(validate_job_id, job_id)
         if job_id is not None:
+            timed_out_starting = self._wait_for_starting_jobs_or_mark_pending([job_id])
+            if job_id in timed_out_starting:
+                result = self._empty_stop_result()
+                result["timed_out"].append(job_id)
+                return self._finalize_stop_result(result)
             with self._sessions_lock:
-                while job_id in self._starting_job_ids:
-                    self._sessions_cond.wait()
                 session = self._sessions.get(job_id)
                 if session and session.state == "stopping":
                     result = self._empty_stop_result()
@@ -461,16 +491,23 @@ class KeepGPUServer:
             return result
 
         with self._sessions_lock:
-            starting_to_wait_for = set(self._starting_job_ids)
-            while starting_to_wait_for & self._starting_job_ids:
-                self._sessions_cond.wait()
+            starting_to_wait_for = list(self._starting_params)
+        timed_out_starting = self._wait_for_starting_jobs_or_mark_pending(
+            starting_to_wait_for
+        )
+        with self._sessions_lock:
             session_items = list(self._sessions.items())
             releasable_items = []
             release_outcomes: List[Dict[str, Any]] = [
                 {} for _job_id, _session in session_items
             ]
             result = self._empty_stop_result()
+            for starting_job_id in starting_to_wait_for:
+                if starting_job_id in timed_out_starting:
+                    result["timed_out"].append(starting_job_id)
             for index, (job_id, session) in enumerate(session_items):
+                if job_id in timed_out_starting:
+                    continue
                 if session.state == "stopping":
                     release_outcomes[index] = {"state": "timed_out"}
                     continue

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1604,6 +1604,14 @@ def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
         controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
     )
     monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+    info_messages = []
+    original_info = server_module.logger.info
+
+    def record_info(message, *args, **kwargs):
+        info_messages.append(message % args if args else message)
+        original_info(message, *args, **kwargs)
+
+    monkeypatch.setattr(server_module.logger, "info", record_info)
 
     start_thread = threading.Thread(
         target=lambda: start_result.update(
@@ -1629,6 +1637,7 @@ def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
         assert start_result["value"] == {"job_id": "starting-job"}
         assert _wait_until(lambda: server.status("starting-job")["active"] is False)
         assert controllers[0].released is True
+        assert "Stopped keep session starting-job" in info_messages
     finally:
         keep_release.set()
         start_thread.join(timeout=1.0)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1493,6 +1493,83 @@ def test_stop_all_waits_only_for_sessions_starting_at_snapshot(monkeypatch):
     server.stop_keep("second-job")
 
 
+def test_stop_all_does_not_stop_completed_session_started_after_snapshot(
+    monkeypatch,
+):
+    keep_entered = [threading.Event(), threading.Event()]
+    keep_release = [threading.Event(), threading.Event()]
+    stop_waiting_for_startup = threading.Event()
+    stop_completed = threading.Event()
+    controllers = []
+    start_results = {}
+    stop_result = {}
+
+    class SlowStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.index = len(controllers)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered[self.index].set()
+            keep_release[self.index].wait()
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: SlowStartController(**kwargs))
+    )
+    original_wait = server._sessions_cond.wait
+
+    def wait_for_startup(timeout=None):
+        stop_waiting_for_startup.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(server._sessions_cond, "wait", wait_for_startup)
+
+    def start_job(job_id):
+        start_results[job_id] = server.start_keep(job_id=job_id)
+
+    def stop_all():
+        stop_result["value"] = server.stop_keep()
+        stop_completed.set()
+
+    first_start_thread = threading.Thread(target=start_job, args=("first-job",))
+    stop_thread = threading.Thread(target=stop_all)
+    second_start_thread = threading.Thread(target=start_job, args=("second-job",))
+    try:
+        first_start_thread.start()
+        assert keep_entered[0].wait(timeout=1.0)
+
+        stop_thread.start()
+        assert stop_waiting_for_startup.wait(timeout=1.0)
+
+        second_start_thread.start()
+        assert keep_entered[1].wait(timeout=1.0)
+        keep_release[1].set()
+        second_start_thread.join(timeout=1.0)
+        assert start_results["second-job"] == {"job_id": "second-job"}
+        assert server.status("second-job")["active"] is True
+
+        keep_release[0].set()
+        first_start_thread.join(timeout=1.0)
+        assert stop_completed.wait(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+        assert start_results["first-job"] == {"job_id": "first-job"}
+        assert stop_result["value"]["stopped"] == ["first-job"]
+        assert controllers[0].released is True
+        assert controllers[1].released is False
+        assert server.status("first-job")["active"] is False
+        assert server.status("second-job")["active"] is True
+    finally:
+        keep_release[0].set()
+        keep_release[1].set()
+        first_start_thread.join(timeout=1.0)
+        second_start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+        server.stop_keep("second-job")
+
+
 def test_stop_keep_times_out_waiting_for_stuck_starting_session(monkeypatch):
     keep_entered = threading.Event()
     keep_release = threading.Event()
@@ -1503,7 +1580,7 @@ def test_stop_keep_times_out_waiting_for_stuck_starting_session(monkeypatch):
         def keep(self):
             self.kept = True
             keep_entered.set()
-            keep_release.wait(timeout=1.0)
+            keep_release.wait()
 
     server = KeepGPUServer(
         controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
@@ -1547,7 +1624,7 @@ def test_stop_all_times_out_waiting_for_stuck_starting_session(monkeypatch):
         def keep(self):
             self.kept = True
             keep_entered.set()
-            keep_release.wait(timeout=1.0)
+            keep_release.wait()
 
     server = KeepGPUServer(
         controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
@@ -1581,6 +1658,40 @@ def test_stop_all_times_out_waiting_for_stuck_starting_session(monkeypatch):
     assert start_result["value"] == {"job_id": "starting-job"}
 
 
+def test_starting_wait_ignores_reused_job_id_with_different_start_token(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.01, raising=False)
+    with server._sessions_lock:
+        server._starting_params["reused-job"] = {}
+        server._starting_tokens["reused-job"] = "new-start-token"
+
+    timed_out = server._wait_for_starting_jobs_or_mark_pending(
+        {"reused-job": "old-start-token"}
+    )
+
+    assert timed_out == set()
+    with server._sessions_lock:
+        assert server._pending_stop_tokens == set()
+
+
+def test_pending_stop_release_does_not_stop_reused_job_id_with_new_token():
+    server = make_server()
+    assert server.start_keep(job_id="reused-job") == {"job_id": "reused-job"}
+    with server._sessions_lock:
+        original_start_token = server._sessions["reused-job"].start_token
+
+    assert server.stop_keep(job_id="reused-job")["stopped"] == ["reused-job"]
+    assert server.start_keep(job_id="reused-job") == {"job_id": "reused-job"}
+
+    stale_stop_result = server._stop_keep_for_start_token(
+        "reused-job", original_start_token
+    )
+
+    assert stale_stop_result["message"] == "job_id not found"
+    assert server.status("reused-job")["active"] is True
+    server.stop_keep(job_id="reused-job")
+
+
 def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
     monkeypatch,
 ):
@@ -1598,7 +1709,7 @@ def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
         def keep(self):
             self.kept = True
             keep_entered.set()
-            keep_release.wait(timeout=1.0)
+            keep_release.wait()
 
     server = KeepGPUServer(
         controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
@@ -1657,7 +1768,7 @@ def test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id(
         def keep(self):
             self.kept = True
             keep_entered.set()
-            fail_startup.wait(timeout=1.0)
+            fail_startup.wait()
             raise RuntimeError("startup exploded")
 
     class SuccessfulController(DummyController):
@@ -1694,7 +1805,7 @@ def test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id(
         assert start_error["value"] == "startup exploded"
         assert server.status("starting-job")["active"] is False
         with server._sessions_lock:
-            assert "starting-job" not in server._pending_stop_job_ids
+            assert server._pending_stop_tokens == set()
 
         monkeypatch.setattr(
             server,
@@ -1729,11 +1840,11 @@ def test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles(
         def keep(self):
             self.kept = True
             keep_entered.set()
-            keep_release.wait(timeout=1.0)
+            keep_release.wait()
 
         def release(self):
             release_started.set()
-            release_done.wait(timeout=1.0)
+            release_done.wait()
             super().release()
 
     server = KeepGPUServer(

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1493,6 +1493,296 @@ def test_stop_all_waits_only_for_sessions_starting_at_snapshot(monkeypatch):
     server.stop_keep("second-job")
 
 
+def test_stop_keep_times_out_waiting_for_stuck_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep(job_id="starting-job"))
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert "Timed out" in stop_result["value"]["message"]
+        assert server.status("starting-job")["state"] == "starting"
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_stop_all_times_out_waiting_for_stuck_starting_session(monkeypatch):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert "Timed out" in stop_result["value"]["message"]
+        assert server.status("starting-job")["state"] == "starting"
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class BlockingStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep(job_id="starting-job"))
+    )
+    stop_thread.start()
+
+    try:
+        stop_thread.join(timeout=0.3)
+        assert not stop_thread.is_alive()
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert controllers[0].released is False
+
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        assert start_result["value"] == {"job_id": "starting-job"}
+        assert _wait_until(lambda: server.status("starting-job")["active"] is False)
+        assert controllers[0].released is True
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+
+def test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    fail_startup = threading.Event()
+    release_started = threading.Event()
+    start_error = {}
+    controllers = []
+
+    class FailingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            fail_startup.wait(timeout=1.0)
+            raise RuntimeError("startup exploded")
+
+    class SuccessfulController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def release(self):
+            release_started.set()
+            super().release()
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: FailingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    def start_failing_job():
+        try:
+            server.start_keep(job_id="starting-job")
+        except RuntimeError as exc:
+            start_error["value"] = str(exc)
+
+    start_thread = threading.Thread(target=start_failing_job)
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    try:
+        stop_result = server.stop_keep(job_id="starting-job")
+        assert stop_result["timed_out"] == ["starting-job"]
+
+        fail_startup.set()
+        start_thread.join(timeout=1.0)
+        assert not start_thread.is_alive()
+        assert start_error["value"] == "startup exploded"
+        assert server.status("starting-job")["active"] is False
+        with server._sessions_lock:
+            assert "starting-job" not in server._pending_stop_job_ids
+
+        monkeypatch.setattr(
+            server,
+            "_controller_factory",
+            cast(Any, lambda **kwargs: SuccessfulController(**kwargs)),
+        )
+        assert server.start_keep(job_id="starting-job") == {"job_id": "starting-job"}
+        assert server.status("starting-job")["state"] == "active"
+        assert release_started.wait(timeout=0.1) is False
+    finally:
+        fail_startup.set()
+        start_thread.join(timeout=1.0)
+        server.stop_keep(job_id="starting-job")
+
+
+def test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    release_started = threading.Event()
+    release_done = threading.Event()
+    controllers = []
+    start_result = {}
+    stop_result = {}
+
+    class BlockingReleaseController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+        def release(self):
+            release_started.set()
+            release_done.wait(timeout=1.0)
+            super().release()
+
+    server = KeepGPUServer(
+        controller_factory=cast(
+            Any, lambda **kwargs: BlockingReleaseController(**kwargs)
+        )
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+    original_wait = server._wait_for_starting_jobs_or_mark_pending
+    intercept_next_wait = True
+
+    def wait_then_settle_startup(job_ids):
+        nonlocal intercept_next_wait
+        if not intercept_next_wait:
+            return original_wait(job_ids)
+        intercept_next_wait = False
+        result = original_wait(job_ids)
+        keep_release.set()
+        assert _wait_until(
+            lambda: server.status("starting-job").get("state") == "stopping"
+        )
+        return result
+
+    monkeypatch.setattr(
+        server, "_wait_for_starting_jobs_or_mark_pending", wait_then_settle_startup
+    )
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep())
+    )
+    stop_thread.start()
+
+    try:
+        assert release_started.wait(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+        assert not stop_thread.is_alive()
+        assert start_result["value"] == {"job_id": "starting-job"}
+        assert stop_result["value"]["timed_out"] == ["starting-job"]
+        assert stop_result["value"]["stopped"] == []
+        assert controllers[0].released is False
+    finally:
+        keep_release.set()
+        release_done.set()
+        start_thread.join(timeout=1.0)
+        stop_thread.join(timeout=1.0)
+
+    assert _wait_until(lambda: server.status("starting-job")["active"] is False)
+    assert controllers[0].released is True
+
+
 def test_stop_keep_returns_timeout_payload(monkeypatch):
     server = make_server()
     job_id = server.start_keep()["job_id"]


### PR DESCRIPTION
## Summary
- Bound `stop_keep` waits for sessions stuck in `starting` so stop requests do not hang indefinitely.
- Preserve the no-missed-starts contract by marking timed-out starting jobs for quiet release after startup completes.
- Update MCP/CLI docs, AGENTS.md lifecycle guidance, and the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_timed_out_stop_of_failed_startup_does_not_affect_reused_job_id tests/mcp/test_server.py::test_stop_all_does_not_duplicate_starting_timeout_after_startup_settles tests/mcp/test_server.py::test_stop_keep_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_for_starting_session tests/mcp/test_server.py::test_stop_all_waits_only_for_sessions_starting_at_snapshot -q` -> 8 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 184 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 626 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unnav'd plan notices
- `git diff --check` -> passed

## Local Review
- Local subagent review found stale AGENTS wording, stale verification counts, and a missing failed-start pending-stop regression.
- All review findings were addressed; re-check found no new must-fix issue besides staging the plan file, which is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop actions now briefly wait for sessions that are still starting, then report a timed-out stop if startup does not finish in time.
  * Sessions that finish starting after a timed-out stop are now quietly released in the background.
* **Bug Fixes**
  * Improved stop-all behavior so starting sessions are handled consistently and not left active.
  * Preserved normal behavior for startups that complete within the wait window, including retries after failed startups.
* **Documentation**
  * Updated user-facing docs and guidelines to describe the new stop timing behavior and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->