### PR TITLE
[telemetry] fix: recover vendor monitor sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,10 @@ This file defines how coding agents should work in this repository.
   For CUDA and ROCm, reject non-integer `rank` values before calling
   `torch.cuda.device_count()`.
 - Hardware probes must clean up vendor libraries after detection (for example, NVML shutdown and ROCm SMI shutdown after init).
+- Runtime telemetry must tolerate those independent vendor-library probes. If a
+  listing/detection path shuts down NVML or ROCm SMI after a keep loop has
+  cached telemetry initialization, the runtime monitor should reinitialize once
+  before reporting utilization as unavailable.
 - ROCm/HIP PyTorch builds take precedence over NVML-based CUDA fallback: if `torch.version.hip` is truthy, `_check_cuda()` must not classify the runtime as CUDA or probe NVML.
 - Keep lifecycle state truthful: a reserved starting session must be visible in status as `state="starting"`; a session is removed only after release succeeds; timed-out or failed stops must stay visible with state and error details.
 - Status responses must be read-only snapshots. Returning active or starting

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -124,6 +124,12 @@ immediately, so detection does not leave NVML or ROCm SMI handles open. A PyTorc
 build with a truthy `torch.version.hip` is treated as ROCm before any NVML-based
 CUDA fallback, even if NVML is available on the host.
 
+Runtime telemetry has its own recovery path because GPU listing can run while a
+keeper is active. If an independent listing probe shuts down NVML or ROCm SMI,
+CUDA and ROCm utilization monitors reinitialize once before reporting telemetry
+as unavailable, preserving eco-safe backoff without wedging a keeper on stale
+library state.
+
 GPU listing follows the same precedence. On HIP/ROCm torch builds, `list_gpus`
 prefers ROCm records and ROCm SMI metadata instead of returning NVML CUDA records
 first on mixed hosts. If ROCm SMI is unavailable, listing falls back to

--- a/docs/plans/telemetry-reinit.md
+++ b/docs/plans/telemetry-reinit.md
@@ -1,0 +1,29 @@
+# Telemetry Reinitialization Plan
+
+## Background
+
+KeepGPU keeps runtime utilization eco-safe by treating unavailable telemetry as
+busy unless the user explicitly selects unconditional mode. GPU listing helpers
+probe vendor libraries independently and then shut them down, which can leave a
+long-lived keep-loop telemetry object with stale initialization state.
+
+## Goal
+
+Recover CUDA NVML and ROCm SMI utilization after an external probe shuts down the
+vendor library, without expanding the public API or adding background polling.
+
+## Solution
+
+- Add regression tests that simulate vendor shutdown after a successful query.
+- Reinitialize the vendor telemetry backend once when a stale-library query
+  fails.
+- Keep invalid visibility masks and unavailable telemetry as `None`.
+- Document the guardrail in `AGENTS.md`.
+
+## Todo
+
+- [x] Add RED tests for CUDA NVML and ROCm SMI stale-library recovery.
+- [x] Implement minimal reinitialization logic.
+- [x] Update agent guidance for vendor telemetry lifecycle recovery.
+- [x] Run targeted tests, pre-commit, and docs build.
+- [x] Request local subagent code review before opening the PR.

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -55,6 +55,7 @@ class RocmGPUController(BaseGPUController):
         self._thread: Optional[threading.Thread] = None
         self._failure_exc: Optional[Exception] = None
         self._num_elements: Optional[int] = None
+        self._rocm_smi_initialized = False
 
         # Lazy rocm_smi import; keep handle for reuse
         try:
@@ -77,11 +78,7 @@ class RocmGPUController(BaseGPUController):
         self._num_elements = int(self.vram_to_keep)
         if self._num_elements <= 0:
             raise ValueError("vram_to_keep must be positive")
-        if self._rocm_smi:
-            try:
-                self._rocm_smi.rsmi_init()
-            except Exception as exc:  # pragma: no cover - env-specific
-                logger.debug("rsmi_init failed: %s", exc)
+        self._ensure_rocm_smi_initialized()
 
         self._stop_evt = threading.Event()
         startup_evt = threading.Event()
