### PR TITLE
[status,cli,mcp] fix: harden status payload contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,8 @@ This file defines how coding agents should work in this repository.
 - CLI method-specific result validation must include nested records consumed by
   downstream tools: `status.active_jobs` entries, `stop_keep` job-id lists and
   error values, and `list_gpus` GPU records with visible ordinal metadata.
+  Known nested `status.params` fields must match the public session contract
+  while extra fields remain forward-compatible.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`
@@ -177,6 +179,8 @@ This file defines how coding agents should work in this repository.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
+- Status responses must be read-only snapshots. Returning active or starting
+  session params must not expose the mutable objects stored in service state.
 - Release paths must be idempotent after timeout: when a previously stopping
   worker has since died, perform backend cache cleanup and clear stale thread
   and stop-event state instead of returning early as not running.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -139,6 +139,9 @@ session state changes.
 Status calls show reserved jobs as `state="starting"` while controller startup
 is still in progress. That includes both `status(job_id)` and the all-session
 `status()` list, so agents do not mistake an in-progress start for no session.
+Returned session `params` are snapshots; local embedding callers can inspect
+or modify the returned object without mutating service state. Known fields in
+`params` follow the same public session contract as `start_keep`.
 If an already-started worker later reports a terminal runtime or allocation
 failure, the retained session is refreshed to `state="runtime_failed"` with
 `last_error`. It remains visible and stoppable. This is distinct from normal

--- a/docs/plans/status-payload-contract.md
+++ b/docs/plans/status-payload-contract.md
@@ -1,0 +1,20 @@
+# Status Payload Contract Plan
+
+## Goal
+
+Keep status responses read-only and reject malformed known session params before the CLI renders them as success.
+
+## Scope
+
+- Snapshot server status params for active and starting sessions.
+- Validate known nested status params in CLI result handling.
+- Keep extra params forward-compatible and avoid broad schema machinery.
+
+## Tasks
+
+- [x] Add failing tests for active and starting status param snapshots.
+- [x] Add failing CLI tests for malformed known `status.params` fields.
+- [x] Implement a tiny status params snapshot helper in `src/keep_gpu/mcp/server.py`.
+- [x] Implement optional known-field status params validation in `src/keep_gpu/cli.py`.
+- [x] Update `AGENTS.md` and MCP docs with the status payload contract.
+- [ ] Run targeted tests, local code review, PR checks, then squash merge.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -669,17 +669,34 @@ def _require_nullable_int_field(
     return value
 
 
+def _validate_status_params(params: Dict[str, Any], method: str, prefix: str) -> None:
+    validators = {
+        "gpu_ids": validate_gpu_ids,
+        "interval": validate_interval,
+        "busy_threshold": validate_busy_threshold,
+        "vram": parse_vram_to_elements,
+    }
+    for field, validator in validators.items():
+        if field not in params:
+            continue
+        try:
+            validator(params[field])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise _malformed_method_result(method, f"{prefix}.{field}: {exc}") from exc
+
+
 def _validate_status_session_record(
     record: Dict[str, Any], method: str, prefix: str
 ) -> None:
     try:
         _require_string_field(record, "job_id", method)
-        _require_dict_field(record, "params", method)
+        params = _require_dict_field(record, "params", method)
         _require_string_field(record, "state", method)
         _require_nullable_string_field(record, "last_error", method)
     except ServiceResponseError as exc:
         detail = str(exc).split(": ", 1)[-1]
         raise _malformed_method_result(method, f"{prefix}.{detail}") from exc
+    _validate_status_params(params, method, f"{prefix}.params")
 
 
 def _validate_status_result(

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -28,7 +28,6 @@ HTTP endpoints:
 from __future__ import annotations
 
 import atexit
-import copy
 import ipaddress
 import json
 import sys
@@ -498,7 +497,10 @@ class KeepGPUServer:
 
     @staticmethod
     def _status_params_snapshot(params: Dict[str, Any]) -> Dict[str, Any]:
-        return copy.deepcopy(params)
+        snapshot = dict(params)
+        if isinstance(snapshot.get("gpu_ids"), list):
+            snapshot["gpu_ids"] = list(snapshot["gpu_ids"])
+        return snapshot
 
     def stop_keep(
         self, job_id: Optional[str] = None, quiet: bool = False

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -28,6 +28,7 @@ HTTP endpoints:
 from __future__ import annotations
 
 import atexit
+import copy
 import ipaddress
 import json
 import sys
@@ -490,10 +491,14 @@ class KeepGPUServer:
         pending_stop = job_id in self._pending_stop_job_ids
         return {
             "job_id": job_id,
-            "params": params,
+            "params": self._status_params_snapshot(params),
             "state": "stopping" if pending_stop else "starting",
             "last_error": self._timeout_error_message() if pending_stop else None,
         }
+
+    @staticmethod
+    def _status_params_snapshot(params: Dict[str, Any]) -> Dict[str, Any]:
+        return copy.deepcopy(params)
 
     def stop_keep(
         self, job_id: Optional[str] = None, quiet: bool = False
@@ -648,7 +653,7 @@ class KeepGPUServer:
                 return {
                     "active": True,
                     "job_id": job_id,
-                    "params": session.params,
+                    "params": self._status_params_snapshot(session.params),
                     "state": session.state,
                     "last_error": session.last_error,
                 }
@@ -663,7 +668,7 @@ class KeepGPUServer:
                 + [
                     {
                         "job_id": jid,
-                        "params": sess.params,
+                        "params": self._status_params_snapshot(sess.params),
                         "state": sess.state,
                         "last_error": sess.last_error,
                     }

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -134,6 +134,25 @@ def test_start_status_stop_cycle():
     assert server.status(job_id)["active"] is False
 
 
+def test_status_returns_param_snapshots_for_active_sessions():
+    server = make_server()
+    job_id = server.start_keep(job_id="snapshot-job", gpu_ids=[0])["job_id"]
+
+    single_status = server.status(job_id)
+    single_status["params"]["gpu_ids"].append(99)
+    single_status["params"]["vram"] = "8GiB"
+
+    all_status = server.status()
+    all_status["active_jobs"][0]["params"]["gpu_ids"].append(42)
+
+    assert server.status(job_id)["params"] == {
+        "gpu_ids": [0],
+        "vram": "1GiB",
+        "interval": 300,
+        "busy_threshold": 25,
+    }
+
+
 def test_start_keep_preserves_fractional_interval():
     server = make_server()
 
@@ -320,6 +339,11 @@ def test_status_reports_starting_session_during_controller_keep():
                 "last_error": None,
             }
         ]
+        single_status = server.status("starting-job")
+        single_status["params"]["gpu_ids"].append(99)
+        list_status = server.status()
+        list_status["active_jobs"][0]["params"]["gpu_ids"].append(42)
+        assert server.status("starting-job")["params"] == expected_params
     finally:
         keep_release.set()
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -784,6 +784,42 @@ def test_status_rejects_malformed_active_job_entries(monkeypatch, payload):
 
 
 @pytest.mark.parametrize(
+    "session_params",
+    [
+        {"gpu_ids": "all"},
+        {"gpu_ids": []},
+        {"interval": -1},
+        {"busy_threshold": 101},
+        {"vram": []},
+    ],
+)
+def test_status_rejects_malformed_known_session_params(monkeypatch, session_params):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {}
+        return {
+            "active_jobs": [
+                {
+                    "job_id": "job-1",
+                    "params": session_params,
+                    "state": "active",
+                    "last_error": None,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert "active_jobs[0].params" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         {},


### PR DESCRIPTION
## Summary
- Return snapshot copies of active and starting session params from `KeepGPUServer.status()`.
- Validate known nested `status.params` fields in CLI service responses before rendering success JSON.
- Document the status payload contract in `AGENTS.md`, `docs/guides/mcp.md`, and the concise plan record.

## Test Plan
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py -q` (`303 passed`)
- [x] `PYTHONPATH=$PWD/src pytest -q` (`670 passed, 11 skipped`)
- [x] `pre-commit run --all-files`
- [x] `PYTHONPATH=$PWD/src mkdocs build` (passes with existing Material warning and unnav'd plan notices)
- [x] `git diff --check`
- [x] Local subagent review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `status` responses now return read-only session snapshots, reducing the risk of accidental changes from inspection or tooling.

* **Bug Fixes**
  * Improved validation for session parameters shown in `status`, with clearer field-specific error messages.
  * Malformed parameter values are now rejected instead of being treated as valid status output.

* **Documentation**
  * Updated guidance and planning docs to clarify the expected `status` payload behavior and compatibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->