### PR TITLE
[cli] fix: validate service result records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,9 @@ This file defines how coding agents should work in this repository.
   method-specific `status`, `stop_keep`, and `list_gpus` result payloads at CLI
   call sites before reading fields or triggering daemon stop side effects, while
   allowing extra result fields for forward compatibility.
+- CLI method-specific result validation must include nested records consumed by
+  downstream tools: `status.active_jobs` entries, `stop_keep` job-id lists and
+  error values, and `list_gpus` GPU records with visible ordinal metadata.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Flags that matter:
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
     that tools such as `jq` can parse directly. Malformed JSON-RPC service
-    envelopes and invalid service endpoints, including non-integer ports, are
-    reported as those JSON error objects instead of empty success results or
-    tracebacks.
+    envelopes, malformed method-specific result records, and invalid service
+    endpoints, including non-integer ports, are reported as those JSON error
+    objects instead of empty success results or tracebacks.
 
 ## Embed in Python
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -92,10 +92,10 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. `status`, `stop`, and `list-gpus` print JSON objects,
 including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
-Malformed JSON-RPC service envelopes are reported as JSON error objects instead
-of empty success results. Invalid service endpoints, including non-integer
-ports, are also reported as JSON errors before any RPC or stop-all fallback
-runs.
+Malformed JSON-RPC service envelopes and malformed method-specific result
+records are reported as JSON error objects instead of empty success results.
+Invalid service endpoints, including non-integer ports, are also reported as
+JSON errors before any RPC or stop-all fallback runs.
 When KeepGPU can identify the underlying device, it reports `physical_id` or
 `uuid` as metadata; those metadata values are not accepted as `--gpu-ids`.
 

