### PR TITLE
[telemetry] fix: share safe CUDA visibility parsing

### DIFF
--- a/src/keep_gpu/utilities/cuda_visibility.py
+++ b/src/keep_gpu/utilities/cuda_visibility.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+_MAX_DEVICE_ORDINAL_DIGITS = len(str(2**63 - 1))
+
+
+@dataclass(frozen=True)
+class CudaVisibleMask:
+    tokens: Optional[Tuple[str, ...]]
+    invalid: bool = False
+
+    @property
+    def permits_torch_fallback(self) -> bool:
+        return not self.invalid and (self.tokens is None or bool(self.tokens))
+
+
+def is_cuda_visible_index_token(token: str) -> bool:
+    return token.isascii() and token.isdigit()
+
+
+def cuda_visible_index_value(token: str) -> int | None:
+    if not is_cuda_visible_index_token(token):
+        return None
+    normalized = token.lstrip("0") or "0"
+    if len(normalized) > _MAX_DEVICE_ORDINAL_DIGITS:
+        return None
+    try:
+        return int(normalized)
+    except ValueError:
+        return None
+
+
+def cuda_visible_token_key(token: str) -> tuple[str, int | str] | None:
+    index_value = cuda_visible_index_value(token)
+    if index_value is not None:
+        return ("index", index_value)
+    if is_cuda_visible_index_token(token):
+        return None
+    return ("token", token.lower())
+
+
+def cuda_visible_mask() -> CudaVisibleMask:
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if raw is None:
+        return CudaVisibleMask(tokens=None)
+    if raw.strip() in {"", "-1"}:
+        return CudaVisibleMask(tokens=())
+
+    tokens = tuple(token.strip() for token in raw.split(","))
+    if any(not token or token == "-1" or not token.isascii() for token in tokens):
+        return CudaVisibleMask(tokens=(), invalid=True)
+
+    token_keys = []
+    for token in tokens:
+        token_key = cuda_visible_token_key(token)
+        if token_key is None:
+            return CudaVisibleMask(tokens=(), invalid=True)
+        token_keys.append(token_key)
+    if len(set(token_keys)) != len(token_keys):
+        return CudaVisibleMask(tokens=(), invalid=True)
+    return CudaVisibleMask(tokens=tokens)
+
+
+__all__ = [
+    "CudaVisibleMask",
+    "cuda_visible_index_value",
+    "cuda_visible_mask",
+    "cuda_visible_token_key",
+    "is_cuda_visible_index_token",
+]

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import torch
 
