### PR TITLE
[global,cli,mcp] fix: classify device enumeration failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,11 @@ This file defines how coding agents should work in this repository.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
-- Expected controller startup unavailability, such as no usable visible GPUs or
-  unsupported platforms, must surface as explicit startup-unavailable errors
-  (direct JSON-RPC `-32000`, REST `503`, MCP tool `isError=true`) while
-  arbitrary unexpected startup/runtime failures remain internal errors.
+- Expected controller startup unavailability, such as no usable visible GPUs,
+  failed CUDA/ROCm visible-device enumeration, or unsupported platforms, must
+  surface as explicit startup-unavailable errors (direct JSON-RPC `-32000`,
+  REST `503`, MCP tool `isError=true`) while arbitrary unexpected
+  startup/runtime failures remain internal errors.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
 - CLI commands that consume service-specific JSON-RPC results must validate
@@ -146,6 +147,9 @@ This file defines how coding agents should work in this repository.
   target was chosen.
 - For CLI `--gpu-ids`, only omission means all visible GPUs; explicit empty or
   whitespace-only values are invalid and must not silently expand to all GPUs.
+- Blocking CLI mode must defer omitted-GPU hardware enumeration to
+  `GlobalGPUController`; the CLI should not perform an early
+  `torch.cuda.device_count()` probe just to log the all-GPU count.
 - Destructive or broad stop surfaces must reject ambiguous inputs such as `--job-id` with `--all` before any RPC, stop-all fallback, or daemon stop side effect.
 - REST session creation bodies must be JSON objects; reject arrays/scalars before field validation or session state changes.
 - REST session creation must validate cheap local fields (`vram`, `interval`,

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -87,9 +87,9 @@ Successful direct-method responses are KeepGPU JSON-RPC envelopes with
 
 For direct JSON-RPC calls, public validation failures and unknown parameters
 return JSON-RPC `-32602 Invalid params`. Expected startup-unavailable
-conditions, such as an unsupported controller platform or no usable visible
-GPUs, return `-32000` with the startup message. Unexpected server failures use
-`-32603 Internal error`.
+conditions, such as an unsupported controller platform, no usable visible GPUs,
+or failed CUDA/ROCm visible-device enumeration, return `-32000` with the
+startup message. Unexpected server failures use `-32603 Internal error`.
 
 Explicit `gpu_ids` that are validly shaped but outside the service process's
 current visible GPU count are public validation failures. Direct JSON-RPC
@@ -98,7 +98,8 @@ returns `-32602`, while MCP `tools/call` returns a tool result with
 
 MCP `tools/call` responses keep protocol envelopes successful for normal tool
 results, public tool-input validation failures, and expected hardware/platform
-startup-unavailable failures. Those tool-level failures return
+startup-unavailable failures, including failed CUDA/ROCm device enumeration.
+Those tool-level failures return
 `result.isError=true` with the message in tool content. Protocol shape errors,
 such as unknown tools, still return JSON-RPC errors such as `-32602`, and
 unexpected internal controller/runtime failures return JSON-RPC

--- a/docs/plans/startup-enumeration-unavailable.md
+++ b/docs/plans/startup-enumeration-unavailable.md
@@ -1,0 +1,61 @@
+# Startup Enumeration Unavailable Plan
+
+## Goal
+
+Classify CUDA/ROCm visible-device enumeration failures as expected
+startup-unavailable errors instead of internal failures.
+
+## Background
+
+`GlobalGPUController` selects CUDA/ROCm from platform detection and then asks
+PyTorch for visible device ordinals. When that runtime enumeration fails or
+changes during startup, the service should report hardware/runtime
+unavailability, not an arbitrary server bug.
+
+The audited gaps were:
+
+- Initial or child-controller `torch.cuda.device_count()` failures leaked as
+  JSON-RPC `-32603`.
+- Late child-controller visible-count drift to zero/smaller counts leaked as
+  plain `ValueError`.
+- REST explicit `gpu_ids` starts returned `400` when no visible GPUs could be
+  listed.
+- REST explicit `gpu_ids` starts returned `500` if GPU listing raised a device
+  enumeration error.
+- Blocking CLI mode queried device count before `GlobalGPUController` could own
+  omitted-GPU enumeration.
+
+## Design
+
+- Add `visible_torch_device_count()` and
+  `DeviceEnumerationUnavailableError` in `platform_manager.py`.
+- Use that helper in global, CUDA, and ROCm controller enumeration paths.
+- Keep invalid explicit `gpu_ids` as invalid input when a visible set is known.
+- Add `VisibleRankValidationError` so global startup classification does not
+  depend on error-message text.
+- Map enumeration failures and late visible-rank drift to
+  `NoGPUAvailableError`, which flows to JSON-RPC `-32000`, REST `503`, and MCP
+  tool `isError=true`.
+- Map REST GPU-listing enumeration failures to the same structured `503`.
+- Let blocking CLI pass omitted `gpu_ids=None` through to `GlobalGPUController`
+  instead of probing the device count for logging.
+
+## Docs
+
+- `AGENTS.md`: startup-unavailable and CLI omitted-GPU contracts.
+- `docs/reference/cli.md`: blocking CLI omitted-GPU wording and JSON-RPC
+  startup-unavailable wording.
+- `docs/guides/mcp.md`: direct JSON-RPC and MCP tool startup-unavailable
+  behavior.
+
+## Verification
+
+- Targeted startup/CLI/session-config shard: `8 passed`; REST listing-failure
+  shard: `3 passed`.
+- Affected suites (`test_cli_thresholds.py`, MCP server/API,
+  global/CUDA/ROCm controllers, utilities): `436 passed, 7 skipped`.
+- Full suite: `664 passed, 11 skipped`.
+- `pre-commit run --all-files`: passed.
+- `PYTHONPATH=$PWD/src mkdocs build`: passed with existing Material warning and
+  existing unnav'd plan notices.
+- `git diff --check`: passed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@ These options apply when you run `keep-gpu` without subcommands.
 | Option | Type | Description |
 | --- | --- | --- |
 | `--interval NUMBER` | seconds | Finite positive sleep duration, including fractional values, between utilization checks and keep-alive batches; values above the Python runtime wait limit are rejected. |
-| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to use all visible GPUs; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. |
+| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to let the controller resolve all visible GPUs; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. |
 | `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`); byte-equivalent values above 1 PiB are rejected. |
 | `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | `0..100` backs off before allocation/compute when utilization is above this value or unavailable; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
@@ -139,8 +139,9 @@ instead of dropping the connection.
 The dashboard consumes those JSON objects and displays `error.message` when it is
 present, falling back to the plain response body or HTTP status only when needed.
 Direct JSON-RPC service calls report the same expected hardware/platform
-startup-unavailable conditions with error code `-32000`; arbitrary runtime
-failures remain `-32603 Internal error`.
+startup-unavailable conditions, including failed CUDA/ROCm visible-device
+enumeration, with error code `-32000`; arbitrary runtime failures remain
+`-32603 Internal error`.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -836,18 +836,15 @@ def _run_blocking(
 
     gpu_id_list = _parse_gpu_ids(gpu_ids)
 
-    import torch
-
     from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
 
     if gpu_id_list is not None:
         logger.info("Using specified visible GPU ordinals: %s", gpu_id_list)
         gpu_count = len(gpu_id_list)
+        logger.info("GPU count: %s", gpu_count)
     else:
-        gpu_count = torch.cuda.device_count()
         logger.info("Using all available GPUs")
 
-    logger.info("GPU count: %s", gpu_count)
     logger.info("VRAM to keep occupied: %s", vram)
     logger.info("Check interval: %s seconds", interval)
     if busy_threshold == -1:

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -1,17 +1,21 @@
 import threading
 from typing import List, Optional, Union
 
-import torch
-
 from keep_gpu.utilities.humanized_input import parse_size, parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
+    VisibleRankValidationError,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
 )
-from keep_gpu.utilities.platform_manager import ComputingPlatform, get_platform
+from keep_gpu.utilities.platform_manager import (
+    ComputingPlatform,
+    DeviceEnumerationUnavailableError,
+    get_platform,
+    visible_torch_device_count,
+)
 
 logger = setup_logger(__name__)
 
@@ -35,7 +39,10 @@ class InvalidVisibleGPUSelectionError(ValueError):
 
 
 def _resolve_visible_gpu_ids(gpu_ids: Optional[List[int]]) -> List[int]:
-    visible_count = torch.cuda.device_count()
+    try:
+        visible_count = visible_torch_device_count()
+    except DeviceEnumerationUnavailableError as exc:
+        raise NoGPUAvailableError(str(exc)) from exc
     if gpu_ids is None:
         return list(range(visible_count))
     invalid_ids = [gpu_id for gpu_id in gpu_ids if gpu_id >= visible_count]
@@ -104,15 +111,20 @@ class GlobalGPUController:
         if not self.gpu_ids:
             raise NoGPUAvailableError("No GPUs available for GlobalGPUController")
 
-        self.controllers = [
-            controller_cls(
-                rank=i,
-                interval=self.interval,
-                vram_to_keep=self.vram_to_keep,
-                busy_threshold=self.busy_threshold,
-            )
-            for i in self.gpu_ids
-        ]
+        try:
+            self.controllers = [
+                controller_cls(
+                    rank=i,
+                    interval=self.interval,
+                    vram_to_keep=self.vram_to_keep,
+                    busy_threshold=self.busy_threshold,
+                )
+                for i in self.gpu_ids
+            ]
+        except VisibleRankValidationError as exc:
+            raise NoGPUAvailableError(str(exc)) from exc
+        except DeviceEnumerationUnavailableError as exc:
+            raise NoGPUAvailableError(str(exc)) from exc
 
     def keep(self) -> None:
         started = []

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -55,6 +55,7 @@ from keep_gpu.utilities.humanized_input import (
 )
 from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     PUBLIC_INTERVAL_MAX_SECONDS,
@@ -1125,7 +1126,30 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     return
 
                 if gpu_ids is not None:
-                    visible_gpus = server_ref.list_gpus().get("gpus", [])
+                    try:
+                        visible_gpus = server_ref.list_gpus().get("gpus", [])
+                    except DeviceEnumerationUnavailableError as exc:
+                        self._json_response(
+                            503,
+                            {
+                                "error": {
+                                    "message": str(exc),
+                                    "type": SessionStartupUnavailable.__name__,
+                                }
+                            },
+                        )
+                        return
+                    if not visible_gpus:
+                        self._json_response(
+                            503,
+                            {
+                                "error": {
+                                    "message": "No usable visible GPUs are available",
+                                    "type": SessionStartupUnavailable.__name__,
+                                }
+                            },
+                        )
+                        return
                     listed_ids = {
                         gpu["id"]
                         for gpu in visible_gpus

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -10,7 +10,10 @@ from keep_gpu.single_gpu_controller.base_gpu_controller import BaseGPUController
 from keep_gpu.utilities.gpu_monitor import get_gpu_utilization
 from keep_gpu.utilities.humanized_input import parse_size
 from keep_gpu.utilities.logger import setup_logger
-from keep_gpu.utilities.platform_manager import ComputingPlatform
+from keep_gpu.utilities.platform_manager import (
+    ComputingPlatform,
+    visible_torch_device_count,
+)
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
@@ -83,7 +86,7 @@ class CudaGPUController(BaseGPUController):
         )
         self.busy_threshold = validate_busy_threshold(busy_threshold)
         rank = validate_rank_type(rank)
-        rank = validate_visible_rank(rank, torch.cuda.device_count())
+        rank = validate_visible_rank(rank, visible_torch_device_count())
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")
         self.interval = interval

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -8,6 +8,7 @@ import torch
 
 from keep_gpu.single_gpu_controller.base_gpu_controller import BaseGPUController
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.platform_manager import visible_torch_device_count
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
@@ -47,7 +48,7 @@ class RocmGPUController(BaseGPUController):
             )
         )
         rank = validate_rank_type(rank)
-        rank = validate_visible_rank(rank, torch.cuda.device_count())
+        rank = validate_visible_rank(rank, visible_torch_device_count())
         self.rank = rank
         self.device = torch.device(f"cuda:{rank}")
         self._stop_evt: Optional[threading.Event] = None

--- a/src/keep_gpu/utilities/platform_manager.py
+++ b/src/keep_gpu/utilities/platform_manager.py
@@ -20,6 +20,20 @@ class ComputingPlatform(Enum):
     MACM = "macm"
 
 
+class DeviceEnumerationUnavailableError(RuntimeError):
+    """Visible torch GPU ordinals could not be enumerated."""
+
+
+def visible_torch_device_count() -> int:
+    """Return the count of torch-visible CUDA/ROCm device ordinals."""
+    try:
+        return int(torch.cuda.device_count())
+    except Exception as exc:
+        raise DeviceEnumerationUnavailableError(
+            f"Unable to enumerate visible GPUs: {exc}"
+        ) from exc
+
+
 def _check_cuda():
     """
     Return True if CUDA appears available.

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -8,6 +8,10 @@ DEFAULT_BUSY_THRESHOLD = 25
 PUBLIC_INTERVAL_MAX_SECONDS = int(threading.TIMEOUT_MAX)
 
 
+class VisibleRankValidationError(ValueError):
+    """A rank cannot be selected from the current visible device set."""
+
+
 def _is_plain_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
@@ -80,9 +84,11 @@ def validate_visible_rank(rank: Any, visible_count: Any) -> int:
     if not _is_plain_int(visible_count) or visible_count < 0:
         raise ValueError("visible device count must be a non-negative integer")
     if visible_count == 0:
-        raise ValueError("no visible GPUs are available; rank cannot be selected")
+        raise VisibleRankValidationError(
+            "no visible GPUs are available; rank cannot be selected"
+        )
     if rank < 0 or rank >= visible_count:
-        raise ValueError(
+        raise VisibleRankValidationError(
             "rank must be a visible device ordinal less than "
             f"{visible_count}; got {rank}"
         )

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -14,6 +14,7 @@ from keep_gpu.mcp.server import (
     SessionStartupUnavailable,
     _JSONRPCHandler,
 )
+from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 
 
 class DummyController:
@@ -696,7 +697,19 @@ def test_http_start_validates_gpu_ids_against_listed_visible_ids(monkeypatch):
     assert controllers == []
 
 
-def test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids(monkeypatch):
+@pytest.mark.parametrize(
+    ("list_gpus_result", "message"),
+    [
+        ({"gpus": []}, "No usable visible GPUs are available"),
+        (
+            DeviceEnumerationUnavailableError("Unable to enumerate visible GPUs"),
+            "Unable to enumerate visible GPUs",
+        ),
+    ],
+)
+def test_http_start_reports_startup_unavailable_when_gpu_listing_unusable(
+    monkeypatch, list_gpus_result, message
+):
     controllers = []
 
     class TrackingController(DummyController):
@@ -707,7 +720,13 @@ def test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids(monkeypatch):
     server = KeepGPUServer(
         controller_factory=cast(Any, lambda **kwargs: TrackingController(**kwargs))
     )
-    monkeypatch.setattr(server, "list_gpus", lambda: {"gpus": []})
+
+    def list_gpus():
+        if isinstance(list_gpus_result, Exception):
+            raise list_gpus_result
+        return list_gpus_result
+
+    monkeypatch.setattr(server, "list_gpus", list_gpus)
     httpd, thread, base = _start_http_server(server)
 
     try:
@@ -727,8 +746,9 @@ def test_http_start_rejects_explicit_gpu_ids_when_no_visible_ids(monkeypatch):
         server.shutdown()
         thread.join(timeout=2)
 
-    assert status == 400
-    assert "listed visible GPU IDs (none)" in payload["error"]["message"]
+    assert status == 503
+    assert payload["error"]["message"] == message
+    assert payload["error"]["type"] == "SessionStartupUnavailable"
     assert controllers == []
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -607,6 +607,68 @@ def test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code(monkeypatch):
         server.shutdown()
 
 
+@pytest.mark.parametrize(
+    ("platform", "device_counts", "job_id", "message"),
+    [
+        (
+            pm.ComputingPlatform.CUDA,
+            [RuntimeError("cuda runtime unavailable")],
+            "device-count-failed",
+            "cuda runtime unavailable",
+        ),
+        (
+            pm.ComputingPlatform.CUDA,
+            [1, RuntimeError("cuda runtime disappeared")],
+            "late-device-count-failed",
+            "cuda runtime disappeared",
+        ),
+        (
+            pm.ComputingPlatform.CUDA,
+            [1, 0],
+            "late-zero-device-count",
+            "no visible GPUs are available",
+        ),
+        (
+            pm.ComputingPlatform.ROCM,
+            [1, 0],
+            "rocm-late-zero-device-count",
+            "no visible GPUs are available",
+        ),
+    ],
+)
+def test_jsonrpc_start_keep_device_enumeration_unavailable_returns_startup_unavailable(
+    monkeypatch, platform, device_counts, job_id, message
+):
+    import torch
+
+    monkeypatch.setattr(pm, "_cached_platform", platform)
+    calls = iter(device_counts)
+
+    def device_count():
+        result = next(calls)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(torch.cuda, "device_count", device_count)
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": job_id},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+        assert message in resp["error"]["message"]
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
 def test_jsonrpc_start_keep_out_of_range_gpu_ids_returns_invalid_params(monkeypatch):
     import torch
 

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -143,6 +143,59 @@ def test_run_blocking_preserves_cuda_visible_devices_for_gpu_ids(monkeypatch):
     }
 
 
+def test_run_blocking_defers_omitted_gpu_enumeration_to_global_controller(
+    monkeypatch,
+):
+    import torch
+
+    captured = {}
+
+    class DummyGlobalController:
+        def __init__(self, *, gpu_ids, interval, vram_to_keep, busy_threshold):
+            captured["gpu_ids"] = gpu_ids
+            captured["interval"] = interval
+            captured["vram_to_keep"] = vram_to_keep
+            captured["busy_threshold"] = busy_threshold
+
+        def __enter__(self):
+            captured["entered"] = True
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            captured["exited"] = True
+
+    import keep_gpu.global_gpu_controller.global_gpu_controller as global_module
+
+    monkeypatch.setattr(global_module, "GlobalGPUController", DummyGlobalController)
+
+    def fail_device_count():
+        raise AssertionError("blocking mode should defer GPU enumeration")
+
+    monkeypatch.setattr(torch.cuda, "device_count", fail_device_count)
+
+    def interrupt_sleep(_seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli.time, "sleep", interrupt_sleep)
+
+    cli._run_blocking(
+        interval=1,
+        gpu_ids=None,
+        vram="1MiB",
+        legacy_threshold=None,
+        busy_threshold=-1,
+    )
+
+    assert captured == {
+        "gpu_ids": None,
+        "interval": 1,
+        "vram_to_keep": "1MiB",
+        "busy_threshold": -1,
+        "entered": True,
+        "exited": True,
+    }
+
+
 @pytest.mark.parametrize(
     ("busy_threshold", "expected_message", "forbidden_message"),
     [

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -88,6 +88,17 @@ def test_validate_visible_rank_rejects_zero_visible_count_with_clear_message():
         validate_visible_rank(0, 0)
 
 
+def test_validate_visible_rank_selection_failures_are_typed_value_errors():
+    error_type = getattr(session_config, "VisibleRankValidationError", None)
+    assert error_type is not None
+    assert issubclass(error_type, ValueError)
+
+    with pytest.raises(error_type, match="no visible GPUs are available"):
+        validate_visible_rank(0, 0)
+    with pytest.raises(error_type, match="rank must be a visible device ordinal"):
+        validate_visible_rank(2, 2)
+
+
 @pytest.mark.parametrize("rank", [-1, 2])
 def test_validate_visible_rank_rejects_out_of_range_rank(rank):
     with pytest.raises(ValueError, match="rank must be a visible device ordinal"):


### PR DESCRIPTION
## Summary
- classify CUDA/ROCm visible-device enumeration failures as startup-unavailable instead of internal errors across direct JSON-RPC, MCP tools, REST session creation, and blocking CLI startup
- centralize torch visible-device counting in `platform_manager`, add typed visible-rank selection errors, and keep invalid explicit `gpu_ids` as invalid params when the visible set is known
- keep the patch compact: production changes are small helpers/mappings, repeated JSON-RPC/REST tests are parameterized, and the plan doc is a short design record

## Local and hosted review
- local spec/API review: no Critical/Important findings after fixes
- local code-quality review: minor string-matching concern resolved with `VisibleRankValidationError`
- Gemini REST listing failure comment fixed by mapping `DeviceEnumerationUnavailableError` from `list_gpus()` to structured 503
- follow-up slimming pass reduced the diff from 442 insertions to 308 insertions without dropping scenario coverage

## Test plan
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_jsonrpc_start_keep_device_enumeration_unavailable_returns_startup_unavailable tests/mcp/test_server.py::test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code tests/mcp/test_http_api.py::test_http_start_reports_startup_unavailable_when_gpu_listing_unusable tests/test_cli_thresholds.py::test_run_blocking_defers_omitted_gpu_enumeration_to_global_controller tests/utilities/test_session_config.py::test_validate_visible_rank_selection_failures_are_typed_value_errors -q` -> 10 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_thresholds.py tests/mcp/test_server.py tests/mcp/test_http_api.py tests/global_controller tests/cuda_controller tests/rocm_controller tests/utilities -q` -> 436 passed, 7 skipped
- `PYTHONPATH=$PWD/src pytest tests -q` -> 664 passed, 11 skipped
- `pre-commit run --all-files` -> passed
- `PYTHONPATH=$PWD/src mkdocs build` -> passed with existing Material warning and unnav'd plan notices
- `git diff --check` -> passed