### PR TITLE
[mcp] fix: expose pending startup stops in status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,8 +200,9 @@ This file defines how coding agents should work in this repository.
   captured starting params, not a later same-`job_id` replacement.
 - Stop requests waiting on starting sessions must be bounded. If startup does
   not settle within the stop wait budget, return the normal additive timeout
-  payload and remember the cancellation so a later successful startup is
-  released in the background instead of becoming a surprise active keeper.
+  payload, report the remembered cancellation in status as `state="stopping"`
+  with a timeout `last_error`, and release a later successful startup in the
+  background instead of exposing it as a surprise active keeper.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
 - Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Dashboard telemetry must display unavailable utilization as unknown/`n/a`, not

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ to zero devices.
 - Status and stop requests both account for in-progress starts: status reports
   them as `starting`, and stop waits for startup to settle so a session is not
   reported as missing or skipped by stop-all. That startup wait is bounded; if
-  it times out, the stop response includes the job in `timed_out`, the job may
-  remain `starting`, and the service remembers the cancellation so a later
-  successful startup is released in the background.
+  it times out, the stop response includes the job in `timed_out`, status shows
+  the remembered cancellation as `state="stopping"` with the timeout message,
+  and a later successful startup is released in the background.
 - Stop-all only covers sessions active or already starting when that request
   begins; later concurrent starts belong to a later stop request.
 - Stop-all releases independent sessions concurrently and reports outcomes in

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -101,9 +101,9 @@ Elementwise keep-alive batches:
   jobs as `state="starting"` while controller startup is in progress, and
   `stop_keep` removes a session only after release succeeds. Stop requests wait
   for starting jobs within a bounded budget; if that wait times out, the
-  response uses `timed_out`, the job can remain visible as `state="starting"`,
-  and the service remembers the cancellation so a later successful startup is
-  released in the background. Timed-out releases stay visible as
+  response uses `timed_out`, status shows the remembered cancellation as
+  `state="stopping"` with the timeout message, and a later successful startup
+  is released in the background. Timed-out releases stay visible as
   `state="stopping"` until the background release finishes; failed releases
   stay visible as `state="stop_failed"` with `last_error`.
 - After startup, terminal worker runtime or allocation failures are surfaced as

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -160,10 +160,11 @@ request timeout.
 If `stop_keep` arrives while a matching session is still starting, the service
 waits for startup to settle before deciding whether the job exists. This wait
 is bounded: if startup does not settle within the stop wait budget, the response
-uses the normal `timed_out` field and the service remembers the cancellation so
-the session is released in the background if startup later succeeds. Stop-all
-requests also wait for in-progress starts from their initial snapshot, with the
-same bounded timeout behavior. For stop-all, starts that begin after that
+uses the normal `timed_out` field, status shows `state="stopping"` with the
+timeout message, and the service remembers the cancellation so the session is
+released in the background if startup later succeeds. Stop-all requests also
+wait for in-progress starts from their initial snapshot, with the same bounded
+timeout behavior. For stop-all, starts that begin after that
 request's initial snapshot are not stopped by that request.
 Stop-all releases the sessions in its snapshot concurrently and aggregates
 results in deterministic snapshot order using the same additive fields.

--- a/docs/plans/pending-stop-status-truth.md
+++ b/docs/plans/pending-stop-status-truth.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Preserve Truthful Pending-Stop State
+## Task 1: Preserve Truthful Pending-Stop State
 
 **Files:**
 - Modify: `src/keep_gpu/mcp/server.py`

