### PR TITLE
[build] chore: remove stdlib argparse dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
+- Build metadata should list external packages only; do not add Python stdlib
+  modules such as `argparse` as build/runtime dependencies.
 - Remove placeholder tests that assert no behavior instead of preserving
   count-only coverage.
 - Python files that use PEP 604 annotations such as `X | Y` must include

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,6 +41,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Use the documented `pyproject.toml`, CI, MkDocs, and dashboard package
   commands as the source of truth; the old `setup.py`/Sphinx command scaffold is
   intentionally not part of the repository.
+- Keep build metadata lean: list external build/runtime packages only, not
+  Python standard library modules such as `argparse`.
 
 ## Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=61.0",
-  "argparse",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Summary
- Remove `argparse` from `build-system.requires` because it is part of the Python standard library.
- Add concise AGENTS/contributor guidance to keep build metadata limited to external packages.

## Test Plan
- Baseline before change: `python -m build --sdist --outdir /tmp/keepgpu-argparse-before` showed isolated build installing `argparse` and `setuptools>=61.0`.
- After change: `python -m build --sdist --outdir /tmp/keepgpu-argparse-after-final` showed isolated build installing only `setuptools>=61.0`.
- `python -m build --wheel --outdir /tmp/keepgpu-argparse-wheel-after`
- `git diff --check`
- `PYTHONPATH=src mkdocs build --strict --site-dir /tmp/keepgpu-argparse-docs-site`
- `PYTHONPATH=src pre-commit run --all-files`

## Notes
- The build still emits the pre-existing setuptools license table deprecation warning; that is intentionally left for a separate focused PR.