### PR TITLE
[docs] docs: exclude internal artifacts from site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ This file defines how coding agents should work in this repository.
 - If the task is complex or ambiguous, propose a short plan and confirm it with the user before large changes.
 - Before starting complex work, capture background, goal, solution, and todo items in a Markdown plan under `docs/plans/`.
 - Implementations must follow the plan and its todo items; update the plan document when tasks or scope change.
+- `docs/plans/` and `docs/skills/` are internal source artifacts and are
+  excluded from the public MkDocs site.
 - If requirements are unclear during planning, ask the user early and proceed only after confirmation.
 - If a plan-related subagent exists, prefer calling it to draft/refine the plan.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,6 +49,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   ```bash
   mkdocs build
   ```
+- Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
+  stay in the repository but are excluded from the published MkDocs site.
 
 ## MCP server (experimental)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,10 @@ repo_url: https://github.com/Wangmerlyn/KeepGPU
 repo_name: Wangmerlyn/KeepGPU
 edit_uri: blob/main/docs/
 
+exclude_docs: |
+  plans/**
+  skills/**
+
 theme:
   name: material
   features:


### PR DESCRIPTION
## Summary
- Exclude internal `docs/plans/**` and `docs/skills/**` artifacts from the published MkDocs site.
- Document that those folders remain repository source artifacts, not public documentation pages.
- Keep the change conservative: no historical plan files deleted.

## RED/GREEN
- RED artifact check before the change: built site contained `plans=82 skills=1`.
- GREEN artifact check after the change: built site contains `plans=0 skills=0`, and strict MkDocs no longer reports unnav'd internal pages.

## Verification
- `rm -rf /tmp/keepgpu-docs-final && PYTHONPATH=$PWD/src mkdocs build --site-dir /tmp/keepgpu-docs-final ...` with `plans=0 skills=0`
- `PYTHONPATH=$PWD/src mkdocs build --strict --site-dir /tmp/keepgpu-docs-strict-final`
- `pre-commit run --all-files`
- `PYTHONPATH=$PWD/src pytest tests -q` (705 passed, 11 skipped)
- `git diff --check`

## Local Review
- MkDocs behavior reviewer: no blocking findings.
- Small-repo/docs proportionality reviewer: no blocking findings.
