### PR TITLE
[packaging] fix: make colorlog optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ This file defines how coding agents should work in this repository.
 - Build metadata should list directly used third-party distributions; do not
   rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.
+- Cosmetic logging helpers must stay optional; stdlib logging fallback is part
+  of the supported runtime path.
 - Keep `project.requires-python` aligned with the documented Python support
   floor and py38-targeted tooling.
 - Keep `project.urls` entries live and aligned with current repository

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep build metadata lean: list directly used third-party build/runtime
   distributions, do not rely on transitive dependencies, and do not list
   Python standard library modules such as `argparse`.
+- Keep cosmetic logging helpers optional. Console logging must work through the
+  Python standard library when packages such as `colorlog` are absent.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
 - Keep project URLs in package metadata pointing to live repository pages.
@@ -101,8 +103,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Update docs/README when behavior or interfaces change.
 - Run a local code review pass before merging; squash merge only after all
   review comments are resolved.
-- Stick to the existing style (Typer CLI, Rich logging) and keep code paths
-  simple—avoid over-engineering.
+- Stick to the existing style (Typer CLI, stdlib logging with optional color
+  helpers) and keep code paths simple—avoid over-engineering.
 
 ## Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "typer",
   "rich>=13.8.0",
   "torch",
-  "colorlog",
 ]
 
 [project.scripts]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from setuptools.config.pyprojecttoml import read_configuration
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -13,8 +15,27 @@ def _optional_dependency_lists():
     return config["project"]["optional-dependencies"]
 
 
+def _runtime_dependencies():
+    config = read_configuration(
+        str(PROJECT_ROOT / "pyproject.toml"),
+        expand=False,
+    )
+    return config["project"]["dependencies"]
+
+
+def _runtime_dependency_names():
+    return {
+        canonicalize_name(Requirement(dependency).name)
+        for dependency in _runtime_dependencies()
+    }
+
+
 def test_rocm_extra_is_declared_without_non_pypi_rocm_smi_dependency():
     extras = _optional_dependency_lists()
 
     assert "rocm" in extras
     assert "rocm-smi" not in extras["rocm"]
+
+
+def test_colorlog_is_not_a_required_runtime_dependency():
+    assert "colorlog" not in _runtime_dependency_names()

--- a/tests/utilities/test_logger.py
+++ b/tests/utilities/test_logger.py
@@ -1,0 +1,32 @@
+import importlib
+import logging
+import sys
+
+import keep_gpu.utilities.logger as logger_module
+
+
+def test_console_handler_falls_back_to_plain_formatter_without_colorlog(monkeypatch):
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "colorlog", None)
+            reloaded = importlib.reload(logger_module)
+
+            handler = reloaded._build_console_handler(logging.INFO)
+            record = logging.LogRecord(
+                name="keep_gpu.tests",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg="hello",
+                args=(),
+                exc_info=None,
+            )
+
+            rendered = handler.formatter.format(record)
+
+            assert reloaded.ColoredFormatter is None
+            assert "hello" in rendered
+            assert "INFO" in rendered
+            assert "log_color" not in rendered
+    finally:
+        importlib.reload(logger_module)


### PR DESCRIPTION
## Summary
- Remove `colorlog` from required runtime dependencies; logger color stays best-effort when the package is present.
- Add package metadata and logger fallback regression tests for the no-`colorlog` path.
- Update AGENTS/contributor guidance so cosmetic logging helpers stay optional.

## Local review
- Locke: no must-fix issues; agreed no optional extra is needed for a cosmetic helper.
- Peirce: no must-fix issues; accepted test/docs shape and suggested a small reload cleanup guard, which is included.

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py tests/utilities/test_logger.py` failed on required `colorlog`
- [x] GREEN: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py tests/utilities/test_logger.py` -> 3 passed
- [x] `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py tests/utilities/test_logger.py tests/test_cli_thresholds.py -q` -> 18 passed
- [x] `PYTHONPATH=$PWD/src pytest tests/mcp tests/utilities/test_gpu_info.py -q` -> 262 passed, 1 skipped
- [x] `PYTHONPATH=$PWD/src mkdocs build` -> passed (upstream Material warning only)
- [x] `python -m pip wheel --no-deps ...` + wheel METADATA inspection -> no `Requires-Dist: colorlog`
- [x] `pre-commit run --all-files --show-diff-on-failure` -> passed