### PR TITLE
[build] fix: point changelog URL to releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ This file defines how coding agents should work in this repository.
   modules such as `argparse` as build/runtime dependencies.
 - Keep `project.requires-python` aligned with the documented Python support
   floor and py38-targeted tooling.
+- Keep `project.urls` entries live and aligned with current repository
+  locations; avoid stale branch names or missing files.
 - Remove placeholder tests that assert no behavior instead of preserving
   count-only coverage.
 - Python files that use PEP 604 annotations such as `X | Y` must include

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,6 +45,7 @@ expectations so you can get productive quickly and avoid surprises in CI.
   Python standard library modules such as `argparse`.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
+- Keep project URLs in package metadata pointing to live repository pages.
 
 ## Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ macm = [
 
 [project.urls]
 bugs = "https://github.com/Wangmerlyn/KeepGPU/issues"
-changelog = "https://github.com/Wangmerlyn/KeepGPU/blob/master/changelog.md"
+changelog = "https://github.com/Wangmerlyn/KeepGPU/releases"
 homepage = "https://github.com/Wangmerlyn/KeepGPU"
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Replace the stale `master/changelog.md` project URL with the live GitHub releases page.
- Add concise AGENTS/contributor guidance to keep package project URLs live.

## Evidence
- `https://github.com/Wangmerlyn/KeepGPU/blob/master/changelog.md` returned HTTP 404.
- No local changelog/history file exists in the repo.
- `https://github.com/Wangmerlyn/KeepGPU/releases` returned HTTP 200.

## Test Plan
- `python -m build --wheel --outdir /tmp/keepgpu-changelog-url-wheel`
- `unzip -p /tmp/keepgpu-changelog-url-wheel/keep_gpu-0.5.1-py3-none-any.whl keep_gpu-0.5.1.dist-info/METADATA | rg "^Project-URL: changelog"` -> `Project-URL: changelog, https://github.com/Wangmerlyn/KeepGPU/releases`
- `python -m build --sdist --outdir /tmp/keepgpu-changelog-url-sdist`
- `git diff --check`
- `PYTHONPATH=src mkdocs build --strict --site-dir /tmp/keepgpu-changelog-url-docs-site`
- `PYTHONPATH=src pre-commit run --all-files`

## Notes
- The build still emits the pre-existing setuptools license table deprecation warning; that remains intentionally separate.