### PR TITLE
[readme] fix: close bibtex fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,4 @@ If you find **KeepGPU** useful in your research or work, please cite it as:
   note         = {GitHub repository},
   keywords     = {ai, hpc, gpu, cluster, cuda, torch, debug}
 }
+```

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -39,3 +39,10 @@ def test_rocm_extra_is_declared_without_non_pypi_rocm_smi_dependency():
 
 def test_colorlog_is_not_a_required_runtime_dependency():
     assert "colorlog" not in _runtime_dependency_names()
+
+
+def test_readme_markdown_code_fences_are_balanced():
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    fences = [line for line in readme.splitlines() if line.strip().startswith("```")]
+
+    assert len(fences) % 2 == 0


### PR DESCRIPTION
## Summary
- Close the README BibTeX fenced code block so the citation renders correctly.
- Add a small regression test that README fenced code blocks stay balanced.

## Local review
- Chandrasekhar: no must-fix issues; agreed the README fix is correct and the regression test is small enough for this bug.

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` failed with 29 README fences
- [x] GREEN: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` -> 3 passed
- [x] `mkdocs build --strict` -> passed (upstream Material warning only)
- [x] `pre-commit run --all-files --show-diff-on-failure` -> passed
- [x] Local subagent review completed with no must-fix findings