--- a/docs/plans/pending-stop-status-truth.md
+++ b/docs/plans/pending-stop-status-truth.md
@@ -1,0 +1,111 @@
+# Pending Stop Status Truth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make timed-out stops of still-starting sessions truthful in `status`, so a remembered cancellation is never exposed as a normal `starting` or `active` keeper.
+
+**Architecture:** Keep the fix inside `KeepGPUServer` lifecycle state. `_pending_stop_job_ids` remains the cancellation memory for starts that have not settled, but status rendering must expose that memory as `state="stopping"` with the existing timeout message, and `start_keep()` must publish a pending-stopped session as `stopping` before launching background cleanup.
+
+**Tech Stack:** Python 3, `threading`, pytest, KeepGPU MCP/service lifecycle tests.
+
+---
+
+### Task 1: Preserve Truthful Pending-Stop State
+
+**Files:**
+- Modify: `src/keep_gpu/mcp/server.py`
+- Modify: `tests/mcp/test_server.py`
+- Modify: `README.md`
+- Modify: `docs/concepts/architecture.md`
+- Modify: `docs/guides/mcp.md`
+- Modify: `docs/reference/cli.md`
+- Modify: `AGENTS.md`
+
+- [x] **Step 1: Write failing tests for pending cancellation visibility**
+
+Add or adjust focused tests in `tests/mcp/test_server.py`:
+
+```python
+def test_timed_out_stop_of_starting_session_reports_stopping_before_startup_finishes(monkeypatch):
+    # Start a controller whose keep() blocks, stop it with a tiny startup wait
+    # timeout, and assert status(job_id) plus status() expose the remembered
+    # cancellation as state="stopping" with the timeout message while keep()
+    # is still blocked.
+```
+
+```python
+def test_pending_stop_session_is_not_reported_with_active_state_before_background_release(monkeypatch):
+    # Defer only the background pending-stop thread started after startup
+    # completes, then assert the published session is visible with
+    # state="stopping" and the timeout message, not state="active", before
+    # running the deferred cleanup thread.
+```
+
+- [x] **Step 2: Run tests to verify they fail for the current bug**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest \
+  tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_reports_stopping_before_startup_finishes \
+  tests/mcp/test_server.py::test_pending_stop_session_is_not_reported_with_active_state_before_background_release \
+  -q
+```
+
+Expected: both tests fail because the current server reports the first window as plain `starting` with `last_error=None` and the second window as plain `active`.
+
+- [x] **Step 3: Implement minimal lifecycle-state fix**
+
+In `src/keep_gpu/mcp/server.py`:
+
+- Add a small helper for the timeout status shape or reuse `_timeout_error_message()` directly.
+- When `status(job_id)` reports a job from `_starting_params`, check whether the job id is in `_pending_stop_job_ids`; if so, report `state="stopping"` and `last_error=_timeout_error_message()`.
+- When all-session `status()` renders `_starting_params`, apply the same rule per job.
+- When `start_keep()` settles a startup whose job id is pending stop, create the `Session` with `state="stopping"` and `last_error=_timeout_error_message()` before adding it to `_sessions` and before launching the background cleanup thread.
+- Ensure the background pending-stop cleanup path can still release this already-marked `stopping` session, while duplicate user stop requests for ordinary `stopping` sessions still return `timed_out` without starting duplicate release work.
+- Keep identity guards intact: the background `_stop_current_session(... expected_session=session)` must still only stop the original session, not a reused job id.
+
+- [x] **Step 4: Verify targeted lifecycle tests**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest \
+  tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session \
+  tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session \
+  tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_reports_stopping_before_startup_finishes \
+  tests/mcp/test_server.py::test_pending_stop_session_is_not_reported_with_active_state_before_background_release \
+  tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes \
+  tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed \
+  tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes \
+  -q
+```
+
+Expected: all listed tests pass.
+
+- [x] **Step 5: Update lifecycle documentation**
+
+Update docs to say that once a stop wait times out for a starting job, `status` shows the remembered cancellation as `state="stopping"` with the timeout message, and after startup succeeds the session remains `stopping` until background release succeeds or becomes `stop_failed`.
+
+- [x] **Step 6: Run broader verification**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/mcp -q
+PYTHONPATH=$PWD/src pytest tests -q
+pre-commit run --all-files
+PYTHONPATH=$PWD/src mkdocs build
+git diff --check
+```
+
+Expected: tests and checks pass. Existing mkdocs warnings about plan pages outside nav are acceptable if unchanged.
+
+- [x] **Step 7: Commit**
+
+Commit with:
+
+```bash
+git add src/keep_gpu/mcp/server.py tests/mcp/test_server.py README.md docs/concepts/architecture.md docs/guides/mcp.md docs/reference/cli.md AGENTS.md docs/plans/pending-stop-status-truth.md
+git commit -m "fix(mcp): expose pending startup stops in status"
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -88,10 +88,11 @@ error before any RPC or stop-all fallback runs.
 Targeted stop waits for a matching in-progress start to settle before returning
 `not found`, so starting sessions are not silently skipped. That wait is
 bounded; if startup does not settle in time, the response includes the job in
