### PR TITLE
[docs] fix: build api reference from src

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
           pip install -r docs/requirements.txt
 
       - name: Build site

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,13 +12,11 @@ build:
 
 python:
   install:
-    - method: pip
-      path: .
     - requirements: docs/requirements.txt
 
 # Build documentation with Mkdocs
 mkdocs:
-   configuration: mkdocs.yml
+  configuration: mkdocs.yml
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ This file defines how coding agents should work in this repository.
 - Python files that use PEP 604 annotations such as `X | Y` must include
   `from __future__ import annotations` while the project tooling targets
   Python 3.8.
+- MkDocs/mkdocstrings must resolve API references from the checkout's `src/`
+  tree so docs-only builds work with `docs/requirements.txt` alone.
 
 ### Git Hygiene & Security
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,6 +66,10 @@ expectations so you can get productive quickly and avoid surprises in CI.
 
 ## Docs
 
+- Install documentation dependencies once:
+  ```bash
+  pip install -r docs/requirements.txt
+  ```
 - Live preview:
   ```bash
   mkdocs serve
@@ -74,6 +78,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   ```bash
   mkdocs build
   ```
+- API reference pages are resolved from the checkout's `src/` tree, so docs-only
+  builds do not need `pip install .`.
 - Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
   stay in the repository but are excluded from the published MkDocs site.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,10 @@ plugins:
   - search
   - mkdocstrings:
       default_handler: python
+      handlers:
+        python:
+          paths:
+            - src
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Configure mkdocstrings to resolve API reference modules from the checkout's `src/` tree.
- Remove the package install step from docs-only GitHub Actions and ReadTheDocs builds so CI verifies the self-contained docs path.
- Update contributor and agent guidance for docs-only builds with `docs/requirements.txt`.

## Root Cause
MkDocs/mkdocstrings saw the repository root but not the `src/` package layout, so a docs-only environment could not collect `keep_gpu.cli` unless KeepGPU had already been installed.

## Local review
- Archimedes: no must-fix issues; verified mkdocstrings config and docs-only CI/RTD install shape.
- Bohr: no must-fix issues; confirmed wording and scope stay small and not bloated.

## Test Plan
- [x] RED: fresh venv with only `docs/requirements.txt`; `mkdocs build --strict` failed with `ModuleNotFoundError: No module named 'keep_gpu'`
- [x] GREEN: same no-install venv; `mkdocs build --strict` passed after adding `handlers.python.paths: [src]`
- [x] Fresh temp venv with only `docs/requirements.txt`; `mkdocs build --strict -d /tmp/.../site` passed
- [x] Normal local `mkdocs build --strict` passed
- [x] `pre-commit run --all-files --show-diff-on-failure` passed
- [x] Local subagent reviews completed with no must-fix findings