### PR TITLE
[cli, docs] test: trim endpoint wrapper matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,10 @@ This file defines how coding agents should work in this repository.
 - Respect existing pytest markers:
   - `rocm` for ROCm-only tests
   - `large_memory` for opt-in heavy VRAM tests; these are skipped unless `--run-large-memory` is supplied
+- Keep broad validation matrices in the utility or controller test that owns
+  the contract; CLI, REST, JSON-RPC, and MCP wrapper tests should use
+  representative smoke cases plus side-effect guards instead of repeating every
+  edge case.
 - Run `pre-commit run --all-files` before final push.
 
 ### Documentation and Build Expectations

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,6 +37,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   pytest tests/mcp tests/utilities/test_gpu_info.py
   ```
 - Avoid enabling `large_memory` in CI.
+- Keep broad validation matrices with the utility or controller that owns the
+  contract; interface tests should use representative smoke cases plus
+  side-effect guards instead of repeating every edge case.
 
 ## Lint/format
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -396,49 +396,14 @@ def test_start_command_rejects_invalid_port_before_auto_start(monkeypatch):
     assert called == {"ensure": False, "rpc": False}
 
 
-@pytest.mark.parametrize(
-    "host",
-    [
-        "localhost",
-        "gpu-box",
-        "gpu-box.local",
-        "node-01.cluster.local",
-        "127.0.0.1",
-        "0.0.0.0",
-    ],
-)
-def test_validate_cli_service_host_accepts_dns_names_and_ipv4_literals(host):
-    assert cli._validate_cli_service_host(host) == host
+def test_validate_cli_service_host_delegates_to_shared_validator():
+    assert cli._validate_cli_service_host("localhost") == "localhost"
 
-
-@pytest.mark.parametrize(
-    "host",
-    [
-        "",
-        " ",
-        "bad host",
-        "%",
-        "%zz",
-        "\\host",
-        "host\\path",
-        "*",
-        "-bad",
-        "bad-",
-        "bad..host",
-        "999.999.999.999",
-        "256.0.0.1",
-        "123",
-        "foo.123",
-        "http://localhost",
-        "localhost:8765",
-    ],
-)
-def test_validate_cli_service_host_rejects_malformed_values(host):
     with pytest.raises(
         cli.typer.BadParameter,
         match="host must be a DNS hostname or IPv4 address",
     ):
-        cli._validate_cli_service_host(host)
+        cli._validate_cli_service_host("bad host")
 
 
 def test_start_command_rejects_non_whitespace_malformed_host_before_auto_start(


### PR DESCRIPTION
## Summary
- Trim the duplicated CLI host-validation matrix now that endpoint parsing lives in `utilities.endpoint_validation`.
- Keep CLI coverage focused on wrapper behavior: valid delegation plus Typer `BadParameter` translation.
- Document the testing boundary in `AGENTS.md` and `docs/contributing.md` so future interface tests stay lean.

## Local Review
- Curie the 2nd: no must-fix issues; utility matrix covers the removed cases and CLI side-effect guards remain.
- Franklin the 2nd: no must-fix issues; change reduces bloat without weakening meaningful coverage.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_endpoint_validation.py tests/test_cli_service_commands.py -q -k 'endpoint_validation or validate_cli_service_host or invalid_host or invalid_port or non_integer_port or service_stop'`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_endpoint_validation.py -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files --show-diff-on-failure`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance to keep broad validation coverage in the core test that owns the behavior, with smaller wrapper-level smoke checks.

* **Tests**
  * Simplified host-validation test coverage for the CLI service command, keeping a representative valid case and an invalid-input check while reducing duplicated edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->