--- a/docs/plans/cli-strict-service-payload-validation.md
+++ b/docs/plans/cli-strict-service-payload-validation.md
@@ -1,0 +1,149 @@
+# CLI Strict Service Payload Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten CLI service result validation so malformed method-specific list items and required records become clean JSON errors instead of successful machine-readable output.
+
+**Architecture:** Keep `_rpc_call()` limited to generic JSON-RPC envelope validation. Extend the existing CLI-side `status`, `stop_keep`, and `list_gpus` validators to validate only the stable fields promised by the service contract while still allowing extra fields for forward compatibility.
+
+**Tech Stack:** Python, Typer CLI, pytest, mkdocs, pre-commit.
+
+---
+
+## Background
+
+The first CLI payload validation pass rejects missing top-level method fields such as `active_jobs`, `stopped`, `errors`, and `gpus`. The remaining gap is that malformed entries inside those containers can still be printed as success: `{"active_jobs": [123]}`, `{"active": true, "job_id": "job-1"}`, `{"stopped": [123], ...}`, or `{"gpus": [{"name": "missing id"}]}`. That violates the CLI JSON contract for downstream automation.
+
+## Task 1: Strict Method-Specific CLI Validators
+
+**Files:**
+- Modify: `src/keep_gpu/cli.py`
+- Modify: `tests/test_cli_service_commands.py`
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `docs/reference/cli.md`
+- Modify: `docs/guides/cli.md`
+
+- [x] **Step 1: Write RED tests for malformed nested payloads**
+
+Add focused tests in `tests/test_cli_service_commands.py` that currently fail because malformed nested payloads exit `0`:
+
+```python
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"active_jobs": [123]},
+        {"active_jobs": [{"params": {}, "state": "active", "last_error": None}]},
+        {"active_jobs": [{"job_id": "job-1", "state": "active", "last_error": None}]},
+        {"active_jobs": [{"job_id": "job-1", "params": {}, "last_error": None}]},
+        {"active_jobs": [{"job_id": "job-1", "params": {}, "state": "active", "last_error": 1}]},
+    ],
+)
+def test_status_rejects_malformed_active_job_entries(monkeypatch, payload):
+    ...
+```
+
+```python
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"active": True, "job_id": "job-1"},
+        {"active": True, "job_id": "job-1", "params": [], "state": "active", "last_error": None},
+        {"active": True, "job_id": "job-1", "params": {}, "state": 1, "last_error": None},
+        {"active": True, "job_id": "job-1", "params": {}, "state": "active", "last_error": 1},
+    ],
+)
+def test_status_job_rejects_active_payload_missing_session_fields(monkeypatch, payload):
+    ...
+```
+
+```python
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"stopped": [123], "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": [False], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": [{}], "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": [], "errors": {"job-1": 2}},
+    ],
+)
+def test_stop_job_rejects_malformed_job_id_lists_and_errors(monkeypatch, payload):
+    ...
+```
+
+```python
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"gpus": [{"name": "missing id"}]},
+        {"gpus": [{"id": True, "visible_id": 0, "platform": "cuda", "name": "GPU", "memory_total": None, "memory_used": None, "utilization": None}]},
+        {"gpus": [{"id": 0, "visible_id": "0", "platform": "cuda", "name": "GPU", "memory_total": None, "memory_used": None, "utilization": None}]},
+        {"gpus": [{"id": 0, "visible_id": 0, "platform": 1, "name": "GPU", "memory_total": None, "memory_used": None, "utilization": None}]},
+    ],
+)
+def test_list_gpus_rejects_records_missing_required_fields(monkeypatch, payload):
+    ...
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'malformed_active_job_entries or active_payload_missing_session_fields or malformed_job_id_lists_and_errors or records_missing_required_fields'
+```
+
+Expected: tests fail because the current validators accept these nested malformed payloads.
+
+- [x] **Step 3: Implement minimal strict validators**
+
+In `src/keep_gpu/cli.py`:
+
+- Add plain-type helpers such as `_is_plain_int()` and field validators for required string, object, optional string, optional integer, and optional numeric fields.
+- Update `_validate_status_result()`:
+  - all-session `active_jobs` must be a list of objects;
+  - each active job must include `job_id: str`, `params: object`, `state: str`, and `last_error: str | None`;
+  - single-job responses still require `active: bool` and `job_id: str`;
+  - if `active` is `True`, require `params: object`, `state: str`, and `last_error: str | None`;
+  - if `active` is `False`, do not require session detail fields.
+- Update `_validate_stop_keep_result()` so `stopped`, `timed_out`, and `failed` are lists of strings, `errors` is an object whose values are strings, and optional `message` remains a string.
+- Update `_validate_list_gpus_result()` so each GPU record includes `id` and `visible_id` as non-bool ints, `platform` and `name` as strings, and `memory_total`, `memory_used`, and `utilization` as nullable telemetry values.
+- Reject non-finite numeric utilization values such as `NaN` and `Infinity`, because the CLI promises directly parseable JSON output.
+- Keep extra result fields and extra per-record fields allowed.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'malformed_active_job_entries or active_payload_missing_session_fields or inactive_payload_without_session_fields or malformed_job_id_lists_and_errors or records_missing_required_fields or outputs_single_decoded_json_object or service_stop_rejects_malformed'
+PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q
+```
+
+- [x] **Step 5: Update docs and AGENTS**
+
+Document that CLI service JSON commands reject malformed method-specific records, not just malformed top-level envelopes:
+
+- `AGENTS.md`: clarify required nested record validation for `status`, `stop_keep`, and `list_gpus`.
+- `README.md`, `docs/reference/cli.md`, and `docs/guides/cli.md`: note that malformed service envelopes and malformed method-specific result records are reported as single JSON error objects.
+
+- [x] **Step 6: Run broad verification**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q
+PYTHONPATH=$PWD/src pytest tests -q
+pre-commit run --all-files
+PYTHONPATH=$PWD/src mkdocs build
+git diff --check
+```
+
+- [x] **Step 7: Commit**
+
+Commit with:
+
+```bash
+git add AGENTS.md README.md docs/reference/cli.md docs/guides/cli.md docs/plans/cli-strict-service-payload-validation.md src/keep_gpu/cli.py tests/test_cli_service_commands.py
+git commit -m "fix(cli): validate service result records"
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -69,7 +69,8 @@ just-created daemon instead of leaving it idle.
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes are reported as JSON error objects instead of empty success results.
+envelopes and malformed status job records are reported as JSON error objects
+instead of empty success results.
 Started sessions with terminal worker allocation/runtime failures remain listed
 as `state="runtime_failed"` with `last_error` and can still be stopped. Normal
 busy-GPU or unavailable-telemetry backoff keeps the session active; it is not a
@@ -97,7 +98,8 @@ later starts.
 in deterministic snapshot order with the same additive response fields.
 The output is a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes are reported as JSON error objects instead of empty success results.
+envelopes and malformed stop result records are reported as JSON error objects
+instead of empty success results.
 
 ### `keep-gpu list-gpus`
 
@@ -110,9 +112,9 @@ usable `gpu_ids`. On ROCm, listed records are limited to visible ordinals that
 Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
 reported as `{"error": "..."}`. Malformed JSON-RPC service envelopes are
-reported as JSON error objects instead of empty success results. Invalid
-endpoint values, including non-integer or out-of-range ports, are reported as
-JSON errors before RPC.
+reported as JSON error objects instead of empty success results; malformed GPU
+records are reported the same way. Invalid endpoint values, including
+non-integer or out-of-range ports, are reported as JSON errors before RPC.
 
 ### `keep-gpu service-stop`
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import math
 import os
 import shlex
 import signal
@@ -632,6 +633,55 @@ def _require_dict_field(
     return value
 
 
+def _require_string_field(result: Dict[str, Any], field: str, method: str) -> str:
+    value = result.get(field)
+    if not isinstance(value, str):
+        raise _malformed_method_result(method, f"{field} must be a string")
+    return value
+
+
+def _require_nullable_string_field(
+    result: Dict[str, Any], field: str, method: str
+) -> Optional[str]:
+    if field not in result:
+        raise _malformed_method_result(method, f"{field} must be a string or null")
+    value = result[field]
+    if value is not None and not isinstance(value, str):
+        raise _malformed_method_result(method, f"{field} must be a string or null")
+    return value
+
+
+def _require_plain_int_field(result: Dict[str, Any], field: str, method: str) -> int:
+    value = result.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _malformed_method_result(method, f"{field} must be an integer")
+    return value
+
+
+def _require_nullable_int_field(
+    result: Dict[str, Any], field: str, method: str
+) -> Optional[int]:
+    if field not in result:
+        raise _malformed_method_result(method, f"{field} must be an integer or null")
+    value = result[field]
+    if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+        raise _malformed_method_result(method, f"{field} must be an integer or null")
+    return value
+
+
+def _validate_status_session_record(
+    record: Dict[str, Any], method: str, prefix: str
+) -> None:
+    try:
+        _require_string_field(record, "job_id", method)
+        _require_dict_field(record, "params", method)
+        _require_string_field(record, "state", method)
+        _require_nullable_string_field(record, "last_error", method)
+    except ServiceResponseError as exc:
+        detail = str(exc).split(": ", 1)[-1]
+        raise _malformed_method_result(method, f"{prefix}.{detail}") from exc
+
+
 def _validate_status_result(
     result: Dict[str, Any], *, single_job: bool
 ) -> Dict[str, Any]:
@@ -640,17 +690,37 @@ def _validate_status_result(
             raise _malformed_method_result("status", "active must be a bool")
         if not isinstance(result.get("job_id"), str):
             raise _malformed_method_result("status", "job_id must be a string")
+        if result["active"]:
+            _validate_status_session_record(result, "status", "result")
     else:
-        _require_list_field(result, "active_jobs", "status")
+        active_jobs = _require_list_field(result, "active_jobs", "status")
+        for index, active_job in enumerate(active_jobs):
+            if not isinstance(active_job, dict):
+                raise _malformed_method_result(
+                    "status", f"active_jobs[{index}] must be an object"
+                )
+            _validate_status_session_record(
+                active_job, "status", f"active_jobs[{index}]"
+            )
     return result
 
 
 def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
     for field in ("stopped", "timed_out", "failed"):
-        _require_list_field(result, field, "stop_keep")
-    _require_dict_field(result, "errors", "stop_keep")
+        value = _require_list_field(result, field, "stop_keep")
+        for index, job_id in enumerate(value):
+            if not isinstance(job_id, str):
+                raise _malformed_method_result(
+                    "stop_keep", f"{field}[{index}] must be a string"
+                )
+    errors = _require_dict_field(result, "errors", "stop_keep")
+    for job_id, error in errors.items():
+        if not isinstance(error, str):
+            raise _malformed_method_result(
+                "stop_keep", f"errors[{job_id!r}] must be a string"
+            )
     message = result.get("message")
-    if message is not None and not isinstance(message, str):
+    if "message" in result and not isinstance(message, str):
         raise _malformed_method_result("stop_keep", "message must be a string")
     return result
 
@@ -662,6 +732,31 @@ def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
             raise _malformed_method_result(
                 "list_gpus", f"gpus[{index}] must be an object"
             )
+        try:
+            _require_plain_int_field(gpu, "id", "list_gpus")
+            _require_plain_int_field(gpu, "visible_id", "list_gpus")
+            _require_string_field(gpu, "platform", "list_gpus")
+            _require_string_field(gpu, "name", "list_gpus")
+            _require_nullable_int_field(gpu, "memory_total", "list_gpus")
+            _require_nullable_int_field(gpu, "memory_used", "list_gpus")
+            if "utilization" not in gpu:
+                raise _malformed_method_result(
+                    "list_gpus", "utilization must be a number or null"
+                )
+            utilization = gpu["utilization"]
+            if utilization is not None and (
+                isinstance(utilization, bool)
+                or not isinstance(utilization, (int, float))
+                or not math.isfinite(utilization)
+            ):
+                raise _malformed_method_result(
+                    "list_gpus", "utilization must be a number or null"
+                )
+        except ServiceResponseError as exc:
+            detail = str(exc).split(": ", 1)[-1]
+            raise _malformed_method_result(
+                "list_gpus", f"gpus[{index}].{detail}"
+            ) from exc
     return result
 
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -654,7 +654,17 @@ def test_status_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "status"
         assert params == {}
-        return {"active": True, "active_jobs": [{"job_id": "job-1"}]}
+        return {
+            "active": True,
+            "active_jobs": [
+                {
+                    "job_id": "job-1",
+                    "params": {"gpu_ids": [0]},
+                    "state": "active",
+                    "last_error": None,
+                }
+            ],
+        }
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
 
@@ -670,7 +680,13 @@ def test_status_job_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "status"
         assert params == {"job_id": "job-1"}
-        return {"active": True, "job_id": "job-1"}
+        return {
+            "active": True,
+            "job_id": "job-1",
+            "params": {"gpu_ids": [0]},
+            "state": "active",
+            "last_error": None,
+        }
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
 
@@ -701,6 +717,75 @@ def test_status_rejects_malformed_all_session_payloads(monkeypatch, payload):
 @pytest.mark.parametrize(
     "payload",
     [
+        {"active_jobs": [1]},
+        {
+            "active_jobs": [
+                {
+                    "job_id": 1,
+                    "params": {},
+                    "state": "active",
+                    "last_error": None,
+                }
+            ]
+        },
+        {
+            "active_jobs": [
+                {
+                    "params": {},
+                    "state": "active",
+                    "last_error": None,
+                }
+            ]
+        },
+        {
+            "active_jobs": [
+                {
+                    "job_id": "job-1",
+                    "state": "active",
+                    "last_error": None,
+                }
+            ]
+        },
+        {
+            "active_jobs": [
+                {
+                    "job_id": "job-1",
+                    "params": {},
+                    "last_error": None,
+                }
+            ]
+        },
+        {
+            "active_jobs": [
+                {
+                    "job_id": "job-1",
+                    "params": {},
+                    "state": "active",
+                    "last_error": 1,
+                }
+            ]
+        },
+    ],
+)
+def test_status_rejects_malformed_active_job_entries(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
         {},
         {"active": "yes", "job_id": "job-1"},
         {"active": True, "job_id": 1},
@@ -720,6 +805,63 @@ def test_status_job_rejects_malformed_payloads(monkeypatch, payload):
     decoded = _single_decoded_json_object(result.output)
     assert "Malformed status response" in decoded["error"]
     assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"active": True, "job_id": "job-1"},
+        {
+            "active": True,
+            "job_id": "job-1",
+            "params": [],
+            "state": "active",
+            "last_error": None,
+        },
+        {
+            "active": True,
+            "job_id": "job-1",
+            "params": {},
+            "last_error": None,
+        },
+        {
+            "active": True,
+            "job_id": "job-1",
+            "params": {},
+            "state": "active",
+            "last_error": 1,
+        },
+    ],
+)
+def test_status_job_rejects_active_payload_missing_session_fields(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {"job_id": "job-1"}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+def test_status_job_allows_inactive_payload_without_session_fields(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {"job_id": "missing-job"}
+        return {"active": False, "job_id": "missing-job"}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", "missing-job"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload == {"active": False, "job_id": "missing-job"}
 
 
 def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
@@ -753,9 +895,42 @@ def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
             "errors": {},
             "message": {"text": "bad"},
         },
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": [],
+            "errors": {},
+            "message": None,
+        },
     ],
 )
 def test_stop_job_rejects_malformed_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "job-1"}
+        assert timeout == 45.0
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"stopped": [1], "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": [None], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": [False], "errors": {}},
+        {"stopped": [], "timed_out": [], "failed": [], "errors": {"job-1": 1}},
+    ],
+)
+def test_stop_job_rejects_malformed_job_id_lists_and_errors(monkeypatch, payload):
     def fake_rpc(method, params, host, port, timeout=8.0):
         assert method == "stop_keep"
         assert params == {"job_id": "job-1"}
@@ -822,7 +997,19 @@ def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "list_gpus"
         assert params == {}
-        return {"gpus": [{"id": 0, "name": "GPU 0"}]}
+        return {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        }
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
 
@@ -835,6 +1022,156 @@ def test_list_gpus_outputs_single_decoded_json_object(monkeypatch):
 
 @pytest.mark.parametrize("payload", [{}, {"gpus": {}}, {"gpus": [1]}])
 def test_list_gpus_rejects_malformed_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "list_gpus"
+        assert params == {}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["list-gpus"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed list_gpus response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": True,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": "0",
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": 1,
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": 0,
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": "1024",
+                    "memory_used": 512,
+                    "utilization": 12.5,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": False,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": float("nan"),
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": float("inf"),
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": float("-inf"),
+                }
+            ]
+        },
+    ],
+)
+def test_list_gpus_rejects_records_missing_required_fields(monkeypatch, payload):
     def fake_rpc(method, params, host, port):
         assert method == "list_gpus"
         assert params == {}
@@ -1378,7 +1715,16 @@ def test_service_stop_refuses_active_sessions_without_force(monkeypatch):
         cli,
         "_rpc_call",
         lambda method, params, host, port, timeout=8.0: (
-            {"active_jobs": [{"job_id": "j1"}]}
+            {
+                "active_jobs": [
+                    {
+                        "job_id": "j1",
+                        "params": {},
+                        "state": "active",
+                        "last_error": None,
+                    }
+                ]
+            }
             if method == "status"
             else {"stopped": []}
         ),


### PR DESCRIPTION
## Summary
- validate nested `status`, `stop_keep`, and `list_gpus` service result records before CLI success output
- reject non-string job-id lists/errors and non-finite GPU utilization values as malformed service responses
- update AGENTS.md, README, CLI docs, and the implementation plan for record-level validation

## Local verification
- RED before implementation: nested malformed payload tests failed (`16 failed, 153 deselected`) because the CLI exited 0
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k "malformed_active_job_entries or active_payload_missing_session_fields or inactive_payload_without_session_fields or malformed_job_id_lists_and_errors or records_missing_required_fields or outputs_single_decoded_json_object or service_stop_rejects_malformed"` -> 32 passed, 144 deselected
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> 179 passed
- `PYTHONPATH=$PWD/src pytest tests -q` -> 657 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unnav'd plan notices
- `git diff --check origin/main..HEAD` -> passed

## Local subagent review
- Spec compliance review: passed; `_rpc_call()` remains generic and method-specific checks stay at CLI call sites
- Code quality review: found non-finite utilization gap; fixed with `math.isfinite()` and NaN/Infinity tests
- Targeted re-review: no Critical, Important, or Minor findings; approved the reviewed diff