-`timed_out`, and the service remembers the cancellation so a later successful
-startup is released in the background. For `--all`, the service records the
-initial active/starting boundary first, waits only for starting jobs in that
-boundary, and does not stop later starts.
+`timed_out`, status shows the remembered cancellation as `state="stopping"`
+with the timeout message, and the service releases a later successful startup
+in the background. For `--all`, the service records the initial active/starting
+boundary first, waits only for starting jobs in that boundary, and does not stop
+later starts.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
 The output is a directly parseable JSON object, including `{"error": "..."}` for

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -349,6 +349,8 @@ class KeepGPUServer:
             session = Session(
                 controller=controller,
                 params=params,
+                state="stopping" if pending_stop else "active",
+                last_error=self._timeout_error_message() if pending_stop else None,
             )
             self._sessions[job_id] = session
             self._sessions_cond.notify_all()
@@ -358,6 +360,7 @@ class KeepGPUServer:
                 kwargs={
                     "job_id": job_id,
                     "expected_session": session,
+                    "pending_stop_cleanup": True,
                 },
                 daemon=True,
             ).start()
@@ -432,6 +435,7 @@ class KeepGPUServer:
         job_id: str,
         quiet: bool = False,
         expected_session: Optional[Session] = None,
+        pending_stop_cleanup: bool = False,
     ) -> Optional[Dict[str, Any]]:
         with self._sessions_lock:
             session = self._sessions.get(job_id)
@@ -439,12 +443,16 @@ class KeepGPUServer:
                 return None
             if session is None:
                 return None
-            if session.state == "stopping":
+            release_existing_stopping = (
+                pending_stop_cleanup and expected_session is session
+            )
+            if session.state == "stopping" and not release_existing_stopping:
                 result = self._empty_stop_result()
                 result["timed_out"].append(job_id)
                 return self._finalize_stop_result(result)
-            session.state = "stopping"
-            session.last_error = None
+            if session.state != "stopping":
+                session.state = "stopping"
+                session.last_error = None
 
         result = self._empty_stop_result()
         try:
@@ -476,6 +484,15 @@ class KeepGPUServer:
         self._mark_stop_timeout(job_id, session)
         result["timed_out"].append(job_id)
         return self._finalize_stop_result(result)
