### PR TITLE
[mcp,dashboard] fix: return 404 for missing static assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ This file defines how coding agents should work in this repository.
 - `/rpc` is a POST-only JSON-RPC endpoint; `GET /rpc` must return structured
   JSON `405 Method Not Allowed` with `Allow: POST` and must never serve the
   dashboard/static fallback.
+- Missing dashboard asset URLs, including `/assets/*` and extension-bearing
+  static paths, must return structured JSON `404` errors instead of the
+  dashboard HTML shell.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -10,6 +10,8 @@ KeepGPU ships a local service that powers three interfaces:
 This is the same backend used by `keep-gpu start/status/stop/list-gpus`.
 Exact `/api` and unknown `/api/*` paths return structured JSON `404` errors
 instead of dashboard HTML.
+Missing packaged asset URLs also return JSON `404` responses instead of the
+dashboard shell.
 
 ## Start service
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1067,13 +1067,26 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         else:
             relative = request_path.lstrip("/")
 
-        requested = (STATIC_DIR / unquote(relative)).resolve()
+        decoded_relative = unquote(relative)
+        requested = (STATIC_DIR / decoded_relative).resolve()
         static_root = STATIC_DIR.resolve()
         if static_root not in requested.parents and requested != static_root:
             self._json_response(403, {"error": {"message": "Forbidden"}})
             return
 
+        is_asset_request = (
+            decoded_relative == "assets"
+            or decoded_relative.startswith("assets/")
+            or (
+                bool(Path(decoded_relative).suffix) and decoded_relative != "index.html"
+            )
+        )
         if not requested.exists() or requested.is_dir():
+            if is_asset_request:
+                self._json_response(
+                    404, {"error": {"message": "Static asset not found"}}
+                )
+                return
             # SPA fallback for client-side routes.
             requested = static_root / "index.html"
             if not requested.exists():

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -486,6 +486,45 @@ def test_http_health_and_static_index():
         thread.join(timeout=2)
 
 
+@pytest.mark.parametrize("path", ["/assets/missing.js", "/missing.keepgpu-test.js"])
+def test_http_missing_static_asset_returns_404_not_dashboard_index(path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("GET", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get_content_type() == "application/json"
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Static asset not found"}
+    }
+
+
+def test_http_missing_dashboard_shell_reports_ui_not_built(monkeypatch, tmp_path):
+    monkeypatch.setattr(server_module, "STATIC_DIR", tmp_path)
+
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("GET", f"{base}/")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get_content_type() == "application/json"
+    assert json.loads(body.decode("utf-8")) == {"error": {"message": "UI not built"}}
+
+
 def test_http_session_lifecycle():
     server = make_server()
 


### PR DESCRIPTION
## Summary
- Return structured JSON 404 responses for missing dashboard asset URLs instead of serving the dashboard shell.
- Preserve dashboard root and extensionless SPA fallback behavior.
- Document the static asset 404 contract in AGENTS.md and MCP guide.

## Verification
- PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_missing_static_asset_returns_404_not_dashboard_index -q
- PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q
- PYTHONPATH=$PWD/src mkdocs build --strict --site-dir /tmp/keepgpu-docs-static-assets-404
- PYTHONPATH=$PWD/src pytest tests -q
- pre-commit run --all-files

## Local review
- Nietzsche: ready to merge; no critical or important issues; optional test assertion simplification addressed.
- Wegener: ready to merge; verified tests/mcp/test_http_api.py with 83 passed.
