### PR TITLE
[docs] docs: align Python requirement with py38 target

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ understand the minimum knobs you need to keep a GPU occupied.
 ## Requirements
 
 - NVIDIA drivers + CUDA runtime visible to PyTorch.
-- Python 3.9+ (matching the version in your environment/cluster image).
+- Python 3.8+ (matching the version in your environment/cluster image).
 - Optional but recommended: `nvidia-smi` in `PATH` for utilization monitoring (CUDA) or `rocm-smi` if you install the `rocm` extra.
 
 !!! info "Platforms"


### PR DESCRIPTION
## Summary
- update getting-started requirements from Python 3.9+ to Python 3.8+
- align user-facing docs with the project py38 formatter/linter target and AGENTS guidance

## Verification
- `PYTHONPATH=src mkdocs build --strict` -> passed with existing Material/MkDocs 2.0 warning
- `python -m ruff check .` -> passed
- `PYTHONPATH=src pre-commit run --all-files` -> passed

Note: plain `mkdocs build --strict` failed locally because this linked worktree was not installed as `keep_gpu`; using `PYTHONPATH=src` exercises this branch without mutating the global editable install.