### PR TITLE
[ci] fix: keep pre-commit workflow lean

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,10 +19,10 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
+      - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install pre-commit
 
       - name: Run pre-commit (no fix)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ This file defines how coding agents should work in this repository.
 - Build metadata should list directly used third-party distributions; do not
   rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.
+- Pre-commit CI should install only the `pre-commit` runner; hooks provision
+  their own tool environments, so do not install KeepGPU runtime dependencies
+  just to lint.
 - Source distributions should not ship the test suite by default; package data
   should enumerate required runtime assets such as the MCP dashboard files.
 - Keep license metadata as a plain SPDX string and keep the advertised Python

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,6 +55,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   intentionally not part of the repository.
 - Keep Ruff settings in `pyproject.toml`; do not add a standalone `ruff.toml`
   unless the full configuration is intentionally migrated there.
+- Keep pre-commit CI lean: install the `pre-commit` runner only, and let hooks
+  provision their own tool environments instead of installing KeepGPU runtime
+  dependencies.
 - Keep build metadata lean: list directly used third-party build/runtime
   distributions, do not rely on transitive dependencies, and do not list
   Python standard library modules such as `argparse`.

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_precommit_workflow_does_not_install_runtime_package():
+    workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
+    if not workflow_path.exists():
+        workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    pip_install_commands = re.findall(
+        r"^\s*(?:python\s+-m\s+)?pip\s+install\b.*$", workflow, re.MULTILINE
+    )
+    normalized_commands = [
+        re.sub(r"\s+", " ", command.strip()) for command in pip_install_commands
+    ]
+
+    assert normalized_commands == [
+        "python -m pip install --upgrade pip",
+        "pip install pre-commit",
+    ]


### PR DESCRIPTION
## Summary
- Install only the `pre-commit` runner in pre-commit CI instead of installing KeepGPU with dev extras.
- Add a regression test that keeps pre-commit CI from pulling runtime package dependencies.
- Document the lean pre-commit CI guardrail in AGENTS and contributing docs.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py -q`
- `pre-commit run --all-files --show-diff-on-failure`
- `mkdocs build --strict` (only upstream Material warning)

## Review
- Local subagent review found no must-fix issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined the pre-commit CI setup so it installs only the pre-commit runner, reducing unnecessary setup time and dependencies.

* **Documentation**
  * Updated contributor guidance to clarify the preferred pre-commit CI installation approach.

* **Tests**
  * Added workflow coverage to ensure the pre-commit CI setup stays limited to upgrading pip and installing pre-commit only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->