### PR TITLE
[ci] ci: verify dashboard static assets

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,45 @@
+name: Dashboard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/dashboard.yml"
+      - "web/dashboard/**"
+      - "src/keep_gpu/mcp/static/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/dashboard.yml"
+      - "web/dashboard/**"
+      - "src/keep_gpu/mcp/static/**"
+
+permissions:
+  contents: read
+
+jobs:
+  dashboard:
+    name: Test and verify packaged dashboard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/dashboard/package-lock.json
+
+      - name: Install dashboard dependencies
+        run: npm ci --prefix web/dashboard
+
+      - name: Test dashboard
+        run: npm --prefix web/dashboard test
+
+      - name: Build packaged dashboard
+        run: npm --prefix web/dashboard run build
+
+      - name: Check packaged dashboard is current
+        run: git diff --exit-code -- src/keep_gpu/mcp/static

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -42,4 +42,6 @@ jobs:
         run: npm --prefix web/dashboard run build
 
       - name: Check packaged dashboard is current
-        run: git diff --exit-code -- src/keep_gpu/mcp/static
+        run: |
+          git diff -- src/keep_gpu/mcp/static
+          test -z "$(git status --porcelain -- src/keep_gpu/mcp/static)"


### PR DESCRIPTION
## Summary
- add a path-filtered dashboard workflow for dashboard source/static changes
- run dashboard npm install, tests, production build, and a packaged-static diff check
- keep Node CI off unrelated Python/docs-only changes

## Evidence
- dashboard Vite builds into `src/keep_gpu/mcp/static`
- packaged static output is served by the MCP HTTP server and included as package data
- prior CI did not run dashboard package scripts or verify regenerated static output

## Verification
- `npm ci --prefix web/dashboard`
- `npm --prefix web/dashboard test` (45 passed)
- `npm --prefix web/dashboard run build`
- `git diff --exit-code -- src/keep_gpu/mcp/static`
- workflow text inspection for expected triggers/commands
- `pre-commit run --all-files`
- `git diff --check --cached`

Note: `npm ci` reports existing npm audit findings but exits 0; this PR only wires the existing dashboard checks.
