### PR TITLE
[http,docs] fix: return json for api root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,9 @@ This file defines how coding agents should work in this repository.
   JSON-RPC `-32700` parse-error envelopes.
 - API/RPC unsupported HTTP methods must not fall back to
   `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
-  JSON `405 Method Not Allowed` responses with `Allow`, and unknown `/api/*`
-  routes return structured JSON `404 Unknown endpoint` responses.
+  JSON `405 Method Not Allowed` responses with `Allow`, and exact `/api` plus
+  unknown `/api/*` routes return structured JSON `404 Unknown endpoint`
+  responses.
 - Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)
   must call the shared unsupported-method helper before local unknown-endpoint
   404 branches, so known paths never regress to 404 or body-parse errors solely

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -8,6 +8,8 @@ KeepGPU ships a local service that powers three interfaces:
 - Dashboard UI (`/`)
 
 This is the same backend used by `keep-gpu start/status/stop/list-gpus`.
+Exact `/api` and unknown `/api/*` paths return structured JSON `404` errors
+instead of dashboard HTML.
 
 ## Start service
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -995,6 +995,10 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             return ("POST",)
         return None
 
+    @staticmethod
+    def _is_api_path(path: str) -> bool:
+        return path == "/api" or path.startswith("/api/")
+
     def _send_api_rpc_unsupported_method_response(self) -> bool:
         if not hasattr(self, "path") or not hasattr(self, "command"):
             return False
@@ -1010,7 +1014,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 write_body=write_body,
             )
             return True
-        if path.startswith("/api/"):
+        if self._is_api_path(path):
             self._json_response(
                 404,
                 {"error": {"message": "Unknown endpoint"}},
@@ -1139,7 +1143,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 self._json_response(200, server_ref.status(job_id=job_id))
                 return
 
-            if path.startswith("/api/"):
+            if self._is_api_path(path):
                 self._json_response(404, {"error": {"message": "Unknown endpoint"}})
                 return
 

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -292,13 +292,20 @@ def test_http_rpc_head_rejects_with_json_405_and_empty_body():
     assert body == b""
 
 
-@pytest.mark.parametrize("method", ["PUT", "OPTIONS"])
-def test_http_unknown_api_routes_reject_unsupported_methods_with_json_404(method):
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("PUT", "/api/unknown"),
+        ("OPTIONS", "/api/unknown"),
+        ("OPTIONS", "/api"),
+    ],
+)
+def test_http_unknown_api_routes_reject_unsupported_methods_with_json_404(method, path):
     server = make_server()
     httpd, thread, base = _start_http_server(server)
 
     try:
-        status, headers, body = _request_http_response(method, f"{base}/api/unknown")
+        status, headers, body = _request_http_response(method, f"{base}{path}")
     finally:
         httpd.shutdown()
         httpd.server_close()
@@ -1104,7 +1111,8 @@ def test_http_session_trailing_slash_rejected():
         thread.join(timeout=2)
 
 
-def test_http_unknown_api_route_returns_json_404():
+@pytest.mark.parametrize("path", ["/api/unknown", "/api"])
+def test_http_unknown_api_route_returns_json_404(path):
     server = make_server()
 
     class _Server(TCPServer):
@@ -1118,7 +1126,7 @@ def test_http_unknown_api_route_returns_json_404():
     base = f"http://127.0.0.1:{httpd.server_address[1]}"
 
     try:
-        status_code, payload = _request_json("GET", f"{base}/api/unknown")
+        status_code, payload = _request_json("GET", f"{base}{path}")
         assert status_code == 404
         assert payload["error"]["message"] == "Unknown endpoint"
     finally:


### PR DESCRIPTION
## Summary
- Treat exact `/api` as part of the API namespace so it returns structured JSON `404` instead of dashboard HTML.
- Route unsupported methods on `/api` through the structured JSON unknown-endpoint path instead of `BaseHTTPRequestHandler` HTML `501`.
- Update AGENTS.md and MCP service docs with the exact `/api` contract.

## TDD
- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k "api_root"` failed before the fix: `GET /api` returned `200`, and `HEAD/OPTIONS /api` returned `501`.
- GREEN: after the route classifier change, the focused unknown-route cases passed; tests were then trimmed into existing unknown API route coverage to avoid bloat.

## Verification
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k "unknown_api_route or unknown_api_routes"` (7 passed)
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` (81 passed)
- `PYTHONPATH=$PWD/src pytest tests/mcp -q` (209 passed)
- `PYTHONPATH=$PWD/src pytest tests -q` (705 passed, 11 skipped)
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files`
- `git diff --check`

## Local Review
- Routing-correctness reviewer: no blocking findings.
- Small-repo/test-doc proportionality reviewer: no blocking findings; no unnecessary plan docs added.
