### PR TITLE
[lint, docs] fix: remove shadowing Ruff config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,8 @@ This file defines how coding agents should work in this repository.
   do not reintroduce legacy root `Makefile` or `requirements_dev.txt`
   scaffolding for removed `setup.py`/Sphinx flows. Keep `MANIFEST.in` limited
   to source-distribution inclusions that `pyproject.toml` cannot express.
+- Keep Ruff settings canonical in `pyproject.toml`; do not add a standalone
+  `ruff.toml` unless the full configuration is intentionally migrated there.
 - Validate docs with:
   - `mkdocs build` for static build verification
   - `mkdocs serve` for local preview when editing rendered content

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,6 +41,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Use the documented `pyproject.toml`, CI, MkDocs, and dashboard package
   commands as the source of truth; the old `setup.py`/Sphinx command scaffold is
   intentionally not part of the repository.
+- Keep Ruff settings in `pyproject.toml`; do not add a standalone `ruff.toml`
+  unless the full configuration is intentionally migrated there.
 - Keep build metadata lean: list external build/runtime packages only, not
   Python standard library modules such as `argparse`.
 - Keep package metadata such as `requires-python` aligned with the documented

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -3,18 +3,18 @@ from typing import List, Optional, Union
 
 from keep_gpu.utilities.humanized_input import parse_size, parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.platform_manager import (
+    ComputingPlatform,
+    DeviceEnumerationUnavailableError,
+    get_platform,
+    visible_torch_device_count,
+)
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     VisibleRankValidationError,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
-)
-from keep_gpu.utilities.platform_manager import (
-    ComputingPlatform,
-    DeviceEnumerationUnavailableError,
-    get_platform,
-    visible_torch_device_count,
 )
 
 logger = setup_logger(__name__)

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -27,20 +27,20 @@ HTTP endpoints:
 
 from __future__ import annotations
 
+import argparse
 import atexit
 import ipaddress
 import json
 import math
+import mimetypes
 import sys
-import uuid
-import argparse
 import threading
 import time
-import mimetypes
-from http.server import BaseHTTPRequestHandler
-from socketserver import TCPServer, ThreadingMixIn
+import uuid
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler
 from pathlib import Path
+from socketserver import TCPServer, ThreadingMixIn
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote, urlparse
 
@@ -50,11 +50,11 @@ from keep_gpu.global_gpu_controller.global_gpu_controller import (
     GlobalGPUController,
     InvalidVisibleGPUSelectionError,
 )
+from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.humanized_input import (
     PUBLIC_VRAM_MAX_BYTES,
     parse_vram_to_elements,
 )
-from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 from keep_gpu.utilities.session_config import (

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -9,6 +9,7 @@ import torch
 from keep_gpu.single_gpu_controller.base_gpu_controller import BaseGPUController
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import visible_torch_device_count
+from keep_gpu.utilities.rocm_visibility import resolve_rocm_visible_rank_to_smi_index
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     validate_busy_threshold,
@@ -16,7 +17,6 @@ from keep_gpu.utilities.session_config import (
     validate_rank_type,
     validate_visible_rank,
 )
-from keep_gpu.utilities.rocm_visibility import resolve_rocm_visible_rank_to_smi_index
 
 logger = setup_logger(__name__)
 

--- a/src/keep_gpu/utilities/cuda_visibility.py
+++ b/src/keep_gpu/utilities/cuda_visibility.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-
 _MAX_DEVICE_ORDINAL_DIGITS = len(str(2**63 - 1))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def rocm_available():
 def macm_available():
     try:
         import sys
+
         import torch
 
         return bool(sys.platform == "darwin" and torch.backends.mps.is_available())

--- a/tests/cuda_controller/test_2_32pow_elements.py
+++ b/tests/cuda_controller/test_2_32pow_elements.py
@@ -1,6 +1,8 @@
 import time
+
 import pytest
 import torch
+
 from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
 
 

--- a/tests/cuda_controller/test_keep_and_release.py
+++ b/tests/cuda_controller/test_keep_and_release.py
@@ -1,6 +1,7 @@
-import pytest
 import threading
 import time
+
+import pytest
 import torch
 
 from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController

--- a/tests/macm_controller/test_macm_basic.py
+++ b/tests/macm_controller/test_macm_basic.py
@@ -7,7 +7,6 @@ import torch
 from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
 from keep_gpu.utilities.platform_manager import ComputingPlatform
 
-
 pytestmark = [
     pytest.mark.skipif(
         not (sys.platform == "darwin" and torch.backends.mps.is_available()),

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -2,19 +2,19 @@ import json
 import math
 import socket
 import threading
+from socketserver import TCPServer, ThreadingMixIn
 from typing import Any, cast
 from urllib.error import HTTPError
-from socketserver import TCPServer, ThreadingMixIn
 from urllib.request import Request, urlopen
 
 import pytest
 
+from keep_gpu.mcp import server as server_module
 from keep_gpu.mcp.server import (
     KeepGPUServer,
     SessionStartupUnavailable,
     _JSONRPCHandler,
 )
-from keep_gpu.mcp import server as server_module
 from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -10,18 +10,18 @@ from typing import Any, cast
 
 import pytest
 
+from keep_gpu.mcp import server as server_module
 from keep_gpu.mcp.server import (
     JSONRPC_INTERNAL_ERROR,
-    JSONRPC_INVALID_REQUEST,
     JSONRPC_INVALID_PARAMS,
+    JSONRPC_INVALID_REQUEST,
     JSONRPC_STARTUP_UNAVAILABLE,
     KeepGPUServer,
     SessionStartupUnavailable,
     _handle_request,
 )
-from keep_gpu.mcp import server as server_module
-from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
 from keep_gpu.utilities import platform_manager as pm
+from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
 
 
 class DummyController:

--- a/tests/rocm_controller/test_rocm_utilization.py
+++ b/tests/rocm_controller/test_rocm_utilization.py
@@ -7,7 +7,6 @@ import pytest
 from keep_gpu.single_gpu_controller import rocm_gpu_controller as rocm_module
 from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
 
-
 OVERSIZED_NUMERIC_TOKEN = "9" * 100
 
 

--- a/tests/test_annotation_compat.py
+++ b/tests/test_annotation_compat.py
@@ -2,7 +2,6 @@ import ast
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -6,7 +6,6 @@ import pytest
 
 from keep_gpu.utilities import gpu_info
 
-
 OVERSIZED_NUMERIC_TOKEN = "9" * 100
 
 

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -4,7 +4,6 @@ import types
 
 from keep_gpu.utilities.gpu_monitor import NVMLMonitor
 
-
 OVERSIZED_NUMERIC_TOKEN = "9" * 100
 
 


### PR DESCRIPTION
## Summary
- remove the zero-byte `ruff.toml` that caused Ruff to ignore `[tool.ruff]` in `pyproject.toml`
- let the existing Ruff config apply and keep the resulting import-order fixes
- document that Ruff settings stay canonical in `pyproject.toml` unless intentionally migrated

## Evidence
- Before: `ruff check --show-settings src/keep_gpu/cli.py` reported `Settings path: .../ruff.toml` even though `ruff.toml` was empty
- After: the same command reports `Settings path: .../pyproject.toml`, with existing isort settings active

## Verification
- `ruff check --show-settings src/keep_gpu/cli.py`
- `pre-commit run ruff --all-files`
- `pre-commit run --all-files`
- `PYTHONPATH=src mkdocs build --strict`
- `PYTHONPATH=src pytest --collect-only -q` (740 tests collected)
