### PR TITLE
[packaging, ci] fix: modernize license metadata

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,5 @@
-# This workflow will install Python dependencies and run tests with a single version of Python
+# This workflow installs Python dependencies and runs tests on the supported floor
+# plus the default development version.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -14,15 +15,18 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,17 +50,19 @@ This file defines how coding agents should work in this repository.
   `argparse` as build/runtime dependencies.
 - Source distributions should not ship the test suite by default; package data
   should enumerate required runtime assets such as the MCP dashboard files.
+- Keep license metadata as a plain SPDX string and keep the advertised Python
+  support floor aligned with build-backend requirements.
 - Cosmetic logging helpers must stay optional; stdlib logging fallback is part
   of the supported runtime path.
 - Keep `project.requires-python` aligned with the documented Python support
-  floor and py38-targeted tooling.
+  floor and py39-targeted tooling.
 - Keep `project.urls` entries live and aligned with current repository
   locations; avoid stale branch names or missing files.
 - Remove placeholder tests that assert no behavior instead of preserving
   count-only coverage.
 - Python files that use PEP 604 annotations such as `X | Y` must include
   `from __future__ import annotations` while the project tooling targets
-  Python 3.8.
+  Python 3.9.
 - MkDocs/mkdocstrings must resolve API references from the checkout's `src/`
   tree so docs-only builds work with `docs/requirements.txt` alone.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,6 +61,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep release artifacts lean: avoid shipping the test suite in sdists by
   default, and enumerate required runtime assets instead of using broad package
   data wildcards.
+- Keep package metadata warning-free with modern SPDX license strings and keep
+  the supported Python version floor aligned with build-backend requirements.
 - Keep cosmetic logging helpers optional. Console logging must work through the
   Python standard library when packages such as `colorlog` are absent.
 - Keep package metadata such as `requires-python` aligned with the documented

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ understand the minimum knobs you need to keep a GPU occupied.
 ## Requirements
 
 - NVIDIA drivers + CUDA runtime visible to PyTorch.
-- Python 3.8+ (matching the version in your environment/cluster image).
+- Python 3.9+ (matching the version in your environment/cluster image).
 - CUDA utilization monitoring uses NVML by way of `nvidia-ml-py` (the `pynvml` module);
   `nvidia-smi` is useful only as an external driver sanity check. ROCm telemetry
   uses `rocm_smi` when the ROCm/system stack provides it, and KeepGPU handles a

--- a/docs/plans/py38-postponed-annotations.md
+++ b/docs/plans/py38-postponed-annotations.md
@@ -1,23 +1,23 @@
-# Python 3.8 Annotation Compatibility Plan
+# Pre-Python 3.10 Annotation Compatibility Plan
 
 ## Background
 
-Project formatting/linting targets Python 3.8, but a few modules use PEP 604
-union annotations without `from __future__ import annotations`. On Python
-3.8/3.9 those annotations can be evaluated at import time and fail before users
-reach KeepGPU's platform detection, controllers, or tests.
+Project formatting/linting now targets Python 3.9, but a few modules use
+PEP 604 union annotations without `from __future__ import annotations`. On
+Python 3.9 those annotations can be evaluated at import time and fail before
+users reach KeepGPU's platform detection, controllers, or tests.
 
 ## Goal
 
 Keep modules with PEP 604 annotations import-compatible with the configured
-Python 3.8 target by requiring postponed annotations where that syntax appears.
+Python 3.9 target by requiring postponed annotations where that syntax appears.
 
 ## Solution
 
 - Add a static regression test that finds Python files containing PEP 604 union
   annotations without `from __future__ import annotations`.
 - Add the future import to the small set of affected source/test modules.
-- Update `AGENTS.md` so future edits keep Python 3.8-targeted annotations safe.
+- Update `AGENTS.md` so future edits keep Python 3.9-targeted annotations safe.
 
 ## Tasks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=61.0",
+  "setuptools>=77.0.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -9,7 +9,7 @@ name = "keep_gpu"
 dynamic = ["version"]  # Let setuptools read the version dynamically
 description = "Keep GPU is a simple CLI app that keeps your GPUs running"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 authors = [
   {name = "Siyuan Wang", email = "sywang0227@gmail.com"},
@@ -24,7 +24,7 @@ maintainers = [
 classifiers = [
 
 ]
-license = {text = "MIT license"}
+license = "MIT"
 dependencies = [
   "nvidia-ml-py",
   "typer",
@@ -128,13 +128,13 @@ disable_error_code = "attr-defined"
 # Black formatter
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py39']
 skip-string-normalization = false
 
 # Ruff linter
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/tests/test_annotation_compat.py
+++ b/tests/test_annotation_compat.py
@@ -158,7 +158,7 @@ def test_pep604_detector_counts_annotated_type_union():
     assert _uses_pep604_annotation(tree)
 
 
-def test_pep604_annotations_are_postponed_for_py38_target():
+def test_pep604_annotations_are_postponed_for_pre_py310_target():
     offenders = []
     for path in _python_files():
         text = path.read_text(encoding="utf-8")

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -23,6 +23,22 @@ def _setuptools_config():
     return config["tool"]["setuptools"]
 
 
+def _project_config():
+    config = read_configuration(
+        str(PROJECT_ROOT / "pyproject.toml"),
+        expand=False,
+    )
+    return config["project"]
+
+
+def _build_system_requires():
+    config = read_configuration(
+        str(PROJECT_ROOT / "pyproject.toml"),
+        expand=False,
+    )
+    return config["build-system"]["requires"]
+
+
 def _runtime_dependencies():
     config = read_configuration(
         str(PROJECT_ROOT / "pyproject.toml"),
@@ -47,6 +63,12 @@ def test_rocm_extra_is_declared_without_non_pypi_rocm_smi_dependency():
 
 def test_colorlog_is_not_a_required_runtime_dependency():
     assert "colorlog" not in _runtime_dependency_names()
+
+
+def test_license_metadata_uses_spdx_string_supported_by_python_floor():
+    assert _project_config()["requires-python"] == ">=3.9"
+    assert _project_config()["license"] == "MIT"
+    assert "setuptools>=77.0.1" in _build_system_requires()
 
 
 def test_readme_markdown_code_fences_are_balanced():


### PR DESCRIPTION
## Summary
- Replace deprecated table-form license metadata with an SPDX `MIT` string.
- Raise the advertised Python floor to 3.9 so the setuptools backend that supports SPDX license strings is resolvable.
- Align Black/Ruff targets, docs, AGENTS guidance, annotation test wording, and CI with the Python 3.9 floor.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py tests/test_annotation_compat.py -q`
- `uv run --no-project --python 3.9 --with build python -m build --sdist --outdir /tmp/keepgpu-license-py39-build .`
- `python -m build --sdist --wheel --outdir /tmp/keepgpu-license-metadata-final .`
- Verified wheel/sdist metadata include `License-Expression: MIT`, `License-File: LICENSE`, and `Requires-Python: >=3.9`.
- Python 3.9 venv source-sdist install succeeded; installed metadata reports `>=3.9` and `MIT`.
- `mkdocs build --strict` (only upstream Material warning)
- `pre-commit run --all-files --show-diff-on-failure`

## Review
- Local subagent review found the initial Python 3.8 source-build incompatibility; the branch now makes the support-floor change explicit.
- Final local subagent review found no must-fix issues; stale workflow wording was fixed before push.
