### PR TITLE
[cli, mcp] refactor: share endpoint validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,10 @@ This file defines how coding agents should work in this repository.
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`
   objects for invalid endpoints, not tracebacks.
+- Shared public endpoint validation belongs in
+  `src/keep_gpu/utilities/endpoint_validation.py`; CLI and MCP entry points
+  should only translate those `ValueError`s into their interface-specific error
+  shape.
 - JSON-output service commands (`status`, `stop`, `list-gpus`) must parse
   `--port` through command-level validation so non-integer values return the
   shared structured `{"error": "port must be an integer between 1 and 65535"}`

--- a/docs/plans/shared-endpoint-validation.md
+++ b/docs/plans/shared-endpoint-validation.md
@@ -1,0 +1,34 @@
+# Shared Endpoint Validation
+
+## Background
+
+The CLI service commands and MCP HTTP executable now enforce the same public
+endpoint contract: `--host` must be a DNS hostname or IPv4 literal, and `--port`
+must be an integer in `1..65535`. The implementations are near-copies in
+`src/keep_gpu/cli.py` and `src/keep_gpu/mcp/server.py`, including duplicated
+error strings and DNS/IP parsing logic.
+
+## Goal
+
+Keep the endpoint contract identical across CLI and MCP while making the code
+smaller and easier to audit.
+
+## Solution
+
+- Add a pure `src/keep_gpu/utilities/endpoint_validation.py` helper with shared
+  error constants and `ValueError`-raising host/port validators.
+- Keep CLI and MCP adapters thin:
+  - CLI wraps utility `ValueError`s as `typer.BadParameter`.
+  - MCP keeps `argparse` behavior and calls `parser.error(str(exc))`.
+- Preserve the current behavior difference where CLI JSON-output commands pass
+  string ports into validation for structured JSON errors, while MCP still lets
+  `argparse(type=int)` reject non-integer port tokens before utility validation.
+- Add focused utility tests and keep existing CLI/MCP endpoint regression tests.
+
+## Validation
+
+- `PYTHONPATH=$PWD/src pytest tests/utilities/test_endpoint_validation.py -q`
+- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k "validate_cli_service_host or invalid_host or invalid_port or non_integer_port or service_stop"`
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k "endpoint"`
+- `PYTHONPATH=$PWD/src mkdocs build`
+- `pre-commit run --all-files`

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ipaddress
 import json
 import math
 import os
@@ -20,6 +19,11 @@ from urllib.request import Request, urlopen
 import typer
 from rich.console import Console
 
+from keep_gpu.utilities.endpoint_validation import (
+    validate_endpoint,
+    validate_endpoint_host,
+    validate_endpoint_port,
+)
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
@@ -33,8 +37,6 @@ from keep_gpu.utilities.session_config import (
 DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
 JSONRPC_STARTUP_UNAVAILABLE = -32000
-SERVICE_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
-SERVICE_PORT_ERROR = "port must be an integer between 1 and 65535"
 ROOT_BLOCKING_OPTION_LABELS = {
     "gpu_ids": "--gpu-ids",
     "vram": "--vram",
@@ -304,59 +306,24 @@ def _validate_cli_job_id(job_id: Optional[str]) -> Optional[str]:
 
 
 def _validate_cli_service_host(host: str) -> str:
-    def _is_dns_hostname(value: str) -> bool:
-        if len(value) > 253 or value.endswith("."):
-            return False
-        labels = value.split(".")
-        if labels[-1].isdigit():
-            return False
-        for label in labels:
-            if not 1 <= len(label) <= 63:
-                return False
-            if label.startswith("-") or label.endswith("-"):
-                return False
-            if not all(
-                char.isascii() and (char.isalnum() or char == "-") for char in label
-            ):
-                return False
-        return True
-
-    if not isinstance(host, str) or host.strip() != host or not host:
-        raise typer.BadParameter(SERVICE_HOST_ERROR)
     try:
-        parsed_ip = ipaddress.ip_address(host)
-    except ValueError:
-        if not _is_dns_hostname(host):
-            raise typer.BadParameter(SERVICE_HOST_ERROR) from None
-    else:
-        if parsed_ip.version != 4:
-            raise typer.BadParameter(SERVICE_HOST_ERROR)
-    return host
+        return validate_endpoint_host(host)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _validate_cli_service_port(port: Any) -> int:
-    if isinstance(port, bool):
-        raise typer.BadParameter(SERVICE_PORT_ERROR)
-
-    if isinstance(port, int):
-        parsed_port = port
-    elif isinstance(port, str):
-        if not port or port.strip() != port:
-            raise typer.BadParameter(SERVICE_PORT_ERROR)
-        try:
-            parsed_port = int(port)
-        except ValueError:
-            raise typer.BadParameter(SERVICE_PORT_ERROR) from None
-    else:
-        raise typer.BadParameter(SERVICE_PORT_ERROR)
-
-    if not 1 <= parsed_port <= 65535:
-        raise typer.BadParameter(SERVICE_PORT_ERROR)
-    return parsed_port
+    try:
+        return validate_endpoint_port(port)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _validate_cli_service_endpoint(host: str, port: Any) -> Tuple[str, int]:
-    return _validate_cli_service_host(host), _validate_cli_service_port(port)
+    try:
+        return validate_endpoint(host, port)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _is_commandline_parameter_source(source: Any) -> bool:

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -49,11 +49,7 @@ from keep_gpu.global_gpu_controller.global_gpu_controller import (
     GlobalGPUController,
     InvalidVisibleGPUSelectionError,
 )
-from keep_gpu.utilities.endpoint_validation import (
-    validate_endpoint,
-    validate_endpoint_host,
-    validate_endpoint_port,
-)
+from keep_gpu.utilities.endpoint_validation import validate_endpoint
 from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.humanized_input import (
     PUBLIC_VRAM_MAX_BYTES,
@@ -1406,14 +1402,6 @@ def run_http(server: KeepGPUServer, host: str = "127.0.0.1", port: int = 8765) -
         httpd.shutdown()
         httpd.server_close()
         server.shutdown()
-
-
-def _validate_mcp_http_host(host: str) -> str:
-    return validate_endpoint_host(host)
-
-
-def _validate_mcp_http_port(port: int) -> int:
-    return validate_endpoint_port(port)
 
 
 def _validate_mcp_http_endpoint(host: str, port: int) -> tuple[str, int]:

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import argparse
 import atexit
-import ipaddress
 import json
 import math
 import mimetypes
@@ -49,6 +48,11 @@ from keep_gpu.global_gpu_controller.global_gpu_controller import (
     ControllerStartupUnavailable,
     GlobalGPUController,
     InvalidVisibleGPUSelectionError,
+)
+from keep_gpu.utilities.endpoint_validation import (
+    validate_endpoint,
+    validate_endpoint_host,
+    validate_endpoint_port,
 )
 from keep_gpu.utilities.gpu_info import get_gpu_info
 from keep_gpu.utilities.humanized_input import (
@@ -76,8 +80,6 @@ JSONRPC_METHOD_NOT_FOUND = -32601
 JSONRPC_INVALID_PARAMS = -32602
 JSONRPC_INTERNAL_ERROR = -32603
 JSONRPC_STARTUP_UNAVAILABLE = -32000
-MCP_ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
-MCP_ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
 STARTUP_STOP_WAIT_TIMEOUT_SECONDS = 10.0
 
 MCP_TOOLS: List[Dict[str, Any]] = [
@@ -1407,44 +1409,15 @@ def run_http(server: KeepGPUServer, host: str = "127.0.0.1", port: int = 8765) -
 
 
 def _validate_mcp_http_host(host: str) -> str:
-    def _is_dns_hostname(value: str) -> bool:
-        if len(value) > 253 or value.endswith("."):
-            return False
-        labels = value.split(".")
-        if labels[-1].isdigit():
-            return False
-        for label in labels:
-            if not 1 <= len(label) <= 63:
-                return False
-            if label.startswith("-") or label.endswith("-"):
-                return False
-            if not all(
-                char.isascii() and (char.isalnum() or char == "-") for char in label
-            ):
-                return False
-        return True
-
-    if not isinstance(host, str) or host.strip() != host or not host:
-        raise ValueError(MCP_ENDPOINT_HOST_ERROR)
-    try:
-        parsed_ip = ipaddress.ip_address(host)
-    except ValueError:
-        if not _is_dns_hostname(host):
-            raise ValueError(MCP_ENDPOINT_HOST_ERROR) from None
-    else:
-        if parsed_ip.version != 4:
-            raise ValueError(MCP_ENDPOINT_HOST_ERROR)
-    return host
+    return validate_endpoint_host(host)
 
 
 def _validate_mcp_http_port(port: int) -> int:
-    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
-        raise ValueError(MCP_ENDPOINT_PORT_ERROR)
-    return port
+    return validate_endpoint_port(port)
 
 
 def _validate_mcp_http_endpoint(host: str, port: int) -> tuple[str, int]:
-    return _validate_mcp_http_host(host), _validate_mcp_http_port(port)
+    return validate_endpoint(host, port)
 
 
 def main() -> None:

--- a/src/keep_gpu/utilities/endpoint_validation.py
+++ b/src/keep_gpu/utilities/endpoint_validation.py
@@ -1,0 +1,69 @@
+"""Shared validation for public HTTP endpoint inputs."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, Tuple
+
+ENDPOINT_HOST_ERROR = "host must be a DNS hostname or IPv4 address"
+ENDPOINT_PORT_ERROR = "port must be an integer between 1 and 65535"
+
+
+def _is_dns_hostname(value: str) -> bool:
+    if len(value) > 253 or value.endswith("."):
+        return False
+    labels = value.split(".")
+    if labels[-1].isdigit():
+        return False
+    for label in labels:
+        if not 1 <= len(label) <= 63:
+            return False
+        if label.startswith("-") or label.endswith("-"):
+            return False
+        if not all(
+            char.isascii() and (char.isalnum() or char == "-") for char in label
+        ):
+            return False
+    return True
+
+
+def validate_endpoint_host(host: Any) -> str:
+    """Validate a public service host as a DNS hostname or IPv4 literal."""
+    if not isinstance(host, str) or host.strip() != host or not host:
+        raise ValueError(ENDPOINT_HOST_ERROR)
+    try:
+        parsed_ip = ipaddress.ip_address(host)
+    except ValueError:
+        if not _is_dns_hostname(host):
+            raise ValueError(ENDPOINT_HOST_ERROR) from None
+    else:
+        if parsed_ip.version != 4:
+            raise ValueError(ENDPOINT_HOST_ERROR)
+    return host
+
+
+def validate_endpoint_port(port: Any) -> int:
+    """Validate a public service port and return it as an integer."""
+    if isinstance(port, bool):
+        raise ValueError(ENDPOINT_PORT_ERROR)
+
+    if isinstance(port, int):
+        parsed_port = port
+    elif isinstance(port, str):
+        if not port or port.strip() != port:
+            raise ValueError(ENDPOINT_PORT_ERROR)
+        try:
+            parsed_port = int(port)
+        except ValueError:
+            raise ValueError(ENDPOINT_PORT_ERROR) from None
+    else:
+        raise ValueError(ENDPOINT_PORT_ERROR)
+
+    if not 1 <= parsed_port <= 65535:
+        raise ValueError(ENDPOINT_PORT_ERROR)
+    return parsed_port
+
+
+def validate_endpoint(host: Any, port: Any) -> Tuple[str, int]:
+    """Validate a public service host/port pair."""
+    return validate_endpoint_host(host), validate_endpoint_port(port)

--- a/tests/utilities/test_endpoint_validation.py
+++ b/tests/utilities/test_endpoint_validation.py
@@ -3,6 +3,7 @@ import pytest
 from keep_gpu.utilities.endpoint_validation import (
     ENDPOINT_HOST_ERROR,
     ENDPOINT_PORT_ERROR,
+    validate_endpoint,
     validate_endpoint_host,
     validate_endpoint_port,
 )
@@ -63,3 +64,14 @@ def test_validate_endpoint_port_accepts_ints_and_clean_digit_strings(port):
 def test_validate_endpoint_port_rejects_invalid_values(port):
     with pytest.raises(ValueError, match=ENDPOINT_PORT_ERROR):
         validate_endpoint_port(port)
+
+
+def test_validate_endpoint_returns_normalized_host_and_port_pair():
+    assert validate_endpoint("localhost", "8765") == ("localhost", 8765)
+
+
+def test_validate_endpoint_rejects_invalid_host_or_port():
+    with pytest.raises(ValueError, match=ENDPOINT_HOST_ERROR):
+        validate_endpoint("bad host", "8765")
+    with pytest.raises(ValueError, match=ENDPOINT_PORT_ERROR):
+        validate_endpoint("localhost", "70000")

--- a/tests/utilities/test_endpoint_validation.py
+++ b/tests/utilities/test_endpoint_validation.py
@@ -1,0 +1,65 @@
+import pytest
+
+from keep_gpu.utilities.endpoint_validation import (
+    ENDPOINT_HOST_ERROR,
+    ENDPOINT_PORT_ERROR,
+    validate_endpoint_host,
+    validate_endpoint_port,
+)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "localhost",
+        "gpu-box",
+        "gpu-box.local",
+        "node-01.cluster.local",
+        "127.0.0.1",
+        "0.0.0.0",
+    ],
+)
+def test_validate_endpoint_host_accepts_dns_names_and_ipv4_literals(host):
+    assert validate_endpoint_host(host) == host
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "",
+        " ",
+        "bad host",
+        "%",
+        "%zz",
+        "\\host",
+        "host\\path",
+        "*",
+        "-bad",
+        "bad-",
+        "bad..host",
+        "999.999.999.999",
+        "256.0.0.1",
+        "123",
+        "foo.123",
+        "http://localhost",
+        "localhost:8765",
+        "::1",
+    ],
+)
+def test_validate_endpoint_host_rejects_malformed_values(host):
+    with pytest.raises(ValueError, match=ENDPOINT_HOST_ERROR):
+        validate_endpoint_host(host)
+
+
+@pytest.mark.parametrize("port", [1, 8765, 65535, "1", "8765", "65535"])
+def test_validate_endpoint_port_accepts_ints_and_clean_digit_strings(port):
+    assert validate_endpoint_port(port) == int(port)
+
+
+@pytest.mark.parametrize(
+    "port",
+    [0, 65536, -1, True, False, "", " ", "abc", " 8765", "8765 ", 8765.0, None],
+)
+def test_validate_endpoint_port_rejects_invalid_values(port):
+    with pytest.raises(ValueError, match=ENDPOINT_PORT_ERROR):
+        validate_endpoint_port(port)


### PR DESCRIPTION
## Summary
- Move duplicated CLI/MCP host and port validation into `keep_gpu.utilities.endpoint_validation`.
- Keep CLI and MCP adapters thin so Typer JSON errors and argparse endpoint failures preserve their current interface shape.
- Add focused utility tests plus a short plan and AGENTS ownership note.

## Test Plan
- PYTHONPATH=$PWD/src pytest tests/utilities/test_endpoint_validation.py -q
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k "validate_cli_service_host or invalid_host or invalid_port or non_integer_port or service_stop"
- PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k "endpoint"
- PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q
- PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q
- PYTHONPATH=$PWD/src pytest tests/utilities/test_endpoint_validation.py tests/test_cli_service_commands.py tests/mcp/test_server.py -q
- PYTHONPATH=$PWD/src mkdocs build
- pre-commit run --all-files --show-diff-on-failure

## Local Review
- Ohm the 2nd reviewed correctness/reliability; no must-fix findings, ready for PR.
- Averroes the 2nd reviewed small-repo discipline; no must-fix findings, ready for PR.