### PR TITLE
[dashboard] test: remove unused integer parser

### DIFF
--- a/web/dashboard/src/lib/session.js
+++ b/web/dashboard/src/lib/session.js
@@ -16,14 +16,6 @@ export function parseGpuIds(raw) {
   return parts.map((part) => Number(part))
 }
 
-export function parsePositiveInt(value, fieldName) {
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(`${fieldName} must be an integer >= 1`)
-  }
-  return parsed
-}
-
 export function parsePositiveNumber(value, fieldName) {
   if (typeof value === "boolean") {
     throw new Error(`${fieldName} must be finite and positive`)

--- a/web/dashboard/src/lib/session.test.js
+++ b/web/dashboard/src/lib/session.test.js
@@ -14,7 +14,6 @@ import {
   isSessionStopping,
   parseBusyThreshold,
   parseGpuIds,
-  parsePositiveInt,
   parsePositiveNumber,
   summarizeDashboardStats
 } from "./session"
@@ -49,11 +48,6 @@ describe("numeric parsing", () => {
     expect(() => parsePositiveNumber("0", "Interval")).toThrow()
     expect(() => parsePositiveNumber("NaN", "Interval")).toThrow()
     expect(() => parsePositiveNumber("Infinity", "Interval")).toThrow()
-  })
-
-  it("keeps integer-only helpers strict", () => {
-    expect(parsePositiveInt("5", "Iteration count")).toBe(5)
-    expect(() => parsePositiveInt("0.5", "Iteration count")).toThrow()
   })
 
   it("validates busy threshold", () => {


### PR DESCRIPTION
## Summary
- remove the unused dashboard `parsePositiveInt()` helper
- remove the self-only test that existed only to exercise that dead helper
- keep the active dashboard payload path on `parsePositiveNumber()` for fractional intervals and `parseBusyThreshold()` for threshold validation

## Test Plan
- [x] Baseline before deletion: `npm test` in `web/dashboard` passed with `43 passed` after `npm ci`
- [x] `rg -n "parsePositiveInt" web/dashboard src tests docs README.md AGENTS.md` found no remaining references after deletion
- [x] `npm test` in `web/dashboard` passed with `42 passed`
- [x] `npm run build` in `web/dashboard` passed and produced no tracked static asset diff
- [x] `PYTHONPATH=$PWD/src pytest tests -q` passed with `690 passed, 11 skipped`
- [x] `pre-commit run --all-files`
- [x] `PYTHONPATH=$PWD/src mkdocs build`

## Local Review
- [x] Local subagent code review found no critical, important, or minor issues and reran dashboard test/build checks successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric input handling for session setup, making validation more consistent for positive values.
  * Updated related checks so invalid values are rejected more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->