### PR TITLE
[ci] chore: remove duplicate flake8 lint pass

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies and run tests with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -27,15 +27,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install flake8 pytest
+        pip install pytest
         pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install -e .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
## Summary
- remove the duplicate flake8 install and lint step from the Python application workflow
- keep lint/format ownership with the existing pre-commit workflow and Ruff/Black hooks

## Verification
- `python - <<'PY' ...` parsed `.github/workflows/python-app.yml` and confirmed workflow steps are checkout, Python setup, install dependencies, and pytest
- `pre-commit run --all-files`
- `PYTHONPATH=src pytest --collect-only -q` (740 tests collected)
