### PR TITLE
[build, docs] fix: declare Rich runtime dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
-- Build metadata should list directly imported third-party packages; do not rely
-  on transitive dependencies, and do not add Python stdlib modules such as
+- Build metadata should list directly used third-party distributions; do not
+  rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.
 - Keep `project.requires-python` aligned with the documented Python support
   floor and py38-targeted tooling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,9 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
-- Build metadata should list external packages only; do not add Python stdlib
-  modules such as `argparse` as build/runtime dependencies.
+- Build metadata should list directly imported third-party packages; do not rely
+  on transitive dependencies, and do not add Python stdlib modules such as
+  `argparse` as build/runtime dependencies.
 - Keep `project.requires-python` aligned with the documented Python support
   floor and py38-targeted tooling.
 - Keep `project.urls` entries live and aligned with current repository

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,9 +43,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   intentionally not part of the repository.
 - Keep Ruff settings in `pyproject.toml`; do not add a standalone `ruff.toml`
   unless the full configuration is intentionally migrated there.
-- Keep build metadata lean: list directly imported third-party build/runtime
-  packages, do not rely on transitive dependencies, and do not list Python
-  standard library modules such as `argparse`.
+- Keep build metadata lean: list directly used third-party build/runtime
+  distributions, do not rely on transitive dependencies, and do not list
+  Python standard library modules such as `argparse`.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
 - Keep project URLs in package metadata pointing to live repository pages.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,8 +43,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   intentionally not part of the repository.
 - Keep Ruff settings in `pyproject.toml`; do not add a standalone `ruff.toml`
   unless the full configuration is intentionally migrated there.
-- Keep build metadata lean: list external build/runtime packages only, not
-  Python standard library modules such as `argparse`.
+- Keep build metadata lean: list directly imported third-party build/runtime
+  packages, do not rely on transitive dependencies, and do not list Python
+  standard library modules such as `argparse`.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
 - Keep project URLs in package metadata pointing to live repository pages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ license = {text = "MIT license"}
 dependencies = [
   "nvidia-ml-py",
   "typer",
-  "rich",
+  "rich>=13.8.0",
   "torch",
   "colorlog",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ license = {text = "MIT license"}
 dependencies = [
   "nvidia-ml-py",
   "typer",
+  "rich",
   "torch",
   "colorlog",
 ]


### PR DESCRIPTION
## Summary
- declare `rich>=13.8.0` as a direct runtime dependency because the CLI imports `rich.console.Console` and uses `Console.print_json(data=...)`
- document that directly used third-party distributions belong in build metadata instead of relying on transitive dependencies

## Evidence
- `src/keep_gpu/cli.py` imports `from rich.console import Console` and calls `console.print_json(data=...)`
- Pre-patch wheel metadata listed `nvidia-ml-py`, `typer`, `torch`, and `colorlog`, but no `Requires-Dist: rich`
- Post-patch wheel metadata includes `Requires-Dist: rich>=13.8.0`
- `rich==13.8.0` exposes the `data` parameter on `Console.print_json`

## Verification
- `python -m venv /tmp/keepgpu-rich-138-venv && /tmp/keepgpu-rich-138-venv/bin/python -m pip install 'rich==13.8.0' && /tmp/keepgpu-rich-138-venv/bin/python - <<'PY' ...` checked `Console.print_json` has `data`
- `python -m build --wheel --outdir /tmp/keepgpu-rich-wheel-bounded` and inspect wheel METADATA for `Requires-Dist: rich>=13.8.0`
- `pre-commit run --all-files`
- `PYTHONPATH=src mkdocs build --strict`
- `git diff --check`