### PR TITLE
[mcp] fix: reject noncanonical RPC routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,10 @@ This file defines how coding agents should work in this repository.
   must call the shared unsupported-method helper before local unknown-endpoint
   404 branches, so known paths never regress to 404 or body-parse errors solely
   because the wrong implemented verb was used.
-- `/rpc` is a POST-only JSON-RPC endpoint; `GET /rpc` must return structured
-  JSON `405 Method Not Allowed` with `Allow: POST` and must never serve the
+- `/rpc` is an exact POST-only JSON-RPC endpoint; `GET /rpc` must return
+  structured JSON `405 Method Not Allowed` with `Allow: POST`, while
+  noncanonical spellings such as `/rpc/`, `/rpc;...`, and `/rpc?...` return
+  structured JSON `404 Unknown endpoint` without JSON-RPC dispatch or
   dashboard/static fallback.
 - Missing dashboard asset URLs, including `/assets/*` and extension-bearing
   static paths, must return structured JSON `404` errors instead of the

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ to zero devices.
 - Stdio stdout is reserved for JSON protocol messages; diagnostics and logs are
   written to stderr.
 - HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
-  same JSON-RPC messages at `/rpc`, but it is not a Streamable HTTP MCP
-  endpoint.
+  same JSON-RPC messages at the exact `/rpc` endpoint, but it is not a
+  Streamable HTTP MCP endpoint.
 - Successful legacy direct JSON-RPC responses use a KeepGPU direct-method
   envelope with `jsonrpc: "2.0"`, the matching request `id`, and an object
   `result`.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ to zero devices.
   written to stderr.
 - HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
   same JSON-RPC messages at the exact `/rpc` endpoint, but it is not a
-  Streamable HTTP MCP endpoint.
+  Streamable HTTP MCP endpoint. Noncanonical `/rpc` URLs return structured
+  `404` errors.
 - Successful legacy direct JSON-RPC responses use a KeepGPU direct-method
   envelope with `jsonrpc: "2.0"`, the matching request `id`, and an object
   `result`.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -57,8 +57,9 @@ envelopes.
 ## HTTP JSON-RPC quick example
 
 HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
-same JSON-RPC message shapes at `/rpc`, but it is not a Streamable HTTP MCP
-endpoint.
+same JSON-RPC message shapes at the exact `/rpc` endpoint, but it is not a
+Streamable HTTP MCP endpoint. Noncanonical `/rpc` URLs, including trailing
+slashes or query strings, return structured `404 Unknown endpoint` errors.
 
 Malformed HTTP JSON-RPC bodies return a JSON-RPC `-32700 Parse error` envelope
 with `id: null`; REST routes keep REST-shaped JSON errors.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -156,7 +156,7 @@ enumeration, with error code `-32000`; arbitrary runtime failures remain
 | `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. |
 | `/api/sessions` | DELETE | Stop all sessions; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/api/sessions/{job_id}` | DELETE | Stop one session; returns `stopped`, `timed_out`, `failed`, and `errors`. |
-| `/rpc` | POST | JSON-RPC compatibility endpoint. |
+| `/rpc` | POST | Exact JSON-RPC compatibility endpoint; noncanonical `/rpc` URLs return structured `404` errors. |
 | `/` | GET | Dashboard UI. |
 
 ## Environment variables

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -999,12 +999,31 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
     def _is_api_path(path: str) -> bool:
         return path == "/api" or path.startswith("/api/")
 
+    @staticmethod
+    def _is_noncanonical_rpc_route(parsed) -> bool:
+        return parsed.path.startswith("/rpc/") or (
+            parsed.path == "/rpc"
+            and bool(parsed.params or parsed.query or parsed.fragment)
+        )
+
+    def _reject_noncanonical_rpc_route(self, parsed, write_body: bool = True) -> bool:
+        if not self._is_noncanonical_rpc_route(parsed):
+            return False
+        self._json_response(
+            404,
+            {"error": {"message": "Unknown endpoint"}},
+            write_body=write_body,
+        )
+        return True
+
     def _send_api_rpc_unsupported_method_response(self) -> bool:
         if not hasattr(self, "path") or not hasattr(self, "command"):
             return False
         parsed = urlparse(self.path)
         path = parsed.path
         write_body = self.command != "HEAD"
