### PR TITLE
[cuda, docs] refactor: drop matmul iteration alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,9 @@ This file defines how coding agents should work in this repository.
   no Google Fonts, CDN, remote CSS/JS/font/image imports, or other runtime
   network assets. Rebuild `src/keep_gpu/mcp/static/` after dashboard changes.
 - Single-GPU keep workload iteration counts must be positive integers (`relu_iterations` for CUDA, `iterations` for ROCm/Mac M); reject invalid values before keep loops so no public path can create a silent no-op keeper or late background thread crash.
+- CUDA workload tuning must use the `relu_iterations` public keyword. Do not
+  reintroduce the legacy `matmul_iterations` alias without an intentional,
+  documented API decision.
 - ROCm optional allocation retry counts must be `None` or positive plain
   integers; reject invalid values before worker startup so background retry
   loops cannot crash with type errors after `keep()` returns.

--- a/docs/plans/drop-cuda-matmul-alias.md
+++ b/docs/plans/drop-cuda-matmul-alias.md
@@ -1,0 +1,40 @@
+# Drop CUDA Matmul Alias
+
+## Background
+
+CUDA keep work now uses lightweight elementwise ReLU operations. The public
+Python API should use the matching `relu_iterations` vocabulary only.
+
+## Goal
+
+Remove the legacy `matmul_iterations` keyword alias from
+`CudaGPUController.__init__` so callers get Python's normal unexpected-keyword
+`TypeError`.
+
+## Solution
+
+- Replace the old alias validation test with a contract test proving
+  `matmul_iterations` is not accepted.
+- Remove the alias parameter, docstring text, and override logic from the CUDA
+  controller.
+- Add a short AGENTS.md guardrail so future CUDA workload tuning keeps the
+  `relu_iterations` name unless a documented API decision reopens it.
+
+## Todo
+
+- [x] Add the failing regression test.
+- [x] Verify the focused test fails on current code because the alias is still
+      accepted.
+- [x] Remove the alias from `CudaGPUController`.
+- [x] Update the guardrail docs.
+- [x] Run targeted tests, docs build, and diff check.
+
+## Verification
+
+- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py::test_cuda_controller_rejects_matmul_iteration_alias_keyword -q`
+- `PYTHONPATH=$PWD/src pytest tests/global_controller/test_contract.py -q`
+- `PYTHONPATH=$PWD/src mkdocs build`
+- `git diff --check`
+
+RED result: the focused test failed with `Failed: DID NOT RAISE <class
+'TypeError'>`, confirming the legacy alias was still accepted.

--- a/docs/plans/rocm-positive-iterations.md
+++ b/docs/plans/rocm-positive-iterations.md
@@ -24,8 +24,10 @@ start.
 - Add a no-GPU regression test for `iterations=0` and `iterations=-1`.
 - Validate positive integer workload iteration counts before constructors start
   keep workers.
-- Apply the shared validation helper to CUDA `relu_iterations`, CUDA's legacy
-  `matmul_iterations` alias, ROCm `iterations`, and Mac M `iterations`.
+- Apply the shared validation helper to CUDA `relu_iterations`, ROCm
+  `iterations`, and Mac M `iterations`. The historical CUDA
+  `matmul_iterations` alias has since been removed; do not reintroduce it as
+  part of iteration validation work.
 - Document that keep workload iteration counts must be positive integers, and
   preserve the eco-safe expectation that KeepGPU should never silently run
   no-op sessions.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -55,7 +55,6 @@ class CudaGPUController(BaseGPUController):
         rank: int,
         interval: float = 1.0,
         relu_iterations: int = 5000,
-        matmul_iterations: Optional[int] = None,
         vram_to_keep: str | int = "1GiB",
         busy_threshold: int = DEFAULT_BUSY_THRESHOLD,
     ):
@@ -66,8 +65,6 @@ class CudaGPUController(BaseGPUController):
                 batches. Defaults to 1.0.
             relu_iterations (int, optional): Number of in-place ReLU ops per
                 batch.
-            matmul_iterations (int, optional): Legacy alias for
-                `relu_iterations`. When set, it overrides `relu_iterations`.
             vram_to_keep (int or str, optional): Amount of VRAM to keep busy,
                 e.g. `"1GiB"`, `"20 GB"`, or an integer like `1000 * 1000`.
                 This represents the total size of the matrix allocated to
@@ -79,8 +76,6 @@ class CudaGPUController(BaseGPUController):
 
         """
         super().__init__(vram_to_keep=vram_to_keep, interval=interval)
-        if matmul_iterations is not None:
-            relu_iterations = matmul_iterations
         self.relu_iterations = validate_positive_integer(
             relu_iterations, "relu_iterations"
         )

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -398,5 +398,5 @@ def test_controller_respects_busy_threshold(monkeypatch):
     time.sleep(0.2)
     ctrl.release()
 
-    # When utilization is always high, no matmul batches should run
+    # When utilization is always high, no ReLU keep-alive batches should run.
     assert calls["run"] == 0

--- a/tests/global_controller/test_contract.py
+++ b/tests/global_controller/test_contract.py
@@ -6,6 +6,7 @@ import torch
 
 from keep_gpu.global_gpu_controller import global_gpu_controller as global_module
 from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.single_gpu_controller import cuda_gpu_controller as cuda_module
 from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
 from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
 from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
@@ -108,15 +109,16 @@ def test_direct_cuda_rocm_controllers_reject_invalid_visible_ranks(
         controller(rank=rank, vram_to_keep=4)
 
 
-@pytest.mark.parametrize("matmul_iterations", [1.5, True, "5000"])
-def test_cuda_controller_rejects_non_integer_matmul_iteration_alias(
-    matmul_iterations,
-):
-    with pytest.raises(TypeError, match="relu_iterations must be an integer"):
+def test_cuda_controller_rejects_matmul_iteration_alias_keyword(monkeypatch):
+    monkeypatch.setattr(cuda_module, "visible_torch_device_count", lambda: 1)
+
+    with pytest.raises(
+        TypeError, match="unexpected keyword argument 'matmul_iterations'"
+    ):
         CudaGPUController(
             rank=0,
             vram_to_keep=4,
-            matmul_iterations=matmul_iterations,
+            matmul_iterations=1,
         )
 
 


### PR DESCRIPTION
## Summary
- Remove the legacy CUDA `matmul_iterations` constructor alias so public tuning uses `relu_iterations` consistently.
- Add a contract test for the removed keyword and document the API cleanup plan.
- Update AGENTS.md and stale internal wording to avoid reintroducing matmul vocabulary accidentally.

## Test Plan
- `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/drop-cuda-matmul-alias/src pytest tests/global_controller/test_contract.py::test_cuda_controller_rejects_matmul_iteration_alias_keyword -q`
- `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/drop-cuda-matmul-alias/src pytest tests/global_controller/test_contract.py -q`
- `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/drop-cuda-matmul-alias/src mkdocs build` (passes with existing Material/MkDocs 2.0 warning)
- `pre-commit run --all-files`
- Local subagent review: no Critical/Important/Minor findings after follow-up; reviewer also ran `test_contract.py`, `test_throttle.py`, docs build, and diff check read-only.
