### PR TITLE
[macm] fix: reject keep while stopping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,9 @@ This file defines how coding agents should work in this repository.
 - Single-GPU `keep()` must not report success until fatal backend startup setup
   has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
   must propagate synchronously so services cannot register false active sessions.
+- Single-GPU `keep()` must reject a restart while a previous worker thread is
+  still alive with its stop event already set; returning success in that state
+  hides a stopping keeper as if a fresh keep succeeded.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
 - Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -59,9 +59,10 @@ ctrl.release()
 ```
 
 The controller spins up a daemon thread. Repeated `keep()` calls are idempotent
-and simply warn if the worker is already running. CUDA and ROCm `keep()` calls
-return only after fatal backend startup setup succeeds, so startup failures such
-as device-selection errors are raised before your guarded work begins.
+and simply warn if the worker is already running, but a restart is rejected if
+the previous worker is still stopping. CUDA and ROCm `keep()` calls return only
+after fatal backend startup setup succeeds, so startup failures such as
+device-selection errors are raised before your guarded work begins.
 Invalid direct `rank` values are rejected even earlier, during construction.
 
 ## Guard multiple GPUs with a single context

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -50,6 +50,10 @@ class MacMGPUController(BaseGPUController):
 
     def keep(self) -> None:
         if self._thread and self._thread.is_alive():
+            if self._stop_evt is not None and self._stop_evt.is_set():
+                raise RuntimeError(
+                    f"rank {self.rank}: previous keep thread is still stopping"
+                )
             logger.warning("rank %s: keep thread already running", self.rank)
             return
 

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
@@ -39,6 +41,11 @@ class _StopWaitForbidden:
 
     def wait(self, _timeout):
         raise AssertionError("fatal worker failures should stop immediately")
+
+
+class _AliveThread:
+    def is_alive(self):
+        return True
 
 
 def _forbid_mps_availability_probe(monkeypatch):
@@ -98,6 +105,20 @@ def test_macm_constructor_preserves_unavailable_mps_runtime_error(monkeypatch):
 
     with pytest.raises(RuntimeError, match="PyTorch MPS backend is not available"):
         MacMGPUController(rank=0, busy_threshold=25, iterations=1)
+
+
+def test_macm_keep_rejects_restart_while_previous_thread_is_stopping():
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl._thread = _AliveThread()
+    ctrl._stop_evt = threading.Event()
+    ctrl._stop_evt.set()
+
+    with pytest.raises(
+        RuntimeError,
+        match="rank 0: previous keep thread is still stopping",
+    ):
+        ctrl.keep()
 
 
 def test_macm_unknown_utilization_backs_off_when_threshold_enabled():


### PR DESCRIPTION
## Summary
- Make `MacMGPUController.keep()` reject a restart while an existing worker is alive but already stopping.
- Align Mac M lifecycle behavior with CUDA/ROCm so callers do not get false-success `keep()` returns after release timeouts.
- Document the direct-controller lifecycle contract in `AGENTS.md` and the Python guide.

## Root Cause / TDD
- Root cause: Mac M only warned and returned when `_thread.is_alive()`, even if `_stop_evt` was already set.
- RED: after fixing a test-harness import mistake, `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py::test_macm_keep_rejects_restart_while_previous_thread_is_stopping -q` failed with `Failed: DID NOT RAISE RuntimeError` before production code changed.
- GREEN: the same regression passed after adding the stop-event guard.

## Local Review
- Hooke the 2nd: no findings; confirmed healthy repeated `keep()` remains idempotent and stopping-thread retries now match CUDA/ROCm.
- Parfit the 2nd: no findings; confirmed the patch stays small and the hardware-free test is appropriate.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py -q`
- `PYTHONPATH=$PWD/src pytest tests/macm_controller/test_macm_backoff.py tests/single_gpu_controller/test_release_contract.py -q`
- `PYTHONPATH=$PWD/src mkdocs build`
- `pre-commit run --all-files --show-diff-on-failure`