+
+    def _starting_status(self, job_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        pending_stop = job_id in self._pending_stop_job_ids
+        return {
+            "job_id": job_id,
+            "params": params,
+            "state": "stopping" if pending_stop else "starting",
+            "last_error": self._timeout_error_message() if pending_stop else None,
+        }
 
     def stop_keep(
         self, job_id: Optional[str] = None, quiet: bool = False
@@ -622,13 +639,9 @@ class KeepGPUServer:
                 if not session:
                     params = self._starting_params.get(job_id)
                     if params is not None:
-                        return {
-                            "active": True,
-                            "job_id": job_id,
-                            "params": params,
-                            "state": "starting",
-                            "last_error": None,
-                        }
+                        status = self._starting_status(job_id, params)
+                        status["active"] = True
+                        return status
                     return {"active": False, "job_id": job_id}
                 self._refresh_session_runtime_state(session)
                 return {
@@ -643,12 +656,7 @@ class KeepGPUServer:
                 self._refresh_session_runtime_state(session)
             return {
                 "active_jobs": [
-                    {
-                        "job_id": jid,
-                        "params": params,
-                        "state": "starting",
-                        "last_error": None,
-                    }
+                    self._starting_status(jid, params)
                     for jid, params in self._starting_params.items()
                 ]
                 + [

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -639,9 +639,9 @@ class KeepGPUServer:
                 if not session:
                     params = self._starting_params.get(job_id)
                     if params is not None:
-                        status = self._starting_status(job_id, params)
-                        status["active"] = True
-                        return status
+                        job_status = self._starting_status(job_id, params)
+                        job_status["active"] = True
+                        return job_status
                     return {"active": False, "job_id": job_id}
                 self._refresh_session_runtime_state(session)
                 return {

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1676,7 +1676,9 @@ def test_stop_keep_times_out_waiting_for_stuck_starting_session(monkeypatch):
         assert not stop_thread.is_alive()
         assert stop_result["value"]["timed_out"] == ["starting-job"]
         assert "Timed out" in stop_result["value"]["message"]
-        assert server.status("starting-job")["state"] == "starting"
+        status = server.status("starting-job")
+        assert status["state"] == "stopping"
+        assert status["last_error"] == server._timeout_error_message()
     finally:
         keep_release.set()
         start_thread.join(timeout=1.0)
@@ -1720,13 +1722,148 @@ def test_stop_all_times_out_waiting_for_stuck_starting_session(monkeypatch):
         assert not stop_thread.is_alive()
         assert stop_result["value"]["timed_out"] == ["starting-job"]
         assert "Timed out" in stop_result["value"]["message"]
-        assert server.status("starting-job")["state"] == "starting"
+        status = server.status("starting-job")
+        assert status["state"] == "stopping"
+        assert status["last_error"] == server._timeout_error_message()
     finally:
         keep_release.set()
         start_thread.join(timeout=1.0)
         stop_thread.join(timeout=1.0)
 
     assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_timed_out_stop_of_starting_session_reports_stopping_before_startup_finishes(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    start_result = {}
+
+    class BlockingStartController(DummyController):
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    start_thread = threading.Thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    try:
+        stop_result = server.stop_keep(job_id="starting-job")
+
+        assert stop_result["timed_out"] == ["starting-job"]
+        expected_error = server._timeout_error_message()
+        status = server.status("starting-job")
+        assert status["active"] is True
+        assert status["state"] == "stopping"
+        assert status["last_error"] == expected_error
+        jobs = {job["job_id"]: job for job in server.status()["active_jobs"]}
+        assert jobs["starting-job"]["state"] == "stopping"
+        assert jobs["starting-job"]["last_error"] == expected_error
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+
+    assert start_result["value"] == {"job_id": "starting-job"}
+
+
+def test_pending_stop_session_is_not_reported_with_active_state_before_background_release(
+    monkeypatch,
+):
+    keep_entered = threading.Event()
+    keep_release = threading.Event()
+    controllers = []
+    deferred_threads = []
+    start_result = {}
+
+    class BlockingStartController(DummyController):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            controllers.append(self)
+
+        def keep(self):
+            self.kept = True
+            keep_entered.set()
+            keep_release.wait(timeout=1.0)
+
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: BlockingStartController(**kwargs))
+    )
+    monkeypatch.setattr(server, "_startup_stop_wait_timeout_s", 0.02, raising=False)
+
+    real_thread = threading.Thread
+
+    class DeferredThread:
+        def __init__(self, target, args=(), kwargs=None):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+
+        def start(self):
+            deferred_threads.append(self)
+
+        def run(self):
+            self._target(*self._args, **self._kwargs)
+
+    def thread_factory(*args, **kwargs):
+        target_kwargs = kwargs.get("kwargs") or {}
+        if (
+            target_kwargs.get("job_id") == "starting-job"
+            and target_kwargs.get("expected_session") is not None
+        ):
+            return DeferredThread(
+                kwargs.get("target"), kwargs.get("args", ()), target_kwargs
+            )
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(server_module.threading, "Thread", thread_factory)
+
+    start_thread = real_thread(
+        target=lambda: start_result.update(
+            value=server.start_keep(job_id="starting-job")
+        )
+    )
+    start_thread.start()
+    assert keep_entered.wait(timeout=1.0)
+
+    try:
+        stop_result = server.stop_keep(job_id="starting-job")
+        assert stop_result["timed_out"] == ["starting-job"]
+
+        keep_release.set()
+        start_thread.join(timeout=1.0)
+        assert start_result["value"] == {"job_id": "starting-job"}
+        assert len(deferred_threads) == 1
+
+        expected_error = server._timeout_error_message()
+        status = server.status("starting-job")
+        # "active" means the retained session is visible; state carries lifecycle truth.
+        assert status["active"] is True
+        assert status["state"] == "stopping"
+        assert status["last_error"] == expected_error
+
+        duplicate_stop = server.stop_keep("starting-job")
+        assert duplicate_stop["timed_out"] == ["starting-job"]
+        assert controllers[0].released is False
+        assert server.status("starting-job")["last_error"] == expected_error
+
+        deferred_threads[0].run()
+        assert controllers[0].released is True
+        assert server.status("starting-job")["active"] is False
+    finally:
+        keep_release.set()
+        start_thread.join(timeout=1.0)
 
 
 def test_timed_out_stop_of_starting_session_releases_after_startup_completes(
@@ -1863,7 +2000,10 @@ def test_pending_stop_does_not_stop_reused_job_id_after_original_removed(
     assert len(deferred_threads) == 1
 
     old_controller = controllers_by_gpu[(0,)][0]
-    stop_original = server.stop_keep("race-job")
+    old_session = server._sessions["race-job"]
+    stop_original = server._stop_current_session(
+        "race-job", expected_session=old_session, pending_stop_cleanup=True
+    )
     assert stop_original["stopped"] == ["race-job"]
     assert old_controller.released is True
 


### PR DESCRIPTION
## Summary
- show remembered startup-stop cancellations as `state="stopping"` with timeout `last_error` in `status(job_id)` and all-session `status()`
- publish settled pending-stop sessions as `stopping` before deferred cleanup, while preserving exact-session identity guards
- update README, MCP/CLI/architecture docs, AGENTS.md, and the implementation plan

## Local verification
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_stop_keep_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_stop_all_times_out_waiting_for_stuck_starting_session tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_reports_stopping_before_startup_finishes tests/mcp/test_server.py::test_pending_stop_session_is_not_reported_with_active_state_before_background_release tests/mcp/test_server.py::test_timed_out_stop_of_starting_session_releases_after_startup_completes tests/mcp/test_server.py::test_pending_stop_does_not_stop_reused_job_id_after_original_removed tests/mcp/test_server.py::test_timed_out_stop_all_of_starting_session_releases_after_startup_completes -q` -> 7 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` -> 189 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 631 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unnav'd plan notices
- `git diff --check origin/main..HEAD` -> passed

## Local subagent review
- Spec compliance review: passed after clarifying that `active=True` means retained session visibility and lifecycle truth is carried by `state`/`last_error`
- Code quality review: no Critical, Important, or Minor findings; ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop requests that time out now report the session as `stopping` with a timeout message, even if it was still starting.
  * Sessions that finish starting after a timed-out stop are now cleaned up in the background.

* **Bug Fixes**
  * Status views and active-session listings now show the same stop state consistently during this transition.
  * `stop all` now respects the initial set of in-progress starts and keeps later sessions out of the stop response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->