### PR TITLE
[tests, docs] test: gate large memory marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,9 +311,10 @@ This file defines how coding agents should work in this repository.
   - `pytest tests/mcp tests/utilities/test_gpu_info.py`
   - `pytest tests/rocm_controller/test_rocm_utilization.py tests/utilities/test_gpu_info.py`
   - `pytest --run-rocm tests/rocm_controller` (only on ROCm-capable machines)
+  - `pytest --run-large-memory -m large_memory` (only on machines where large VRAM allocations are acceptable)
 - Respect existing pytest markers:
   - `rocm` for ROCm-only tests
-  - `large_memory` for opt-in heavy VRAM tests
+  - `large_memory` for opt-in heavy VRAM tests; these are skipped unless `--run-large-memory` is supplied
 - Run `pre-commit run --all-files` before final push.
 
 ### Documentation and Build Expectations

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ to zero devices.
   for install compatibility; ROCm SMI comes from the ROCm/system stack.
 - Fast CUDA checks: `pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py tests/test_cli_thresholds.py`
 - ROCm visibility tests use mocks and run without hardware; ROCm-only hardware tests carry `@pytest.mark.rocm` and run with `pytest --run-rocm tests/rocm_controller`.
-- Markers: `rocm` (needs ROCm stack) and `large_memory` (opt-in locally).
+- Large VRAM tests carry `@pytest.mark.large_memory` and are skipped unless
+  explicitly run with `pytest --run-large-memory -m large_memory`.
 
 ### MCP and service API
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,12 +27,16 @@ expectations so you can get productive quickly and avoid surprises in CI.
   ```bash
   pytest --run-rocm tests/rocm_controller
   ```
+- Heavy VRAM tests are marked `large_memory` and skipped by default; run only
+  on a machine where the allocation is acceptable:
+  ```bash
+  pytest --run-large-memory -m large_memory
+  ```
 - MCP + utilities:
   ```bash
   pytest tests/mcp tests/utilities/test_gpu_info.py
   ```
-- All tests honor markers `rocm` and `large_memory`; avoid enabling
-  `large_memory` in CI.
+- Avoid enabling `large_memory` in CI.
 
 ## Lint/format
 

--- a/docs/plans/large-memory-marker-gate.md
+++ b/docs/plans/large-memory-marker-gate.md
@@ -1,0 +1,29 @@
+# Large Memory Marker Gate
+
+## Background
+
+KeepGPU documents `large_memory` tests as opt-in because they may allocate
+large VRAM. The pytest configuration registered the marker but did not skip it
+by default, so the marked CUDA allocation test could run whenever CUDA was
+available.
+
+## Goal
+
+Keep the repository small and friendly for ordinary development and CI by making heavy
+VRAM tests opt-in with an explicit `--run-large-memory` flag.
+
+## Solution
+
+- Add a pytest `--run-large-memory` option beside the existing `--run-rocm` and
+  `--run-macm` gates.
+- Skip tests marked `large_memory` unless the flag is supplied.
+- Add a hardware-free pytester regression test for both the default skip path
+  and the explicit opt-in path.
+- Update README, contributor docs, and AGENTS guidance with the exact command.
+
+## Validation
+
+- `PYTHONPATH=$PWD/src pytest tests/test_pytest_marker_gates.py -q`
+- `PYTHONPATH=$PWD/src pytest -q -m large_memory tests/cuda_controller/test_2_32pow_elements.py -rs`
+- `PYTHONPATH=$PWD/src pytest --collect-only -q -m large_memory tests`
+- `pre-commit run --all-files`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,20 +14,34 @@ def pytest_addoption(parser):
         default=False,
         help="run tests marked as macm (require Apple Silicon MPS)",
     )
+    parser.addoption(
+        "--run-large-memory",
+        action="store_true",
+        default=False,
+        help="run tests marked as large_memory (may allocate large VRAM)",
+    )
+
+
+def _skip_marked(items, marker_name, reason):
+    skip_marker = pytest.mark.skip(reason=reason)
+    for item in items:
+        if item.get_closest_marker(marker_name) is not None:
+            item.add_marker(skip_marker)
 
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--run-rocm"):
-        skip_rocm = pytest.mark.skip(reason="need --run-rocm option to run")
-        for item in items:
-            if "rocm" in item.keywords:
-                item.add_marker(skip_rocm)
+        _skip_marked(items, "rocm", "need --run-rocm option to run")
 
     if not config.getoption("--run-macm"):
-        skip_macm = pytest.mark.skip(reason="need --run-macm option to run")
-        for item in items:
-            if "macm" in item.keywords:
-                item.add_marker(skip_macm)
+        _skip_marked(items, "macm", "need --run-macm option to run")
+
+    if not config.getoption("--run-large-memory"):
+        _skip_marked(
+            items,
+            "large_memory",
+            "need --run-large-memory option to run",
+        )
 
 
 @pytest.fixture

--- a/tests/test_pytest_marker_gates.py
+++ b/tests/test_pytest_marker_gates.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+pytest_plugins = ("pytester",)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_CONFTEST = PROJECT_ROOT / "tests" / "conftest.py"
+
+
+def _install_project_conftest(pytester):
+    pytester.makeconftest(PROJECT_CONFTEST.read_text(encoding="utf-8"))
+    pytester.makeini(
+        """
+        [pytest]
+        markers =
+            large_memory: tests that use large VRAM
+        """
+    )
+
+
+def test_large_memory_tests_skip_without_explicit_opt_in(pytester):
+    _install_project_conftest(pytester)
+    pytester.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.mark.large_memory
+        def test_large_allocation_placeholder():
+            raise AssertionError("large memory test should be opt-in")
+        """
+    )
+
+    result = pytester.runpytest("-q", "-rs")
+
+    result.assert_outcomes(skipped=1)
+    result.stdout.fnmatch_lines(["*need --run-large-memory option to run*"])
+
+
+def test_large_memory_tests_run_with_explicit_opt_in(pytester):
+    _install_project_conftest(pytester)
+    pytester.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.mark.large_memory
+        def test_large_allocation_placeholder():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest("--run-large-memory", "-q")
+
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
- add an explicit pytest `--run-large-memory` opt-in gate for tests marked `large_memory`
- add a hardware-free pytester regression for default skip and explicit opt-in behavior
- document the exact command in README, contributing docs, AGENTS, and a short plan note

## Test Plan
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest tests/test_pytest_marker_gates.py -q`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest -q -m large_memory tests/cuda_controller/test_2_32pow_elements.py -rs`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest --run-large-memory -q -m large_memory tests/cuda_controller/test_2_32pow_elements.py -rs`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest --collect-only -q -m large_memory tests`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest --run-large-memory --collect-only -q -m large_memory tests`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src mkdocs build`
- [x] `pre-commit run --all-files`
- [x] `PYTHONPATH=/root/new_test/KeepGPU/.worktrees/codex/gate-large-memory-tests/src pytest tests -q`