### PR TITLE
[packaging] fix: trim release artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ This file defines how coding agents should work in this repository.
 - Build metadata should list directly used third-party distributions; do not
   rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.
+- Source distributions should not ship the test suite by default; package data
+  should enumerate required runtime assets such as the MCP dashboard files.
 - Cosmetic logging helpers must stay optional; stdlib logging fallback is part
   of the supported runtime path.
 - Keep `project.requires-python` aligned with the documented Python support

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include tests *.py
+prune tests

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep build metadata lean: list directly used third-party build/runtime
   distributions, do not rely on transitive dependencies, and do not list
   Python standard library modules such as `argparse`.
+- Keep release artifacts lean: avoid shipping the test suite in sdists by
+  default, and enumerate required runtime assets instead of using broad package
+  data wildcards.
 - Keep cosmetic logging helpers optional. Console logging must work through the
   Python standard library when packages such as `colorlog` are absent.
 - Keep package metadata such as `requires-python` aligned with the documented

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,11 @@ homepage = "https://github.com/Wangmerlyn/KeepGPU"
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-"*" = ["*.*"]
+"keep_gpu.mcp" = [
+  "static/index.html",
+  "static/assets/*.css",
+  "static/assets/*.js",
+]
 
 # Dynamic version source: reads __version__ from keep_gpu package
 [tool.setuptools.dynamic]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -15,6 +15,14 @@ def _optional_dependency_lists():
     return config["project"]["optional-dependencies"]
 
 
+def _setuptools_config():
+    config = read_configuration(
+        str(PROJECT_ROOT / "pyproject.toml"),
+        expand=False,
+    )
+    return config["tool"]["setuptools"]
+
+
 def _runtime_dependencies():
     config = read_configuration(
         str(PROJECT_ROOT / "pyproject.toml"),
@@ -46,3 +54,28 @@ def test_readme_markdown_code_fences_are_balanced():
     fences = [line for line in readme.splitlines() if line.strip().startswith("```")]
 
     assert len(fences) % 2 == 0
+
+
+def test_sdist_manifest_does_not_package_test_suite():
+    manifest_path = PROJECT_ROOT / "MANIFEST.in"
+    assert manifest_path.exists()
+    manifest = manifest_path.read_text(encoding="utf-8")
+    active_lines = [
+        line.strip()
+        for line in manifest.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert active_lines == ["prune tests"]
+
+
+def test_package_data_only_includes_dashboard_static_assets():
+    package_data = _setuptools_config()["package-data"]
+
+    assert package_data == {
+        "keep_gpu.mcp": [
+            "static/index.html",
+            "static/assets/*.css",
+            "static/assets/*.js",
+        ],
+    }

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -66,7 +66,13 @@ def test_sdist_manifest_does_not_package_test_suite():
         if line.strip() and not line.lstrip().startswith("#")
     ]
 
-    assert active_lines == ["prune tests"]
+    assert "prune tests" in active_lines
+    assert not any(
+        parts[0] in {"graft", "include", "recursive-include"}
+        and len(parts) > 1
+        and parts[1].lstrip("./").startswith("tests")
+        for parts in (line.split() for line in active_lines)
+    )
 
 
 def test_package_data_only_includes_dashboard_static_assets():


### PR DESCRIPTION
## Summary
- Prune `tests/` from source distributions instead of recursively including the suite.
- Replace broad package-data wildcard with explicit MCP dashboard static assets.
- Add package metadata regression tests and short contributor/agent guardrails for lean artifacts.

## Root Cause
`MANIFEST.in` explicitly included `tests/*.py`, so the sdist shipped the test suite. `pyproject.toml` also used `"*" = ["*.*"]`, which made runtime package data less intentional than the three dashboard files the server actually serves.

## Evidence
- Before: sdist had 82 entries with test files; wheel had 0 tests and 3 dashboard static files.
- After: sdist has 45 entries, tests 0, dashboard static files 3; wheel tests 0, dashboard static files 3.

## Local review
- Dirac: no must-fix issues; agreed `prune tests` is minimal, `keep_gpu.mcp` owns the static asset paths, and docs/AGENTS wording is proportional.

## Test Plan
- [x] RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` failed on test-suite manifest include and wildcard package-data
- [x] GREEN: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` -> 5 passed
- [x] Built wheel and sdist; asserted no tests and 3 dashboard static files in both artifacts
- [x] `mkdocs build --strict` -> passed (upstream Material warning only)
- [x] `pre-commit run --all-files --show-diff-on-failure` -> passed
- [x] Local subagent review completed with no must-fix findings