+from keep_gpu.utilities.cuda_visibility import (
+    cuda_visible_index_value,
+    cuda_visible_mask,
+)
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.rocm_visibility import (
     resolve_rocm_visible_rank_to_smi_index,
@@ -15,50 +17,10 @@ from keep_gpu.utilities.rocm_visibility import (
 logger = setup_logger(__name__)
 
 
-@dataclass(frozen=True)
-class _CudaVisibleMask:
-    tokens: Optional[List[str]]
-    invalid: bool = False
-
-    @property
-    def permits_torch_fallback(self) -> bool:
-        return not self.invalid and (self.tokens is None or bool(self.tokens))
-
-
-def _is_cuda_visible_index_token(token: str) -> bool:
-    return token.isascii() and token.isdigit()
-
-
-def _cuda_visible_token_key(token: str) -> tuple[str, int | str]:
-    if _is_cuda_visible_index_token(token):
-        return ("index", int(token))
-    return ("token", token.lower())
-
-
 def _decode_nvml_text(value: Any) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="ignore")
     return str(value)
-
-
-def _cuda_visible_mask() -> _CudaVisibleMask:
-    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if raw is None:
-        return _CudaVisibleMask(tokens=None)
-    if raw.strip() in {"", "-1"}:
-        return _CudaVisibleMask(tokens=[])
-    tokens = [token.strip() for token in raw.split(",")]
-    if any(
-        not token
-        or token == "-1"
-        or (token.isdigit() and not _is_cuda_visible_index_token(token))
-        for token in tokens
-    ):
-        return _CudaVisibleMask(tokens=[], invalid=True)
-    token_keys = [_cuda_visible_token_key(token) for token in tokens]
-    if len(set(token_keys)) != len(token_keys):
-        return _CudaVisibleMask(tokens=[], invalid=True)
-    return _CudaVisibleMask(tokens=tokens)
 
 
 def _torch_cuda_visible_count() -> Optional[int]:
@@ -165,54 +127,89 @@ def _nvml_info_for_handle(
     return info
 
 
-def _query_nvml() -> List[Dict[str, Any]]:
+def _resolve_nvml_visible_handles(pynvml, visible_tokens):
+    visible_handles = [None for _token in visible_tokens]
+    seen_physical_ids = set()
+    for visible_id, token in enumerate(visible_tokens):
+        physical_id = cuda_visible_index_value(token)
+        if physical_id is not None:
+            continue
+        try:
+            handle = _lookup_nvml_uuid_handle(pynvml, token)
+        except Exception:
+            handle = None
+
+        if handle is None:
+            return None
+
+        resolved_physical_id = _nvml_physical_id(pynvml, handle, physical_id)
+        if resolved_physical_id is not None:
+            if resolved_physical_id in seen_physical_ids:
+                return None
+            seen_physical_ids.add(resolved_physical_id)
+        visible_handles[visible_id] = (visible_id, handle, resolved_physical_id)
+
+    for visible_id, token in enumerate(visible_tokens):
+        physical_id = cuda_visible_index_value(token)
+        if physical_id is None:
+            continue
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_id)
+        except Exception:
+            handle = None
+
+        if handle is None:
+            return None
+
+        resolved_physical_id = _nvml_physical_id(pynvml, handle, physical_id)
+        if resolved_physical_id is not None:
+            if resolved_physical_id in seen_physical_ids:
+                return None
+            seen_physical_ids.add(resolved_physical_id)
+        visible_handles[visible_id] = (visible_id, handle, resolved_physical_id)
+
+    resolved_handles = [handle for handle in visible_handles if handle is not None]
+    return resolved_handles if len(resolved_handles) == len(visible_tokens) else None
+
+
+def _query_nvml() -> tuple[List[Dict[str, Any]], bool]:
     import pynvml
 
     pynvml.nvmlInit()
     infos: List[Dict[str, Any]] = []
     try:
         count = pynvml.nvmlDeviceGetCount()
-        visible_mask = _cuda_visible_mask()
+        visible_mask = cuda_visible_mask()
         if visible_mask.invalid:
-            return []
+            return [], False
         visible_tokens = visible_mask.tokens
         if visible_tokens is None:
             visible_tokens = [str(idx) for idx in range(count)]
 
+        for token in visible_tokens:
+            index_value = cuda_visible_index_value(token)
+            if index_value is not None and index_value >= count:
+                return [], False
+
         torch_visible_count = _torch_cuda_visible_count()
         if torch_visible_count is None or torch_visible_count <= 0:
-            return []
+            return [], False
+
+        visible_handles = None
+        if any(cuda_visible_index_value(token) is None for token in visible_tokens):
+            visible_handles = _resolve_nvml_visible_handles(pynvml, visible_tokens)
+            if visible_handles is None:
+                return [], False
+
         if len(visible_tokens) != torch_visible_count:
-            return []
+            return [], True
         if not _torch_cuda_visible_ordinals_startable(torch_visible_count):
-            return []
+            return [], False
 
-        for token in visible_tokens:
-            if _is_cuda_visible_index_token(token) and int(token) >= count:
-                return []
-
-        visible_handles = []
-        seen_physical_ids = set()
-        for visible_id, token in enumerate(visible_tokens):
-            physical_id = int(token) if _is_cuda_visible_index_token(token) else None
-            try:
-                handle = (
-                    pynvml.nvmlDeviceGetHandleByIndex(physical_id)
-                    if physical_id is not None
-                    else _lookup_nvml_uuid_handle(pynvml, token)
-                )
-            except Exception:
-                handle = None
-
-            if handle is None:
-                return []
-
-            resolved_physical_id = _nvml_physical_id(pynvml, handle, physical_id)
-            if resolved_physical_id is not None:
-                if resolved_physical_id in seen_physical_ids:
-                    return []
-                seen_physical_ids.add(resolved_physical_id)
-            visible_handles.append((visible_id, handle, resolved_physical_id))
+        if visible_handles is None:
+            visible_handles = _resolve_nvml_visible_handles(pynvml, visible_tokens)
+            if visible_handles is None:
+                return [], False
 
         for visible_id, handle, physical_id in visible_handles:
             infos.append(
@@ -228,7 +225,7 @@ def _query_nvml() -> List[Dict[str, Any]]:
             pynvml.nvmlShutdown()
         except Exception:
             pass
-    return infos
+    return infos, True
 
 
 def _query_rocm() -> List[Dict[str, Any]]:
@@ -409,15 +406,16 @@ def get_gpu_info() -> List[Dict[str, Any]]:
             logger.debug("Torch GPU info failed: %s", exc)
         return _query_mps()
 
-    cuda_visible_mask = _cuda_visible_mask()
+    cuda_visible_mask_info = cuda_visible_mask()
+    nvml_allows_torch_fallback = cuda_visible_mask_info.permits_torch_fallback
     try:
-        infos = _query_nvml()
+        infos, nvml_allows_torch_fallback = _query_nvml()
         if infos:
             return infos
     except Exception as exc:
         logger.debug("NVML info failed: %s", exc)
 
-    if cuda_visible_mask.permits_torch_fallback:
+    if cuda_visible_mask_info.permits_torch_fallback and nvml_allows_torch_fallback:
         try:
             infos = _query_torch()
             if infos:

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import atexit
-import os
 import threading
 from typing import Optional
 
+from keep_gpu.utilities.cuda_visibility import (
+    cuda_visible_index_value,
+    cuda_visible_mask,
+    is_cuda_visible_index_token,
+)
 from keep_gpu.utilities.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -16,10 +20,6 @@ try:  # pragma: no cover - import guard
     import pynvml  # type: ignore
 except Exception:  # pragma: no cover - env without NVML
     pynvml = None
-
-
-def _is_ascii_digit_token(token: str) -> bool:
-    return token.isascii() and token.isdigit()
 
 
 class NVMLMonitor:
@@ -79,28 +79,13 @@ class NVMLMonitor:
             return None
 
     def _get_handle_for_visible_index(self, index: int):
-        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if cuda_visible_devices is None:
+        visible_mask = cuda_visible_mask()
+        if visible_mask.invalid:
+            return None
+        if visible_mask.tokens is None:
             return self._nvml.nvmlDeviceGetHandleByIndex(index)
 
-        tokens = [token.strip() for token in cuda_visible_devices.split(",")]
-        if cuda_visible_devices.strip() in {"", "-1"}:
-            tokens = []
-        elif any(not token or token == "-1" for token in tokens):
-            return None
-        elif any(not token.isascii() for token in tokens):
-            return None
-
-        token_keys = [
-            (
-                ("index", int(token))
-                if _is_ascii_digit_token(token)
-                else ("token", token.lower())
-            )
-            for token in tokens
-        ]
-        if len(set(token_keys)) != len(token_keys):
-            return None
+        tokens = list(visible_mask.tokens)
         if index < 0 or index >= len(tokens):
             return None
         if not self._numeric_tokens_within_device_count(tokens):
@@ -115,9 +100,13 @@ class NVMLMonitor:
         return handles[index]
 
     def _numeric_tokens_within_device_count(self, tokens: list[str]) -> bool:
-        numeric_tokens = [
-            int(token) for token in tokens if _is_ascii_digit_token(token)
-        ]
+        numeric_tokens = []
+        for token in tokens:
+            index_value = cuda_visible_index_value(token)
+            if index_value is not None:
+                numeric_tokens.append(index_value)
+            elif is_cuda_visible_index_token(token):
+                return False
         if not numeric_tokens:
             return True
 
@@ -137,7 +126,7 @@ class NVMLMonitor:
         # UUID tokens can fail independently from numeric tokens. Resolve them
         # first so an unresolved later UUID cannot permit partial numeric telemetry.
         for visible_index, token in enumerate(tokens):
-            if _is_ascii_digit_token(token):
+            if is_cuda_visible_index_token(token):
                 continue
             handle = self._get_handle_for_visible_token(token)
             if handle is None:
@@ -145,7 +134,7 @@ class NVMLMonitor:
             handles[visible_index] = handle
 
         for visible_index, token in enumerate(tokens):
-            if not _is_ascii_digit_token(token):
+            if not is_cuda_visible_index_token(token):
                 continue
             handle = self._get_handle_for_visible_token(token)
             if handle is None:
@@ -168,11 +157,14 @@ class NVMLMonitor:
         if not token:
             return None
 
-        if _is_ascii_digit_token(token):
+        index_value = cuda_visible_index_value(token)
+        if index_value is not None:
             try:
-                return self._nvml.nvmlDeviceGetHandleByIndex(int(token))
+                return self._nvml.nvmlDeviceGetHandleByIndex(index_value)
             except self._nvml.NVMLError:
                 return None
+        if is_cuda_visible_index_token(token):
+            return None
 
         uuid_lookup = getattr(self._nvml, "nvmlDeviceGetHandleByUUID", None)
         if uuid_lookup is None:

--- a/src/keep_gpu/utilities/rocm_visibility.py
+++ b/src/keep_gpu/utilities/rocm_visibility.py
@@ -4,10 +4,21 @@ import os
 from typing import Optional, Tuple
 
 _UNSET = object()
+_MAX_DEVICE_ORDINAL_DIGITS = len(str(2**63 - 1))
 
 
 def _is_ascii_digit_token(token: str) -> bool:
     return token.isascii() and token.isdigit()
+
+
+def _numeric_token_value(token: str) -> Optional[int]:
+    normalized = token.lstrip("0") or "0"
+    if len(normalized) > _MAX_DEVICE_ORDINAL_DIGITS:
+        return None
+    try:
+        return int(normalized)
+    except ValueError:
+        return None
 
 
 def _parse_numeric_mask(name: str) -> Optional[Tuple[int, ...]]:
@@ -21,7 +32,13 @@ def _parse_numeric_mask(name: str) -> Optional[Tuple[int, ...]]:
     ):
         return ()
 
-    values = tuple(int(token) for token in tokens)
+    values_list = []
+    for token in tokens:
+        value = _numeric_token_value(token)
+        if value is None:
+            return ()
+        values_list.append(value)
+    values = tuple(values_list)
     if len(set(values)) != len(values):
         return ()
     return values

--- a/tests/rocm_controller/test_rocm_utilization.py
+++ b/tests/rocm_controller/test_rocm_utilization.py
@@ -8,6 +8,9 @@ from keep_gpu.single_gpu_controller import rocm_gpu_controller as rocm_module
 from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
 
 
+OVERSIZED_NUMERIC_TOKEN = "9" * 100
+
+
 class DummyRocmSMI:
     def __init__(self, util_by_index: dict[int, int] | None = None, count: int = 8):
         self.util_by_index = util_by_index or {}
@@ -111,6 +114,24 @@ def test_rocm_utilization_treats_non_ascii_digit_mask_as_unavailable(
     monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.setenv(mask_name, "\u00b2")
+    dummy = DummyRocmSMI()
+    controller = _controller_with_dummy_smi(monkeypatch, rank=0, dummy=dummy)
+
+    assert controller._query_utilization() is None
+    assert dummy.queried_indexes == []
+
+
+@pytest.mark.parametrize(
+    "mask_name",
+    ["ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"],
+)
+def test_rocm_utilization_treats_oversized_numeric_mask_as_unavailable(
+    monkeypatch, mask_name
+):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv(mask_name, OVERSIZED_NUMERIC_TOKEN)
     dummy = DummyRocmSMI()
     controller = _controller_with_dummy_smi(monkeypatch, rank=0, dummy=dummy)
 

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -7,6 +7,9 @@ import pytest
 from keep_gpu.utilities import gpu_info
 
 
+OVERSIZED_NUMERIC_TOKEN = "9" * 100
+
+
 class DummyNVMLMemory:
     def __init__(self, total: int, used: int):
         self.total = total
@@ -361,6 +364,20 @@ def test_get_gpu_info_nvml_unresolved_uuid_mask_does_not_list_placeholder(
     assert dummy_nvml.shutdown_calls == 1
 
 
+def test_get_gpu_info_nvml_mixed_invalid_uuid_mask_avoids_partial_numeric_lookup(
+    monkeypatch,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,GPU-typo")
+    dummy_nvml = MultiGPUDummyNVML(count=2)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    _install_cuda_gpu_info_mocks(monkeypatch, count=2)
+
+    assert gpu_info.get_gpu_info() == []
+    assert dummy_nvml.queried_indexes == []
+    assert dummy_nvml.queried_uuids == ["GPU-typo", b"GPU-typo"]
+    assert dummy_nvml.shutdown_calls == 1
+
+
 def test_get_gpu_info_nvml_malformed_cuda_visible_devices_hides_all(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,,2")
     dummy_nvml = MultiGPUDummyNVML(count=3)
@@ -374,7 +391,18 @@ def test_get_gpu_info_nvml_malformed_cuda_visible_devices_hides_all(monkeypatch)
 
 @pytest.mark.parametrize(
     "mask",
-    ["", "-1", "0,,2", "0,0", "0,00", "GPU-abc123,gpu-abc123", "-1,0", "\u00b2"],
+    [
+        "",
+        "-1",
+        "0,,2",
+        "0,0",
+        "0,00",
+        "GPU-abc123,gpu-abc123",
+        "-1,0",
+        "\u00b2",
+        "GPU-\u00b2",
+        OVERSIZED_NUMERIC_TOKEN,
+    ],
 )
 def test_get_gpu_info_cuda_hidden_or_invalid_mask_does_not_fall_back_to_torch(
     monkeypatch, mask
@@ -398,6 +426,20 @@ def test_get_gpu_info_nvml_out_of_range_cuda_visible_devices_hides_all(
     assert gpu_info.get_gpu_info() == []
     assert dummy_nvml.queried_indexes == []
     assert dummy_nvml.shutdown_calls == 1
+
+
+def test_get_gpu_info_nvml_out_of_range_cuda_visible_devices_blocks_torch_fallback(
+    monkeypatch,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "99")
+    dummy_nvml = MultiGPUDummyNVML(count=2)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    dummy_cuda = _install_cuda_gpu_info_mocks(monkeypatch, count=1)
+
+    assert gpu_info.get_gpu_info() == []
+    assert dummy_nvml.queried_indexes == []
+    assert dummy_nvml.shutdown_calls == 1
+    assert dummy_cuda.set_devices == []
 
 
 def test_get_gpu_info_nvml_duplicate_cuda_visible_devices_hides_all(monkeypatch):
@@ -425,6 +467,26 @@ def test_get_gpu_info_nvml_duplicate_uuid_mask_hides_all_when_torch_has_no_devic
     assert gpu_info.get_gpu_info() == []
     assert dummy_nvml.queried_indexes == []
     assert dummy_nvml.queried_uuids == []
+    assert dummy_nvml.shutdown_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("mask", "torch_count", "uuid_to_index"),
+    [
+        ("GPU-typo", 1, {}),
+        ("GPU-a,GPU-b", 1, {"GPU-a": 2, "GPU-b": 2}),
+        ("GPU-a,GPU-b", 2, {"GPU-a": 2, "GPU-b": 2}),
+    ],
+)
+def test_get_gpu_info_nvml_semantically_invalid_cuda_mask_blocks_torch_fallback(
+    monkeypatch, mask, torch_count, uuid_to_index
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    dummy_nvml = MultiGPUDummyNVML(count=3, uuid_to_index=uuid_to_index)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    _install_cuda_gpu_info_mocks(monkeypatch, count=torch_count)
+
+    assert gpu_info.get_gpu_info() == []
     assert dummy_nvml.shutdown_calls == 1
 
 

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -5,6 +5,9 @@ import types
 from keep_gpu.utilities.gpu_monitor import NVMLMonitor
 
 
+OVERSIZED_NUMERIC_TOKEN = "9" * 100
+
+
 class DummyNVML:
     """Minimal stand-in for the NVML module used in tests."""
 
@@ -157,6 +160,18 @@ def test_monitor_returns_none_for_equivalent_numeric_cuda_visible_devices(
 def test_monitor_returns_none_for_non_ascii_digit_cuda_visible_devices(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "\u00b2")
     dummy = DummyNVML(gpu_util=99, support_uuid_lookup=True)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) is None
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == []
+
+
+def test_monitor_returns_none_for_oversized_numeric_cuda_visible_devices(
+    monkeypatch,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", OVERSIZED_NUMERIC_TOKEN)
+    dummy = DummyNVML(gpu_util=99)
     monitor = NVMLMonitor(dummy)
 
     assert monitor.get_gpu_utilization(0) is None


### PR DESCRIPTION
## Summary
- add one shared CUDA visibility parser for GPU listing and utilization paths
- fail closed for invalid, non-ASCII, duplicate/equivalent, unresolved, physical-alias, or implausibly large CUDA masks before Torch fallback or partial NVML lookup
- guard ROCm numeric visibility mask parsing against implausibly large ordinals
- preserve the existing Torch fallback for pure numeric NVML/Torch visible-count mismatch while blocking fallback for semantically invalid masks

## Notes
- docs already describe these as malformed/out-of-range visibility masks that produce unavailable telemetry, so this PR keeps documentation unchanged to avoid duplicate prose
- the oversized-token regression uses a 100-digit token so the behavior is enforced by KeepGPU, not only by newer Python integer-string limits
- local reviews found fallback gaps for `CUDA_VISIBLE_DEVICES=99`, UUID physical-alias masks, and mixed numeric/unresolved UUID partial lookup; the updated commit adds regressions for each case

## Verification
- RED focused regression with 100-digit token -> 1 failed, 13 passed before the explicit ordinal-size guard
- RED local-review regression `test_get_gpu_info_nvml_out_of_range_cuda_visible_devices_blocks_torch_fallback` -> failed before fallback guard
- RED local-review regression for `CUDA_VISIBLE_DEVICES=GPU-a,GPU-b` with Torch count 1 -> failed before UUID semantic validation moved before fallback
- RED local-review regression for `CUDA_VISIBLE_DEVICES=0,GPU-typo` -> failed before UUID-first listing resolution
- `PYTHONPATH=src python -m pytest tests/utilities/test_gpu_monitor.py tests/utilities/test_gpu_info.py tests/rocm_controller/test_rocm_utilization.py -q` -> 83 passed, 1 skipped
- `PYTHONPATH=src python -m pytest -q` -> 722 passed, 11 skipped
- `python -m ruff check .` -> passed
- `mkdocs build --strict` -> passed with existing Material/MkDocs 2.0 warning
- `PYTHONPATH=src pre-commit run --all-files` -> passed