@@ -120,11 +117,27 @@ class RocmGPUController(BaseGPUController):
         logger.info("rank %s: ROCm keep thread started", self.rank)
 
     def _shutdown_rocm_smi(self) -> None:
-        if self._rocm_smi:
-            try:
-                self._rocm_smi.rsmi_shut_down()
-            except Exception as exc:  # noqa: BLE001  # pragma: no cover - best effort
-                logger.debug("rsmi_shut_down failed: %s", exc)
+        if not self._rocm_smi:
+            return
+        try:
+            self._rocm_smi.rsmi_shut_down()
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - best effort
+            logger.debug("rsmi_shut_down failed: %s", exc)
+        finally:
+            self._rocm_smi_initialized = False
+
+    def _ensure_rocm_smi_initialized(self) -> bool:
+        if not self._rocm_smi:
+            return False
+        if self._rocm_smi_initialized:
+            return True
+        try:
+            self._rocm_smi.rsmi_init()
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - env-specific
+            logger.debug("rsmi_init failed: %s", exc)
+            return False
+        self._rocm_smi_initialized = True
+        return True
 
     def release(self) -> None:
         try:
@@ -178,17 +191,25 @@ class RocmGPUController(BaseGPUController):
         self.release()
 
     def _query_utilization(self) -> Optional[int]:
