### PR TITLE
[cuda, telemetry] fix: retry UUID lookup as bytes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,14 @@ This file defines how coding agents should work in this repository.
   the current visible device count are public invalid-parameter errors
   (`-32602` for direct JSON-RPC, MCP tool `isError=true`), not internal server
   failures.
-- Keep CUDA telemetry aligned with visible CUDA ordinals: `get_gpu_utilization(index)` receives the visible rank used by `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES` ASCII numeric/UUID tokens to the correct NVML handle. If that mapping is malformed, duplicate/equivalent, ambiguous, or unsupported, return `None` without partial NVML handle queries so eco-safe backoff applies instead of falling back to a possibly wrong physical index.
+- Keep CUDA telemetry aligned with visible CUDA ordinals:
+  `get_gpu_utilization(index)` receives the visible rank used by
+  `CudaGPUController`, and `gpu_monitor.py` resolves `CUDA_VISIBLE_DEVICES`
+  ASCII numeric/UUID tokens to the correct NVML handle. UUID token resolution
+  must preserve NVML string/bytes lookup fallbacks. If that mapping is
+  malformed, duplicate/equivalent, ambiguous, or unsupported, return `None`
+  without partial NVML handle queries so eco-safe backoff applies instead of
+  falling back to a possibly wrong physical index.
 - Keep ROCm telemetry aligned with visible ROCm ordinals: resolve `ROCR_VISIBLE_DEVICES` as the base mask and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` ASCII numeric overlay before querying ROCm SMI. If the mapping is malformed, conflicting, unsupported, or out of range, return unavailable utilization rather than querying a guessed SMI index.
 - Keep GPU listing IDs aligned with start APIs: `list_gpus`/`/api/gpus`
   must expose `id` as the visible ordinal users can pass as `gpu_ids`;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,6 +40,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep broad validation matrices with the utility or controller that owns the
   contract; interface tests should use representative smoke cases plus
   side-effect guards instead of repeating every edge case.
+- When changing CUDA visibility telemetry, cover numeric and UUID
+  `CUDA_VISIBLE_DEVICES` masks, including NVML UUID string/bytes lookup
+  differences.
 
 ## Lint/format
 

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -172,9 +172,7 @@ class NVMLMonitor:
         for uuid in (token, token.encode("utf-8")):
             try:
                 return uuid_lookup(uuid)
-            except self._nvml.NVMLError:
-                return None
-            except (AttributeError, TypeError):
+            except (self._nvml.NVMLError, AttributeError, TypeError):
                 continue
         return None
 

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -20,6 +20,7 @@ class DummyNVML:
         util_by_index: dict[int, int] | None = None,
         util_by_uuid: dict[object, int] | None = None,
         fail_uuid_lookup: bool = False,
+        uuid_string_raises_nvml: bool = False,
         uuid_requires_bytes: bool = False,
         uuid_always_type_error: bool = False,
         support_uuid_lookup: bool = False,
@@ -36,6 +37,7 @@ class DummyNVML:
         self.util_by_index = util_by_index or {}
         self.util_by_uuid = util_by_uuid or {}
         self.fail_uuid_lookup = fail_uuid_lookup
+        self.uuid_string_raises_nvml = uuid_string_raises_nvml
         self.uuid_requires_bytes = uuid_requires_bytes
         self.uuid_always_type_error = uuid_always_type_error
         self.invalid_indexes = invalid_indexes or set()
@@ -68,6 +70,8 @@ class DummyNVML:
             self.uuid_requires_bytes and isinstance(uuid, str)
         ):
             raise TypeError("uuid must be bytes")
+        if self.uuid_string_raises_nvml and isinstance(uuid, str):
+            raise self.NVMLError("uuid string lookup failure")
         if self.fail_uuid_lookup:
             raise self.NVMLError("uuid lookup failure")
         return types.SimpleNamespace(uuid=uuid)
@@ -265,7 +269,7 @@ def test_monitor_returns_none_when_later_uuid_token_is_unresolved(monkeypatch):
 
     assert monitor.get_gpu_utilization(0) is None
     assert dummy.queried_indexes == []
-    assert dummy.queried_uuids == ["GPU-typo"]
+    assert dummy.queried_uuids == ["GPU-typo", b"GPU-typo"]
 
 
 def test_monitor_returns_none_for_numeric_uuid_alias_to_same_device(monkeypatch):
@@ -340,6 +344,21 @@ def test_monitor_retries_uuid_token_as_bytes_after_type_error(monkeypatch):
     assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]
 
 
+def test_monitor_retries_uuid_token_as_bytes_after_nvml_error(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc123")
+    dummy = DummyNVML(
+        gpu_util=99,
+        util_by_uuid={b"GPU-abc123": 62},
+        support_uuid_lookup=True,
+        uuid_string_raises_nvml=True,
+    )
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) == 62
+    assert dummy.queried_indexes == []
+    assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]
+
+
 def test_monitor_returns_none_when_uuid_lookup_type_errors_for_all_inputs(
     monkeypatch,
 ):
@@ -362,7 +381,7 @@ def test_monitor_returns_none_when_uuid_lookup_fails(monkeypatch):
 
     assert monitor.get_gpu_utilization(0) is None
     assert dummy.queried_indexes == []
-    assert dummy.queried_uuids == ["GPU-abc123"]
+    assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]
 
 
 def test_monitor_returns_none_when_prior_uuid_lookup_fails(monkeypatch):
@@ -376,4 +395,4 @@ def test_monitor_returns_none_when_prior_uuid_lookup_fails(monkeypatch):
 
     assert monitor.get_gpu_utilization(1) is None
     assert dummy.queried_indexes == []
-    assert dummy.queried_uuids == ["GPU-abc123"]
+    assert dummy.queried_uuids == ["GPU-abc123", b"GPU-abc123"]


### PR DESCRIPTION
## Summary
- Retry CUDA visibility UUID NVML lookup with bytes when the string form raises `NVMLError`.
- Keep genuine unresolved UUID masks unavailable after both forms fail, preserving eco-safe backoff instead of falling back to guessed physical indexes.
- Add a focused regression and update CUDA visibility telemetry guidance in `AGENTS.md` and `docs/contributing.md`.

## Root Cause / TDD
- Root cause: `NVMLMonitor._get_handle_for_visible_token()` returned `None` on the first UUID `NVMLError`, so it never tried the bytes UUID form that `gpu_info` already attempts.
- RED: `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_monitor.py::test_monitor_retries_uuid_token_as_bytes_after_nvml_error -q` failed with `assert None == 62` before the production change.
- GREEN: the same regression passed after continuing to the bytes UUID lookup.

## Local Review
- Laplace the 2nd: no findings; confirmed partial lookup protection and duplicate/malformed mask rejection are preserved.
- Godel the 2nd: no findings; confirmed the diff stays small and aligned with the low-power telemetry contract.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_monitor.py -q`
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_monitor.py tests/utilities/test_gpu_info.py -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files --show-diff-on-failure`
