### PR TITLE
[cli,docs] fix: validate stop outcome consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,10 +114,11 @@ This file defines how coding agents should work in this repository.
   call sites before reading fields or triggering daemon stop side effects, while
   allowing extra result fields for forward compatibility.
 - CLI method-specific result validation must include nested records consumed by
-  downstream tools: `status.active_jobs` entries, `stop_keep` job-id lists and
-  error values, and `list_gpus` GPU records with visible ordinal metadata.
-  Known nested `status.params` fields must match the public session contract
-  while extra fields remain forward-compatible.
+  downstream tools: `status.active_jobs` entries, disjoint `stop_keep` job-id
+  outcome lists whose `errors` keys exactly match `failed`, and `list_gpus` GPU
+  records with visible ordinal metadata. Known nested `status.params` fields
+  must match the public session contract while extra fields remain
+  forward-compatible.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ to zero devices.
 - Stop responses distinguish completed cleanup from partial cleanup:
   `stopped` means released, while `timed_out` sessions remain visible as
   `stopping` until background cleanup completes and `failed` sessions remain
-  visible with `state` and `last_error`.
+  visible with `state` and `last_error`. The outcome lists are disjoint, and
+  `errors` contains one message for each `failed` job only.
 - Status and stop requests both account for in-progress starts: status reports
   them as `starting`, and stop waits for startup to settle so a session is not
   reported as missing or skipped by stop-all. That startup wait is bounded; if