+        if self._reject_noncanonical_rpc_route(parsed, write_body=write_body):
+            return True
         allowed_methods = self._allowed_methods_for_path(path)
         if allowed_methods is not None:
             self._json_response(
@@ -1129,6 +1148,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if self._reject_noncanonical_rpc_route(parsed):
+                return
             if path == "/rpc":
                 self._send_api_rpc_unsupported_method_response()
                 return
@@ -1174,6 +1195,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if self._reject_noncanonical_rpc_route(parsed):
+                return
             if self._send_known_route_unsupported_method_response(path):
                 return
             if path not in ("/api/sessions", "/", "/rpc"):
@@ -1302,6 +1325,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if self._reject_noncanonical_rpc_route(parsed):
+                return
             if self._send_known_route_unsupported_method_response(path):
                 return
             server_ref = self.server.keepgpu_server  # type: ignore[attr-defined]

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1001,8 +1001,12 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
 
     @staticmethod
     def _is_noncanonical_rpc_route(parsed) -> bool:
-        return parsed.path.startswith("/rpc/") or (
-            parsed.path == "/rpc"
+        route_paths = (parsed.path, unquote(parsed.path))
+        return any(
+            path.startswith(("/rpc/", "/rpc;", "/rpc?", "/rpc#"))
+            for path in route_paths
+        ) or (
+            any(path == "/rpc" for path in route_paths)
             and bool(parsed.params or parsed.query or parsed.fragment)
         )
 

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -292,12 +292,18 @@ def test_http_rpc_head_rejects_with_json_405_and_empty_body():
     assert body == b""
 
 
-def test_http_rpc_trailing_slash_returns_json_404_without_static_fallback():
+@pytest.mark.parametrize(
+    "rpc_path",
+    ["/rpc/", "/rpc%2F", "/rpc%3Bdebug", "/rpc%3Fdebug=1"],
+)
+def test_http_rpc_noncanonical_get_returns_json_404_without_static_fallback(
+    rpc_path,
+):
     server = make_server()
     httpd, thread, base = _start_http_server(server)
 
     try:
-        status, headers, body = _request_http_response("GET", f"{base}/rpc/")
+        status, headers, body = _request_http_response("GET", f"{base}{rpc_path}")
     finally:
         httpd.shutdown()
         httpd.server_close()

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -292,6 +292,43 @@ def test_http_rpc_head_rejects_with_json_405_and_empty_body():
     assert body == b""
 
 
+def test_http_rpc_trailing_slash_returns_json_404_without_static_fallback():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("GET", f"{base}/rpc/")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+@pytest.mark.parametrize("rpc_path", ["/rpc/", "/rpc;debug", "/rpc?debug=1"])
+def test_http_rpc_noncanonical_path_rejects_before_jsonrpc_parse(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_raw("POST", f"{base}{rpc_path}", b"{bad json")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload["error"]["message"] == "Unknown endpoint"
+
+
 @pytest.mark.parametrize(
     ("method", "path"),
     [


### PR DESCRIPTION
## Summary
- Reject noncanonical `/rpc` URLs such as `/rpc/`, `/rpc;...`, and `/rpc?...` with structured JSON 404 responses.
- Keep exact `POST /rpc` JSON-RPC behavior and `GET /rpc` 405 behavior intact.
- Document the exact `/rpc` endpoint contract in AGENTS, README, and MCP/service docs.

## Test Plan
- `PYTHONPATH=src python -m pytest tests/mcp/test_http_api.py::test_http_rpc_trailing_slash_returns_json_404_without_static_fallback tests/mcp/test_http_api.py::test_http_rpc_noncanonical_path_rejects_before_jsonrpc_parse -q`
- `PYTHONPATH=src python -m pytest tests/mcp/test_http_api.py -q`
- `python -m ruff check .`
- `git diff --check`
- `PYTHONPATH=src python -m pytest tests/mcp -q`
- `PYTHONPATH=src mkdocs build --strict --site-dir /tmp/keepgpu-rpc-noncanonical-site`
- `PYTHONPATH=src pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the MCP JSON-RPC endpoint is available only at the exact `/rpc` path.
  * Added guidance that malformed or non-canonical `/rpc` URLs return structured 404 or 405 responses.

* **Bug Fixes**
  * Requests to `/rpc` with trailing slashes, extra path parts, or query strings are now consistently rejected.
  * `GET /rpc` now returns a clear `405 Method Not Allowed` response with `Allow: POST`.
  * Added coverage to confirm invalid `/rpc` URLs do not fall back to other handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->