### PR TITLE
[build] fix: declare Python support metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ This file defines how coding agents should work in this repository.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
 - Build metadata should list external packages only; do not add Python stdlib
   modules such as `argparse` as build/runtime dependencies.
+- Keep `project.requires-python` aligned with the documented Python support
+  floor and py38-targeted tooling.
 - Remove placeholder tests that assert no behavior instead of preserving
   count-only coverage.
 - Python files that use PEP 604 annotations such as `X | Y` must include

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,6 +43,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   intentionally not part of the repository.
 - Keep build metadata lean: list external build/runtime packages only, not
   Python standard library modules such as `argparse`.
+- Keep package metadata such as `requires-python` aligned with the documented
+  supported Python versions.
 
 ## Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ name = "keep_gpu"
 dynamic = ["version"]  # Let setuptools read the version dynamically
 description = "Keep GPU is a simple CLI app that keeps your GPUs running"
 readme = {file = "README.md", content-type = "text/markdown"}
+requires-python = ">=3.8"
 
 authors = [
   {name = "Siyuan Wang", email = "sywang0227@gmail.com"},


### PR DESCRIPTION
## Summary
- Add `requires-python = ">=3.8"` to package metadata, matching existing docs and py38-targeted tooling.
- Add concise AGENTS/contributor guidance to keep Python support metadata aligned with docs.

## Test Plan
- Baseline before change: `python -m build --wheel --outdir /tmp/keepgpu-requires-python-before` then `unzip -p .../METADATA | rg "^Requires-Python" || true` produced no `Requires-Python` line.
- After change: `python -m build --wheel --outdir /tmp/keepgpu-requires-python-after` then `unzip -p .../METADATA | rg "^Requires-Python"` produced `Requires-Python: >=3.8`.
- `python -m build --sdist --outdir /tmp/keepgpu-requires-python-sdist-after`
- `git diff --check`
- `PYTHONPATH=src mkdocs build --strict --site-dir /tmp/keepgpu-requires-python-docs-site`
- `PYTHONPATH=src pre-commit run --all-files`

## Notes
- The build still emits the pre-existing setuptools license table deprecation warning; that remains intentionally separate.