### PR TITLE
[gpu-info,docs] fix: reject hidden cuda mask fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,11 +243,12 @@ This file defines how coding agents should work in this repository.
   physical/vendor identifiers belong in explicit metadata fields such as
   `physical_id` and must not be accepted implicitly as selection IDs. CUDA NVML
   records must only be returned when Torch CUDA can address the same visible
-  ordinal set; do not advertise NVML-only devices that controller startup
-  cannot use. ROCm records must likewise be limited to visible ordinals that
-  `torch.cuda.set_device()` can select; nullable ROCm memory fields mean memory
-  telemetry is unavailable after successful selection, not that the device is
-  unstartable.
+  ordinal set, and malformed or duplicate CUDA visibility masks must not fall
+  back to guessed Torch records; do not advertise NVML-only devices that
+  controller startup cannot use. ROCm records must likewise be limited to
+  visible ordinals that `torch.cuda.set_device()` can select; nullable ROCm
+  memory fields mean memory telemetry is unavailable after successful
+  selection, not that the device is unstartable.
 - Keep GPU listing platform precedence aligned with controller platform
   detection: HIP/ROCm torch builds must prefer ROCm listing over NVML CUDA
   listing, and must not fall back to NVML CUDA records when torch's active

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Flags that matter:
     `id` is the visible ordinal accepted by `--gpu-ids`; optional
     `physical_id`/`uuid` fields are metadata only. CUDA and ROCm devices are
     listed only when Torch can select the same visible ordinal; NVML-only or
