### PR TITLE
[cli] fix: stop daemon after autostart timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,9 @@ This file defines how coding agents should work in this repository.
   `-32000` before creating a session, the CLI must best-effort stop that
   just-created daemon. Do not stop already-running daemons, malformed success
   payloads, or unrelated RPC failures.
+- If service auto-start itself times out before the health check succeeds, the
+  CLI must best-effort stop the just-started managed daemon and preserve the
+  auto-start timeout error.
 - Blocking-mode root CLI options (`--gpu-ids`, `--vram`,
   `--busy-threshold`/`--util-threshold`, hidden `--threshold`, and
   `--interval`) must be rejected when explicitly supplied before a service

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -31,6 +31,8 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 If this invocation auto-starts the service but session creation fails with an
 expected startup-unavailable error before a session is created, `start`
 best-effort stops the just-created daemon so it does not remain idle.
+If auto-start times out before the service becomes healthy, the CLI applies the
+same best-effort cleanup to the daemon it just started.
 
 Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,6 +48,8 @@ GPUs; explicit empty or whitespace-only values are invalid.
 If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
+The same best-effort cleanup runs when auto-start times out before the service
+passes its health check.
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -471,6 +471,14 @@ def _ensure_service_running(host: str, port: int, auto_start: bool = True) -> bo
             return True
         time.sleep(0.2)
 
+    try:
+        _stop_service_process(host, port, timeout=1.0)
+    except Exception:  # noqa: BLE001 - cleanup must not mask auto-start timeout
+        logger.debug(
+            "Failed to stop auto-started service after health-check timeout",
+            exc_info=True,
+        )
+
     raise RuntimeError(
         f"Failed to auto-start KeepGPU service at {host}:{port}. Try `keep-gpu serve` manually."
     )

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -650,6 +650,27 @@ def test_http_json_request_reports_invalid_utf8_as_service_response_error(monkey
         cli._http_json_request("GET", "http://127.0.0.1:8765/health")
 
 
+def test_ensure_service_running_stops_auto_started_process_on_health_timeout(
+    monkeypatch,
+):
+    stopped = []
+
+    monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: None)
+    monkeypatch.setattr(cli, "_start_service_process", lambda host, port: 4321)
+    monkeypatch.setattr(cli.time, "sleep", lambda seconds: None)
+
+    def fake_stop(host, port, timeout=3.0):
+        stopped.append((host, port, timeout))
+
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop)
+
+    with pytest.raises(RuntimeError, match="Failed to auto-start KeepGPU service"):
+        cli._ensure_service_running("127.0.0.1", 8765)
+
+    assert stopped == [("127.0.0.1", 8765, 1.0)]
+
+
 def test_status_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port):
         assert method == "status"


### PR DESCRIPTION
## Summary
- Stop the just-started managed service daemon when auto-start health polling times out.
- Preserve the original auto-start timeout error if cleanup itself fails.
- Document the timeout cleanup behavior in AGENTS.md and CLI docs.

## Verification
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_ensure_service_running_stops_auto_started_process_on_health_timeout -q
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_start_rolls_back_auto_started_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_does_not_stop_already_running_service_on_startup_unavailable tests/test_cli_service_commands.py::test_start_rollback_stop_failure_preserves_startup_error -q
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q
- PYTHONPATH=$PWD/src mkdocs build --strict --site-dir /tmp/keepgpu-docs-autostart-timeout-cleanup
- PYTHONPATH=$PWD/src pytest tests -q
- pre-commit run --all-files

## Local review
- Huygens: ready to merge; no critical or important issues. Suggested an optional cleanup-failure test.
- Kuhn: ready to merge; recommended not adding more tests/docs for this small regression.
- Decision: kept the PR small because cleanup failure is already guarded by an explicit try/except and the main orphan-daemon regression is covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `keep-gpu start` behavior when auto-start times out before the service becomes healthy. The CLI now attempts to clean up the newly started service and keeps the original timeout error visible.
* **Documentation**
  * Clarified service start guidance in the CLI docs and reference to explain the cleanup behavior on health-check timeout.
* **Tests**
  * Added coverage for the auto-start timeout cleanup path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->