### PR TITLE
[cli] fix: refuse daemon stop after incomplete session cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ This file defines how coding agents should work in this repository.
   has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
   must propagate synchronously so services cannot register false active sessions.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
-- Non-force `keep-gpu service-stop` must require a reachable service and a successful status/RPC check before signaling; use `--force` for unresponsive auto-started daemons.
+- Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
 - Stop requests must not miss starting sessions. Targeted stops wait for the

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -76,9 +76,9 @@ Explicit `--job-id` values use the same non-empty URL-path-safe validation as
 keep-gpu service-stop
 ```
 
-If sessions are still active, stop them first or use `--force`. Force mode skips
-the active-session RPC check, but it still stops only an ownership-verified
-daemon that KeepGPU auto-started.
+If sessions are still active, timed out, or failed to stop cleanly, resolve them
+first or use `--force`. Force mode skips the session RPC checks, but it still
+stops only an ownership-verified daemon that KeepGPU auto-started.
 
 ### List telemetry
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -123,12 +123,13 @@ non-integer or out-of-range ports, are reported as JSON errors before RPC.
 
 Stops the ownership-verified local daemon process created by auto-start logic.
 Invalid endpoint values are rejected locally before service checks or
-ownership-verified stop operations.
+ownership-verified stop operations. Non-force shutdown requires session checks
+to finish cleanly with no timed-out or failed stops.
 
 | Option | Description |
 | --- | --- |
 | `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be an integer in `1..65535`. |
-| `--force` | Skip active-session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
+| `--force` | Skip session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
 
 ## Service HTTP endpoints
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -773,6 +773,20 @@ def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _require_clean_stop_keep_for_service_stop(result: Dict[str, Any]) -> None:
+    incomplete = []
+    if result["timed_out"]:
+        incomplete.append(f"timed out: {', '.join(result['timed_out'])}")
+    if result["failed"]:
+        incomplete.append(f"failed: {', '.join(result['failed'])}")
+    if incomplete:
+        raise RuntimeError(
+            "Stop sessions before stopping the service daemon. Incomplete stop_keep result "
+            f"({'; '.join(incomplete)}). Resolve those sessions first, or use "
+            "`keep-gpu service-stop --force` for an unresponsive auto-started daemon."
+        )
+
+
 def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
     gpus = _require_list_field(result, "gpus", "list_gpus")
     visible_ids = set()
@@ -1228,7 +1242,8 @@ def service_stop(
                 "Tracked keep sessions detected. Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
             )
         stop_result = _rpc_call("stop_keep", {}, host, port, timeout=45.0)
-        _validate_stop_keep_result(stop_result)
+        stop_result = _validate_stop_keep_result(stop_result)
+        _require_clean_stop_keep_for_service_stop(stop_result)
 
         stopped = _stop_service_process(host, port)
         if not stopped:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1862,6 +1862,58 @@ def test_service_stop_rejects_malformed_stop_keep_before_stopping_daemon(
     assert "Traceback" not in result.output
 
 
+@pytest.mark.parametrize(
+    ("payload", "job_id"),
+    [
+        (
+            {
+                "stopped": [],
+                "timed_out": ["slow-job"],
+                "failed": [],
+                "errors": {},
+            },
+            "slow-job",
+        ),
+        (
+            {
+                "stopped": [],
+                "timed_out": [],
+                "failed": ["bad-job"],
+                "errors": {"bad-job": "release failed"},
+            },
+            "bad-job",
+        ),
+    ],
+)
+def test_service_stop_rejects_incomplete_stop_keep_before_stopping_daemon(
+    monkeypatch, payload, job_id
+):
+    calls = {"stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        if method == "stop_keep":
+            return payload
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert job_id in result.output
+    assert "keep-gpu" in result.output
+    assert "service-stop --force" in result.output
+    assert calls["stop_process"] == 0
+    assert "Traceback" not in result.output
+
+
 def test_service_stop_requires_live_status_without_force(monkeypatch):
     called = {"stop_process": False}
 


### PR DESCRIPTION
## Summary
- refuse non-force `keep-gpu service-stop` when `stop_keep` reports timed-out or failed sessions
- keep the daemon alive so unresolved sessions remain inspectable/stoppable unless the user explicitly chooses `--force`
- update CLI docs and AGENTS contract wording

## Verification
- `PYTHONPATH=src python -m pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py -q` -> 211 passed
- `PYTHONPATH=src python -m pytest -q` -> 711 passed, 11 skipped
- `python -m ruff check .` -> passed
- `mkdocs build --strict` -> passed with existing Material/MkDocs 2.0 warning
- `PYTHONPATH=src pre-commit run --all-files` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping the local daemon now performs stricter checks before shutdown, preventing stops when sessions are still timed out or failed to close cleanly.
  * If shutdown can’t complete cleanly, the command now provides clearer guidance to stop sessions first or retry with `--force` when appropriate.

* **Documentation**
  * Updated CLI guidance to better explain when `--force` is needed and what happens during daemon shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->