-    unselectable ROCm inventory is hidden instead of producing unusable
-    `gpu_ids`.
+    malformed CUDA mask or unselectable ROCm inventory is hidden instead of
+    producing unusable `gpu_ids`.
   - `status`, `stop`, and `list-gpus` print structured JSON objects, including
     `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
     that tools such as `jq` can parse directly. Malformed JSON-RPC service

--- a/docs/plans/cuda-mask-no-torch-fallback.md
+++ b/docs/plans/cuda-mask-no-torch-fallback.md
@@ -1,0 +1,22 @@
+# CUDA Mask Fallback Plan
+
+## Goal
+
+Do not advertise Torch fallback CUDA records when `CUDA_VISIBLE_DEVICES` is malformed.
+
+## Scope
+
+- Preserve valid-mask Torch fallback behavior for start-compatible visible ordinals.
+- Treat malformed/duplicate CUDA masks as unavailable listing state, not as "all hidden" or "guess with Torch".
+- Keep the change inside `gpu_info.py` with focused utility tests.
+
+## Tasks
+
+- [x] Add failing tests for malformed CUDA masks with Torch fallback available.
+- [x] Add a small mask-state helper that distinguishes hidden-all, valid tokens, and invalid masks.
+- [x] Use the invalid-mask state to skip CUDA Torch fallback while preserving MPS fallback.
+- [x] Update `AGENTS.md` and docs after tightening the listing contract.
+- [x] Run targeted/full tests, docs build, and pre-commit.
+- [x] Address local review finding for equivalent duplicate mask tokens such as `0,00`.
+- [x] Address hosted review finding for Unicode digit masks such as `\u00b2`.
+- [x] Run local review; PR checks and squash merge are tracked on GitHub.

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -14,24 +15,50 @@ from keep_gpu.utilities.rocm_visibility import (
 logger = setup_logger(__name__)
 
 
+@dataclass(frozen=True)
+class _CudaVisibleMask:
+    tokens: Optional[List[str]]
+    invalid: bool = False
+
+    @property
+    def permits_torch_fallback(self) -> bool:
+        return not self.invalid and (self.tokens is None or bool(self.tokens))
+
+
+def _is_cuda_visible_index_token(token: str) -> bool:
+    return token.isascii() and token.isdigit()
+
+
+def _cuda_visible_token_key(token: str) -> tuple[str, int | str]:
+    if _is_cuda_visible_index_token(token):
+        return ("index", int(token))
+    return ("token", token.lower())
+
+
 def _decode_nvml_text(value: Any) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="ignore")
     return str(value)
 
 
-def _cuda_visible_tokens() -> Optional[List[str]]:
+def _cuda_visible_mask() -> _CudaVisibleMask:
     raw = os.environ.get("CUDA_VISIBLE_DEVICES")
     if raw is None:
-        return None
+        return _CudaVisibleMask(tokens=None)
     if raw.strip() in {"", "-1"}:
-        return []
+        return _CudaVisibleMask(tokens=[])
     tokens = [token.strip() for token in raw.split(",")]
-    if any(not token or token == "-1" for token in tokens):
-        return []
-    if len(set(tokens)) != len(tokens):
-        return []
-    return tokens
+    if any(
+        not token
+        or token == "-1"
+        or (token.isdigit() and not _is_cuda_visible_index_token(token))
+        for token in tokens
+    ):
+        return _CudaVisibleMask(tokens=[], invalid=True)
+    token_keys = [_cuda_visible_token_key(token) for token in tokens]
+    if len(set(token_keys)) != len(token_keys):
+        return _CudaVisibleMask(tokens=[], invalid=True)
+    return _CudaVisibleMask(tokens=tokens)
 
 
 def _torch_cuda_visible_count() -> Optional[int]:
@@ -145,7 +172,10 @@ def _query_nvml() -> List[Dict[str, Any]]:
     infos: List[Dict[str, Any]] = []
     try:
         count = pynvml.nvmlDeviceGetCount()
-        visible_tokens = _cuda_visible_tokens()
+        visible_mask = _cuda_visible_mask()
+        if visible_mask.invalid:
+            return []
+        visible_tokens = visible_mask.tokens
         if visible_tokens is None:
             visible_tokens = [str(idx) for idx in range(count)]
 
@@ -158,13 +188,13 @@ def _query_nvml() -> List[Dict[str, Any]]:
             return []
 
         for token in visible_tokens:
-            if token.isdigit() and int(token) >= count:
+            if _is_cuda_visible_index_token(token) and int(token) >= count:
                 return []
 
         visible_handles = []
         seen_physical_ids = set()
         for visible_id, token in enumerate(visible_tokens):
-            physical_id = int(token) if token.isdigit() else None
+            physical_id = int(token) if _is_cuda_visible_index_token(token) else None
             try:
                 handle = (
                     pynvml.nvmlDeviceGetHandleByIndex(physical_id)
@@ -379,6 +409,7 @@ def get_gpu_info() -> List[Dict[str, Any]]:
             logger.debug("Torch GPU info failed: %s", exc)
         return _query_mps()
 
+    cuda_visible_mask = _cuda_visible_mask()
     try:
         infos = _query_nvml()
         if infos:
@@ -386,12 +417,13 @@ def get_gpu_info() -> List[Dict[str, Any]]:
     except Exception as exc:
         logger.debug("NVML info failed: %s", exc)
 
-    try:
-        infos = _query_torch()
-        if infos:
-            return infos
-    except Exception as exc:
-        logger.debug("Torch GPU info failed: %s", exc)
+    if cuda_visible_mask.permits_torch_fallback:
+        try:
+            infos = _query_torch()
+            if infos:
+                return infos
+        except Exception as exc:
+            logger.debug("Torch GPU info failed: %s", exc)
 
     return _query_mps()
 

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -372,6 +372,21 @@ def test_get_gpu_info_nvml_malformed_cuda_visible_devices_hides_all(monkeypatch)
     assert dummy_nvml.shutdown_calls == 1
 
 
+@pytest.mark.parametrize(
+    "mask",
+    ["", "-1", "0,,2", "0,0", "0,00", "GPU-abc123,gpu-abc123", "-1,0", "\u00b2"],
+)
+def test_get_gpu_info_cuda_hidden_or_invalid_mask_does_not_fall_back_to_torch(
+    monkeypatch, mask
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    dummy_cuda = _install_cuda_gpu_info_mocks(monkeypatch, count=1)
+
+    assert gpu_info.get_gpu_info() == []
+    assert dummy_cuda.set_devices == []
+
+
 def test_get_gpu_info_nvml_out_of_range_cuda_visible_devices_hides_all(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Distinguish hidden and invalid `CUDA_VISIBLE_DEVICES` masks from valid CUDA listing masks.
- Skip guessed `torch.cuda` fallback records when CUDA is hidden, malformed, or contains equivalent duplicate tokens such as `0,00`.
- Keep the docs footprint narrow: `AGENTS.md`, `README.md`, and the implementation plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py::test_get_gpu_info_cuda_hidden_or_invalid_mask_does_not_fall_back_to_torch -q`
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_info.py tests/utilities/test_gpu_monitor.py tests/utilities/test_platform_manager.py -q`
- `PYTHONPATH=$PWD/src pytest -q`
- `pre-commit run --all-files`
- `PYTHONPATH=$PWD/src mkdocs build`
- `git diff --check`

## Local Review
- Ptolemy: no findings; ready to merge; verified small-repo fit and test scope.
- Dewey: found equivalent duplicate mask leak (`0,00` / case-insensitive UUID aliases); fixed with normalized duplicate keys.
- Bacon: follow-up re-review found no findings; `tests/utilities/test_gpu_info.py` passed and diff whitespace was clean.