--- a/docs/plans/validate-stop-payload-consistency.md
+++ b/docs/plans/validate-stop-payload-consistency.md
@@ -1,0 +1,45 @@
+# Validate Stop Payload Consistency
+
+## Background
+
+The CLI validates `stop_keep` service results before rendering JSON output or
+triggering daemon stop side effects. It already checks the required field types,
+but it does not reject internally inconsistent additive outcomes.
+
+## Goal
+
+Reject malformed `stop_keep` results when a job id appears more than once, appears
+in more than one outcome list, or when the `errors` mapping does not correspond
+exactly to the `failed` list.
+
+## Solution
+
+Keep the check in `src/keep_gpu/cli.py` alongside the existing method-specific
+payload validation. The server contract remains unchanged: `stopped`,
+`timed_out`, and `failed` are disjoint job-id lists, and `errors` contains one
+string error for each failed job only.
+
+## Todo
+
+- [x] Add focused RED tests in `tests/test_cli_service_commands.py` for duplicate
+      job ids, cross-list job ids, missing failed errors, and stray error keys.
+- [x] Update `_validate_stop_keep_result()` with minimal consistency checks.
+- [x] Clarify the CLI contract in `AGENTS.md` and user docs where stop payloads
+      are described.
+- [x] Run targeted CLI stop tests, broader CLI service tests, full pytest,
+      pre-commit, and docs build before opening the PR.
+
+## Verification
+
+- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'stop_job_rejects_inconsistent_outcome_payloads or stop_all_rejects_inconsistent_payload_before_stopping_daemon'`
+  failed with six exit-code assertions before the validator change.
+- GREEN: the same command passed with `6 passed, 184 deselected`.
+- Focused: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'stop_job_outputs_single_decoded_json_object or stop_job_rejects_malformed_payloads or stop_job_rejects_malformed_job_id_lists_and_errors or stop_job_rejects_inconsistent_outcome_payloads or stop_all_outputs_single_decoded_json_object or stop_all_rejects_malformed_payload or stop_all_rejects_inconsistent_payload_before_stopping_daemon or service_stop_rejects_malformed_stop_keep_before_stopping_daemon'`
+  passed with `22 passed, 168 deselected`.
+- CLI service: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
+  passed with `190 passed`.
+- Full suite: `PYTHONPATH=$PWD/src pytest tests -q` passed with
+  `691 passed, 11 skipped`.
+- Quality: `pre-commit run --all-files` passed.
+- Docs: plain `mkdocs build` could not import `keep_gpu`; `PYTHONPATH=$PWD/src mkdocs build`
+  passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -723,19 +723,42 @@ def _validate_status_result(
 
 
 def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    outcomes: Dict[str, List[str]] = {}
+    seen_jobs: Dict[str, str] = {}
     for field in ("stopped", "timed_out", "failed"):
         value = _require_list_field(result, field, "stop_keep")
+        outcomes[field] = value
+        field_jobs = set()
         for index, job_id in enumerate(value):
             if not isinstance(job_id, str):
                 raise _malformed_method_result(
                     "stop_keep", f"{field}[{index}] must be a string"
                 )
+            if job_id in field_jobs:
+                raise _malformed_method_result(
+                    "stop_keep", f"{field}[{index}] duplicates job id"
+                )
+            field_jobs.add(job_id)
+            if job_id in seen_jobs:
+                raise _malformed_method_result(
+                    "stop_keep",
+                    f"{job_id!r} appears in both {seen_jobs[job_id]} and {field}",
+                )
+            seen_jobs[job_id] = field
     errors = _require_dict_field(result, "errors", "stop_keep")
     for job_id, error in errors.items():
+        if not isinstance(job_id, str):
+            raise _malformed_method_result("stop_keep", "errors keys must be strings")
         if not isinstance(error, str):
             raise _malformed_method_result(
                 "stop_keep", f"errors[{job_id!r}] must be a string"
             )
+    failed_jobs = set(outcomes["failed"])
+    error_jobs = set(errors)
+    if failed_jobs != error_jobs:
+        raise _malformed_method_result(
+            "stop_keep", "errors keys must match failed job ids"
+        )
     message = result.get("message")
     if "message" in result and not isinstance(message, str):
         raise _malformed_method_result("stop_keep", "message must be a string")

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -983,6 +983,43 @@ def test_stop_job_rejects_malformed_job_id_lists_and_errors(monkeypatch, payload
     assert "Traceback" not in result.output
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"stopped": ["job-1", "job-1"], "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": ["job-1"], "timed_out": ["job-1"], "failed": [], "errors": {}},
+        {
+            "stopped": ["job-1"],
+            "timed_out": [],
+            "failed": ["job-1"],
+            "errors": {"job-1": "boom"},
+        },
+        {"stopped": [], "timed_out": [], "failed": ["job-1"], "errors": {}},
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": [],
+            "errors": {"job-1": "boom"},
+        },
+    ],
+)
+def test_stop_job_rejects_inconsistent_outcome_payloads(monkeypatch, payload):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "job-1"}
+        assert timeout == 45.0
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
 def test_stop_all_outputs_single_decoded_json_object(monkeypatch):
     monkeypatch.setattr(
         cli,
@@ -1010,6 +1047,38 @@ def test_stop_all_rejects_malformed_payload(monkeypatch):
         assert params == {}
         assert timeout == 45.0
         return {"stopped": []}
+
+    def fake_stop_process(host, port):
+        called["stop_process"] = True
+        raise AssertionError("_stop_service_process must not be called")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert called["stop_process"] is False
+    assert "Traceback" not in result.output
+
+
+def test_stop_all_rejects_inconsistent_payload_before_stopping_daemon(monkeypatch):
+    called = {"stop_process": False}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {}
+        assert timeout == 45.0
+        return {
+            "stopped": ["job-1"],
+            "timed_out": [],
+            "failed": ["job-1"],
+            "errors": {"job-1": "boom"},
+        }
 
     def fake_stop_process(host, port):
         called["stop_process"] = True


### PR DESCRIPTION
## Summary
- reject inconsistent `stop_keep` service payloads in the CLI before rendering output or triggering daemon stop side effects
- require stop outcome lists to be disjoint and require `errors` keys to match `failed` exactly
- document the clarified stop result contract in `README.md`, `AGENTS.md`, and the plan note

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'stop_job_rejects_inconsistent_outcome_payloads or stop_all_rejects_inconsistent_payload_before_stopping_daemon'` failed before the validator change with six exit-code assertions
- [x] GREEN: same command passed with `6 passed, 184 deselected`
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'stop_job_outputs_single_decoded_json_object or stop_job_rejects_malformed_payloads or stop_job_rejects_malformed_job_id_lists_and_errors or stop_job_rejects_inconsistent_outcome_payloads or stop_all_outputs_single_decoded_json_object or stop_all_rejects_malformed_payload or stop_all_rejects_inconsistent_payload_before_stopping_daemon or service_stop_rejects_malformed_stop_keep_before_stopping_daemon'`
- [x] `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- [x] `PYTHONPATH=$PWD/src pytest tests -q`
- [x] `pre-commit run --all-files`
- [x] `PYTHONPATH=$PWD/src mkdocs build`

## Local Review
- [x] Local subagent code review: no critical, important, or minor issues; reviewer reran `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` with `190 passed`.