-        if not self._rocm_smi:
-            return None
-        smi_index = resolve_rocm_visible_rank_to_smi_index(self.rank, self._rocm_smi)
-        if smi_index is None:
-            return None
-        try:
-            util = self._rocm_smi.rsmi_dev_busy_percent_get(smi_index)
-            return int(util)
-        except Exception as exc:  # pragma: no cover - env-specific
-            logger.debug("ROCm utilization query failed: %s", exc)
-            return None
+        for attempt in range(2):
+            if not self._ensure_rocm_smi_initialized():
+                return None
+            try:
+                smi_index = resolve_rocm_visible_rank_to_smi_index(
+                    self.rank,
+                    self._rocm_smi,
+                )
+                if smi_index is None:
+                    return None
+                util = self._rocm_smi.rsmi_dev_busy_percent_get(smi_index)
+                return int(util)
+            except Exception as exc:  # noqa: BLE001  # pragma: no cover - env-specific
+                logger.debug("ROCm utilization query failed: %s", exc)
+                if attempt == 0:
+                    self._rocm_smi_initialized = False
+                    continue
+                return None
+        return None
 
     def _keep_loop(
         self,

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -65,18 +65,34 @@ class NVMLMonitor:
 
     def get_gpu_utilization(self, index: int) -> Optional[int]:
         """Return utilization percentage for `index`, or None when unavailable."""
-        if not self._ensure_initialized():
-            return None
-
-        try:
-            handle = self._get_handle_for_visible_index(index)
-            if handle is None:
+        for attempt in range(2):
+            if not self._ensure_initialized():
                 return None
-            rates = self._nvml.nvmlDeviceGetUtilizationRates(handle)
-            return int(rates.gpu)
-        except self._nvml.NVMLError as exc:
-            logger.debug("NVML query failed for GPU %s: %s", index, exc)
-            return None
+
+            try:
+                handle = self._get_handle_for_visible_index(index)
+                if handle is None:
+                    return None
+                rates = self._nvml.nvmlDeviceGetUtilizationRates(handle)
+                return int(rates.gpu)
+            except self._nvml.NVMLError as exc:
+                logger.debug("NVML query failed for GPU %s: %s", index, exc)
+                if attempt == 0 and self._is_uninitialized_error(exc):
+                    self._mark_uninitialized()
+                    continue
+                return None
+        return None
+
+    def _mark_uninitialized(self) -> None:
+        with self._lock:
+            self._initialized = False
+
+    def _is_uninitialized_error(self, exc: Exception) -> bool:
+        if exc.__class__.__name__ == "NVMLError_Uninitialized":
+            return True
+        return (
+            "uninitialized" in str(exc).lower() or "not initialized" in str(exc).lower()
+        )
 
     def _get_handle_for_visible_index(self, index: int):
         visible_mask = cuda_visible_mask()
@@ -115,7 +131,12 @@ class NVMLMonitor:
             return True
         try:
             count = int(count_lookup())
-        except (self._nvml.NVMLError, TypeError, ValueError) as exc:
+        except self._nvml.NVMLError as exc:
+            if self._is_uninitialized_error(exc):
+                raise
+            logger.debug("NVML device count query failed: %s", exc)
+            return False
+        except (TypeError, ValueError) as exc:
             logger.debug("NVML device count query failed: %s", exc)
             return False
         return all(token < count for token in numeric_tokens)
@@ -148,7 +169,11 @@ class NVMLMonitor:
         if index_lookup is not None:
             try:
                 return ("index", int(index_lookup(handle)))
-            except (self._nvml.NVMLError, TypeError, ValueError) as exc:
+            except self._nvml.NVMLError as exc:
+                if self._is_uninitialized_error(exc):
+                    raise
+                logger.debug("NVML handle index query failed: %s", exc)
+            except (TypeError, ValueError) as exc:
                 logger.debug("NVML handle index query failed: %s", exc)
 
         return ("handle", id(handle))
@@ -161,7 +186,9 @@ class NVMLMonitor:
         if index_value is not None:
             try:
                 return self._nvml.nvmlDeviceGetHandleByIndex(index_value)
-            except self._nvml.NVMLError:
+            except self._nvml.NVMLError as exc:
+                if self._is_uninitialized_error(exc):
+                    raise
                 return None
         if is_cuda_visible_index_token(token):
             return None
@@ -172,7 +199,11 @@ class NVMLMonitor:
         for uuid in (token, token.encode("utf-8")):
             try:
                 return uuid_lookup(uuid)
-            except (self._nvml.NVMLError, AttributeError, TypeError):
+            except self._nvml.NVMLError as exc:
+                if self._is_uninitialized_error(exc):
+                    raise
+                continue
+            except (AttributeError, TypeError):
                 continue
         return None
 

--- a/tests/rocm_controller/test_rocm_utilization.py
+++ b/tests/rocm_controller/test_rocm_utilization.py
@@ -11,15 +11,38 @@ OVERSIZED_NUMERIC_TOKEN = "9" * 100
 
 
 class DummyRocmSMI:
-    def __init__(self, util_by_index: dict[int, int] | None = None, count: int = 8):
+    def __init__(
+        self,
+        util_by_index: dict[int, int] | None = None,
+        count: int = 8,
+        require_initialized: bool = False,
+    ):
         self.util_by_index = util_by_index or {}
         self.count = count
+        self.require_initialized = require_initialized
+        self.initialized = False
+        self.init_calls = 0
+        self.shutdown_calls = 0
         self.queried_indexes: list[int] = []
 
+    def rsmi_init(self):
+        self.init_calls += 1
+        self.initialized = True
+
+    def rsmi_shut_down(self):
+        self.shutdown_calls += 1
+        self.initialized = False
+
+    def _require_initialized(self):
+        if self.require_initialized and not self.initialized:
+            raise RuntimeError("ROCm SMI is not initialized")
+
     def rsmi_num_monitor_devices(self):
+        self._require_initialized()
         return self.count
 
     def rsmi_dev_busy_percent_get(self, index):
+        self._require_initialized()
         self.queried_indexes.append(index)
         return self.util_by_index.get(index, 40 + index)
 
@@ -43,6 +66,20 @@ def test_rocm_utilization_defaults_visible_rank_to_smi_index(monkeypatch):
 
     assert controller._query_utilization() == 71
     assert dummy.queried_indexes == [1]
+
+
+def test_rocm_utilization_reinitializes_after_external_smi_shutdown(monkeypatch):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyRocmSMI(util_by_index={1: 71}, require_initialized=True)
+    controller = _controller_with_dummy_smi(monkeypatch, rank=1, dummy=dummy)
+
+    assert controller._query_utilization() == 71
+    dummy.rsmi_shut_down()
+    assert controller._query_utilization() == 71
+    assert dummy.init_calls == 2
+    assert dummy.queried_indexes == [1, 1]
 
 
 def test_rocm_utilization_maps_hip_visible_rank_to_smi_index(monkeypatch):

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -32,6 +32,8 @@ class DummyNVML:
         self.gpu_util = gpu_util
         self.count = count
         self.init_calls = 0
+        self.shutdown_calls = 0
+        self.initialized = False
         self.queried_indexes: list[int] = []
         self.queried_uuids: list[object] = []
         self.util_by_index = util_by_index or {}
@@ -49,14 +51,22 @@ class DummyNVML:
         self.init_calls += 1
         if self.should_fail:
             raise self.NVMLError("init failure")
+        self.initialized = True
 
     def nvmlShutdown(self):
-        pass
+        self.shutdown_calls += 1
+        self.initialized = False
+
+    def _require_initialized(self):
+        if not self.initialized:
+            raise self.NVMLError("NVML is not initialized")
 
     def nvmlDeviceGetCount(self):
+        self._require_initialized()
         return self.count
 
     def nvmlDeviceGetHandleByIndex(self, index: int):
+        self._require_initialized()
         if self.should_fail:
             raise self.NVMLError("handle failure")
         if index in self.invalid_indexes:
@@ -65,6 +75,7 @@ class DummyNVML:
         return types.SimpleNamespace(index=index)
 
     def _nvmlDeviceGetHandleByUUID(self, uuid: str):
+        self._require_initialized()
         self.queried_uuids.append(uuid)
         if self.uuid_always_type_error or (
             self.uuid_requires_bytes and isinstance(uuid, str)
@@ -77,6 +88,7 @@ class DummyNVML:
         return types.SimpleNamespace(uuid=uuid)
 
     def nvmlDeviceGetIndex(self, handle):
+        self._require_initialized()
         if hasattr(handle, "index"):
             return handle.index
         if hasattr(handle, "uuid") and handle.uuid in self.uuid_index_by_value:
@@ -84,6 +96,7 @@ class DummyNVML:
         raise self.NVMLError("index lookup failure")
 
     def nvmlDeviceGetUtilizationRates(self, handle):
+        self._require_initialized()
         if hasattr(handle, "uuid"):
             return types.SimpleNamespace(
                 gpu=self.util_by_uuid.get(handle.uuid, self.gpu_util)
@@ -107,6 +120,18 @@ def test_monitor_reads_gpu_utilization(monkeypatch):
     assert monitor.get_gpu_utilization(2) == 73
     assert dummy.init_calls == 1
     assert dummy.queried_indexes == [1, 2]
+
+
+def test_monitor_reinitializes_after_external_nvml_shutdown(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyNVML(gpu_util=73)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) == 73
+    dummy.nvmlShutdown()
+    assert monitor.get_gpu_utilization(1) == 73
+    assert dummy.init_calls == 2
+    assert dummy.queried_indexes == [0, 1]
 
 
 def test_monitor_handles_nvml_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- retry CUDA NVML utilization once after stale uninitialized vendor-session errors
- ensure/retry ROCm SMI utilization after external shutdown while preserving unavailable telemetry as `None`
- add lifecycle regression tests plus AGENTS/docs/plan guidance

## Verification
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_gpu_monitor.py tests/utilities/test_gpu_info.py tests/rocm_controller/test_rocm_utilization.py -q` -> 86 passed, 1 skipped
- `PYTHONPATH=$PWD/src pytest tests/cuda_controller tests/rocm_controller/test_rocm_utilization.py tests/utilities/test_gpu_monitor.py tests/utilities/test_gpu_info.py -q` -> 102 passed, 6 skipped
- `PYTHONPATH=$PWD/src pytest tests/single_gpu_controller/test_release_contract.py::test_rocm_late_release_still_shuts_down_rocm_smi -q` -> 1 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 763 passed, 11 skipped
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `mkdocs build --strict` -> passed, with existing upstream Material for MkDocs warning

## Local review
- Local subagent code review: approved, no Critical/Important/Minor issues.
