### PR TITLE
[readme] docs: keep front page concise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ This file defines how coding agents should work in this repository.
 
 - When adding user-visible features, update the user documentation with usage guidance alongside the code changes.
 - For complex features, bug investigations, or refactorings that require detailed documentation (for example, plans, testing guides, summaries), create a dedicated subfolder under `docs/` with a descriptive name (for example, `docs/opencode-poll-loop-refactor/`). Place all related documentation files in that subfolder.
+- Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
+  contracts in `docs/` pages and link to them from README instead of repeating
+  reference material.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -7,36 +7,51 @@
 [![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/Wangmerlyn/KeepGPU?utm_source=oss&utm_medium=github&utm_campaign=Wangmerlyn%2FKeepGPU&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 [![SkillCheck Passed](https://raw.githubusercontent.com/olgasafonova/skillcheck-free/main/skill-check/passed.svg)](https://github.com/olgasafonova/skillcheck-free)
 
-**Keep GPU** keeps shared GPUs from being reclaimed while you prep data, debug, or coordinate multi-stage pipelines. It allocates just enough VRAM and issues lightweight CUDA work so schedulers observe an “active” device—without running a full training job.
+KeepGPU keeps shared GPUs reserved while you prepare data, debug, or coordinate pipelines by holding a small, polite keep-alive workload instead of a full training job.
 
-- 🧾 License: MIT
-- 📚 Docs: https://keepgpu.readthedocs.io
+## Why KeepGPU
 
-## Why it exists
+- Guard interactive or staged work from idle GPU reclaim policies.
+- Reserve only the VRAM you ask for, with a low-power `1GiB` default.
+- Back off when utilization shows the device is busy, unless you explicitly opt into unconditional keepalive.
+- Use the same session contract from the CLI, Python controllers, and MCP service.
 
-On many clusters, idle GPUs are reaped or silently shared after a short grace period. The cost of losing your reservation (or discovering another job has taken your card) can dwarf the cost of a tiny keep-alive loop. KeepGPU is a minimal, auditable guardrail:
+## Quick Start
 
-- **Predictable** – Single-purpose controller with explicit resource knobs (VRAM size, interval, utilization backoff).
-- **Polite** – Uses telemetry to read utilization and backs off when the GPU is busy or utilization is unavailable.
-- **Portable** – Typer/Rich CLI for humans; Python API for orchestrators and notebooks.
-- **Observable** – Structured logging and optional file logs for auditing what kept the GPU alive.
-- **Power-aware** – Uses intervalled elementwise ops instead of heavy matmul floods to present “busy” utilization while keeping power and thermals lower (see `CudaGPUController._run_relu_batch` for the loop).
-- **Telemetry-aware** – GPU telemetry comes from `nvidia-ml-py` (the `pynvml` module), system-provided ROCm SMI when `rocm_smi` is importable, and best-effort MPS memory counters on Mac M series.
-
-## Quick start (CLI)
+Install the package:
 
 ```bash
 pip install keep-gpu
+```
 
-# Hold GPU 0 with 1 GiB VRAM and throttle if utilization exceeds 25%
+Run a blocking keep-alive in the current shell:
+
+```bash
 keep-gpu --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
+```
 
-# Non-blocking mode for agent workflows (auto-starts local service)
+Use service mode when a workflow needs the command to return immediately:
+
+```bash
 keep-gpu start --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
 keep-gpu status
 keep-gpu stop --all
 keep-gpu service-stop
 ```
+
+## Python
+
+```python
+from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+
+with GlobalGPUController(gpu_ids=[0], vram_to_keep="1GiB", interval=60):
+    preprocess_dataset()
+    run_pipeline_stage()
+```
+
+## Service, Dashboard, and MCP
+
+Service mode provides local session control for agents and long-running shells. Start it explicitly with `keep-gpu serve`, or let `keep-gpu start` auto-start it for local use.
 
 Open the dashboard while service mode is running:
 
@@ -44,223 +59,25 @@ Open the dashboard while service mode is running:
 http://127.0.0.1:8765/
 ```
 
-Telemetry refresh is manual by default; use the dashboard controls for
-on-demand or opt-in auto-refresh.
+The MCP server is available as `keep-gpu-mcp-server` over stdio, with optional HTTP mode for browser and local service access. See [MCP and Service API](docs/guides/mcp.md) for protocol and deployment details.
 
-### Platform installs at a glance
+## Documentation
 
-- **CUDA (example: cu121)**
-  ```bash
-  pip install --index-url https://download.pytorch.org/whl/cu121 torch
-  pip install keep-gpu
-  ```
-- **ROCm (example: rocm6.1)**
-  ```bash
-  pip install --index-url https://download.pytorch.org/whl/rocm6.1 torch
-  pip install keep-gpu[rocm]
-  ```
-  The `rocm` extra is kept as an install-compatible marker; ROCm SMI comes from
-  the ROCm/system stack, and KeepGPU handles a missing `rocm_smi` module
-  gracefully.
-- **CPU-only**
-  ```bash
-  pip install torch
-  pip install keep-gpu
-  ```
-- **Mac M series (M1/M2/M3/M4)**
-  ```bash
-  pip install torch
-  pip install keep-gpu[macm]
-  ```
-  Uses Metal Performance Shaders (MPS) backend on Apple Silicon.
-
-Flags that matter:
-
-- Blocking mode knobs:
-  - `--vram` (`1GiB`, `750MB`, or bare bytes like `1073741824`): how much memory to pin.
-    Public VRAM byte-equivalent values are capped at 1 PiB so absurd requests
-    fail as validation errors instead of overflow failures.
-  - `--interval` (finite positive seconds, including fractional values): sleep between keep-alive bursts.
-    Values above the Python runtime wait limit are rejected.
-  - `--busy-threshold`: defaults to `25`; `0..100` skips work when telemetry reports higher utilization or cannot report utilization; `-1` disables utilization backoff.
-  - `--gpu-ids`: target unique non-negative visible device ordinals after user-supplied visibility filtering (`CUDA_VISIBLE_DEVICES` on CUDA, `ROCR_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` on ROCm). Omit the option to guard all visible GPUs. Empty, whitespace-only, duplicate, or out-of-range selections are invalid, and startup fails if no GPUs resolve.
-- Service mode commands:
-  - `keep-gpu serve`: run local service (HTTP + dashboard).
-  - `keep-gpu start`: create keep session and return immediately.
-    Service endpoint flags are validated locally: `--host` must be a DNS
-    hostname or IPv4 address, and `--port` must be an integer in `1..65535`.
-  - `keep-gpu status`: inspect tracked sessions, including in-progress or failed releases.
-  - `keep-gpu stop --job-id <id>` or `keep-gpu stop --all`: release sessions.
-    The two stop targets are mutually exclusive; passing both returns a JSON
-    error before contacting the service.
-    Explicit `--job-id` values for `status` and `stop` must be non-empty
-    URL-path-safe IDs; invalid values return JSON errors before any RPC or
-    stop-all fallback.
-  - `keep-gpu service-stop`: stop the ownership-verified auto-started local daemon.
-  - `keep-gpu list-gpus`: fetch telemetry from local service. Each listed
-    `id` is the visible ordinal accepted by `--gpu-ids`; optional
-    `physical_id`/`uuid` fields are metadata only. CUDA and ROCm devices are
-    listed only when Torch can select the same visible ordinal; NVML-only or
-    malformed CUDA mask or unselectable ROCm inventory is hidden instead of
-    producing unusable `gpu_ids`.
-  - `status`, `stop`, and `list-gpus` print structured JSON objects, including
-    `{"error": "..."}` for service/runtime errors after CLI parsing succeeds,
-    that tools such as `jq` can parse directly. Malformed JSON-RPC service
-    envelopes, malformed method-specific result records, and invalid service
-    endpoints, including non-integer ports, are reported as those JSON error
-    objects instead of empty success results or tracebacks.
-
-## Embed in Python
-
-```python
-from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
-
-with CudaGPUController(rank=0, interval=0.5, vram_to_keep="1GiB", busy_threshold=20):
-    preprocess_dataset()   # GPU is marked busy while you run CPU-heavy code
-
-train_model()              # GPU freed after exiting the context
-```
-
-Direct CUDA/ROCm controller `rank` values are visible ordinals in the current
-process environment and are validated during construction. Non-integer,
-negative, or out-of-range ranks fail before KeepGPU creates a device handle or
-starts a keep worker.
-
-Need multiple devices?
-
-```python
-from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
-
-with GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="750MB", interval=90, busy_threshold=30):
-    run_pipeline_stage()
-```
-
-Pass `gpu_ids=None` to use all visible GPUs. Explicit values are visible device
-ordinals, not physical NVML/ROCm SMI IDs. Passing an empty, duplicate, or
-out-of-range list is invalid, and startup raises an error if discovery resolves
-to zero devices.
-
-## What you get
-
-- Battle-tested keep-alive loop built on PyTorch.
-- NVML-based utilization monitoring (by way of `nvidia-ml-py`) to avoid hogging busy GPUs; ROCm SMI telemetry is used when the ROCm/system stack provides the `rocm_smi` module. Public entry points default `busy_threshold` to `25`. Valid values are `-1` or `0..100`; if utilization is unavailable and the threshold is non-negative, KeepGPU sleeps before allocating keep tensors or running compute. CUDA utilization checks use visible CUDA ordinals, so with `CUDA_VISIBLE_DEVICES=3,5`, rank `1` reads NVML telemetry for physical GPU `5`; malformed, duplicate/equivalent, ambiguous, or out-of-range CUDA masks are treated as unavailable telemetry before partial handle lookup. ROCm utilization similarly resolves visible ranks through `ROCR_VISIBLE_DEVICES` and one matching `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm SMI. Ambiguous mappings are treated as unavailable telemetry.
-- CLI + API parity: same controllers power both code paths.
-- Continuous docs + CI: mkdocs + mkdocstrings build in CI to keep guidance up to date.
-
-## For developers
-
-- Install dev extras: `pip install -e ".[dev]"`. The `rocm` extra is retained
-  for install compatibility; ROCm SMI comes from the ROCm/system stack.
-- Fast CUDA checks: `pytest tests/cuda_controller tests/global_controller tests/utilities/test_platform_manager.py tests/test_cli_thresholds.py`
-- ROCm visibility tests use mocks and run without hardware; ROCm-only hardware tests carry `@pytest.mark.rocm` and run with `pytest --run-rocm tests/rocm_controller`.
-- Large VRAM tests carry `@pytest.mark.large_memory` and are skipped unless
-  explicitly run with `pytest --run-large-memory -m large_memory`.
-
-### MCP and service API
-
-- Start an MCP server on stdin/stdout (default):
-  ```bash
-  keep-gpu-mcp-server
-  ```
-- Or expose it over HTTP (JSON-RPC + REST + dashboard):
-  ```bash
-  keep-gpu-mcp-server --mode http --host 0.0.0.0 --port 8765
-  ```
-- MCP clients use the standard `initialize`, `tools/list`, and `tools/call`
-  protocol methods over stdio. KeepGPU exposes four tools: `start_keep`,
-  `stop_keep`, `status`, and `list_gpus`.
-- Legacy direct JSON-RPC method calls remain supported for scripts:
-  ```json
-  {"id": 1, "method": "start_keep", "params": {"gpu_ids": [0], "vram": "512MB", "interval": 60, "busy_threshold": 20}}
-  ```
-- Stdio stdout is reserved for JSON protocol messages; diagnostics and logs are
-  written to stderr.
-- HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
-  same JSON-RPC messages at the exact `/rpc` endpoint, but it is not a
-  Streamable HTTP MCP endpoint. Noncanonical `/rpc` URLs return structured
-  `404` errors.
-- The dashboard loads once and refreshes telemetry on demand by default; its
-  opt-in auto-refresh polls every 10 seconds only while the tab is visible.
-- Successful legacy direct JSON-RPC responses use a KeepGPU direct-method
-  envelope with `jsonrpc: "2.0"`, the matching request `id`, and an object
-  `result`.
-- REST examples:
-  ```bash
-  curl http://127.0.0.1:8765/health
-  curl http://127.0.0.1:8765/api/sessions
-  ```
-- Methods: `start_keep`, `stop_keep` (optional `job_id`, default stops all), `status` (optional `job_id`), `list_gpus` (basic info). REST session creation accepts a JSON object body, not arrays or scalar values. Omitting `gpu_ids` uses all visible GPUs, and omitting `busy_threshold` uses the eco-safe default `25`; explicit values must be unique visible ordinals in the service process environment. `list_gpus` returns those same start-compatible, non-negative, unique ordinals as `id`/`visible_id`; `physical_id` and `uuid` are informational metadata, not valid substitutes for `gpu_ids`. The server validates listed records before responding, so malformed telemetry records become internal service failures instead of advertised GPU targets; nullable memory fields and `utilization: null` remain valid unavailable-telemetry values. On CUDA, NVML records are returned only when Torch CUDA can address the same visible ordinal set, so NVML-only devices are not advertised as startable. On ROCm, records are returned only when Torch can select the visible ordinal; nullable memory fields mean memory telemetry is unavailable after successful selection. Empty, duplicate, or out-of-range lists are invalid and startup fails if no GPUs resolve. Public numeric session inputs must stay finite and bounded: interval values are positive seconds, including fractional seconds, capped by the runtime wait limit, and VRAM byte-equivalent values are capped at 1 PiB. Custom `job_id` values must be unique across active and starting sessions, and only `null`/omitted means generated or all-sessions; custom IDs must be non-empty strings containing only letters, digits, `.`, `_`, `-`, or `~`. Status responses include reserved jobs as `state="starting"` while controller startup is still in progress.
-- Supported REST route/method failures remain machine-readable: validation
-  errors use JSON `400` responses, unknown API routes use JSON `404`, and
-  unexpected service/runtime failures use JSON `500` instead of closing the
-  connection without a response.
-  The dashboard reads those structured payloads and displays `error.message`
-  instead of the raw JSON body.
-- Stop responses distinguish completed cleanup from partial cleanup:
-  `stopped` means released, while `timed_out` sessions remain visible as
-  `stopping` until background cleanup completes and `failed` sessions remain
-  visible with `state` and `last_error`. The outcome lists are disjoint, and
-  `errors` contains one message for each `failed` job only.
-- Status and stop requests both account for in-progress starts: status reports
-  them as `starting`, and stop waits for startup to settle so a session is not
-  reported as missing or skipped by stop-all. That startup wait is bounded; if
-  it times out, the stop response includes the job in `timed_out`, status shows
-  the remembered cancellation as `state="stopping"` with the timeout message,
-  and a later successful startup is released in the background.
-- Stop-all only covers sessions active or already starting when that request
-  begins; later concurrent starts belong to a later stop request.
-- Stop-all releases independent sessions concurrently and reports outcomes in
-  deterministic snapshot order with the same `stopped`, `timed_out`, `failed`,
-  and `errors` fields.
-- Dashboard GPU cards show the visible ordinal to type into the start form first,
-  with physical/vendor metadata shown only as secondary context.
-- Dashboard cards mirror lifecycle state so a retained session shows
-  `Releasing` or `Release failed` instead of being presented as a fully active
-  keepalive.
-- Dashboard utilization summaries ignore unavailable readings and show `n/a`
-  when no finite readings exist; per-GPU cards also omit the utilization fill
-  for unavailable telemetry so unknown readings are not presented as idle.
-- Dashboard: `http://127.0.0.1:8765/`
-- **Mac M series limitations:**
-  - GPU utilization monitoring is not available on macOS.
-  - The default `busy_threshold=25` keeps MPS in conservative sleep-only mode; set `busy_threshold=-1` to opt into unconditional keepalive compute.
-  - `list-gpus` reports best-effort MPS memory counters and `null` for unsupported telemetry fields.
-- Minimal client config (stdio MCP):
-  ```yaml
-  servers:
-    keepgpu:
-      command: ["keep-gpu-mcp-server"]
-      adapter: stdio
-  ```
-- Remote/SSH tunnel example (HTTP):
-  ```bash
-  keep-gpu-mcp-server --mode http --host 0.0.0.0 --port 8765
-  ```
-  Use `http://gpu-box.example.com:8765/` for the dashboard and
-  `http://gpu-box.example.com:8765/rpc` for JSON-RPC scripts.
-  For untrusted networks, put the server behind your own auth/reverse-proxy or
-  tunnel by way of SSH (for example, `ssh -L 8765:localhost:8765 gpu-box`).
+- [Getting Started](docs/getting-started.md)
+- [CLI Guide](docs/guides/cli.md)
+- [Python Guide](docs/guides/python.md)
+- [MCP and Service API](docs/guides/mcp.md)
+- [CLI Reference](docs/reference/cli.md)
+- [Python API Reference](docs/reference/api.md)
+- [Architecture](docs/concepts/architecture.md)
 
 ## Contributing
 
-Contributions are welcome—especially around ROCm support, platform fallbacks, and scheduler-specific recipes. Open an issue or PR if you hit edge cases on your cluster.
-See [docs/contributing.md](docs/contributing.md) for dev setup, test commands, and PR tips.
+Contributions are welcome, especially around platform fallbacks and scheduler-specific recipes. See [Contributing](docs/contributing.md) for setup, tests, and PR guidance.
 
-## Credits
+## Citation
 
-This package was created with [Cookiecutter](https://github.com/audreyr/cookiecutter) and the [audreyr/cookiecutter-pypackage](https://github.com/audreyr/cookiecutter-pypackage) project template.
-
-## Contributors
-
-<!-- google-doc-style-ignore -->
-<a href="https://github.com/Wangmerlyn/KeepGPU/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Wangmerlyn/KeepGPU" />
-</a>
-<!-- google-doc-style-resume -->
-
-## 📖 Citation
-
-If you find **KeepGPU** useful in your research or work, please cite it as:
+If you find KeepGPU useful in your research or work, please cite it as:
 
 ```bibtex
 @software{Wangmerlyn_KeepGPU_2025,

--- a/docs/plans/readme-slim.md
+++ b/docs/plans/readme-slim.md
@@ -1,0 +1,138 @@
+# README Slimming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `README.md` into a clean front door while keeping detailed CLI, Python, MCP, platform, and development guidance in published docs.
+
+**Architecture:** Keep README as a compact product overview with links to existing docs. Move no behavior into new code paths and avoid creating a new docs page unless an existing destination is missing. Add a tiny metadata test so the README does not quietly grow back into a reference manual.
+
+**Tech Stack:** Markdown, MkDocs, pytest, pre-commit.
+
+---
+
+### Task 1: Add README Shape Guard
+
+**Files:**
+- Modify: `tests/test_package_metadata.py`
+
+- [x] **Step 1: Add a failing test**
+
+Add this test after `test_readme_markdown_code_fences_are_balanced`:
+
+```python
+def test_readme_stays_a_compact_front_door():
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    lines = [line for line in readme.splitlines() if line.strip()]
+
+    assert len(lines) <= 130
+    assert "### MCP and service API" not in readme
+    assert "Platform installs at a glance" not in readme
+    assert "docs/guides/mcp.md" in readme
+    assert "docs/reference/cli.md" in readme
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q
+```
+
+Expected: FAIL because the current README has more than 130 nonblank lines.
+
+### Task 2: Slim README and Keep Links
+
+**Files:**
+- Modify: `README.md`
+
+- [x] **Step 1: Replace README with a compact front door**
+
+Keep these sections only:
+
+- `# Keep GPU`
+- badges and one-sentence product pitch
+- `## Why KeepGPU`
+- `## Quick Start`
+- `## Python`
+- `## Service, Dashboard, and MCP`
+- `## Documentation`
+- `## Contributing`
+- `## Citation`
+
+The README must include:
+
+- one blocking CLI example
+- one service-mode example
+- one Python snippet
+- dashboard URL
+- links to `docs/getting-started.md`, `docs/guides/cli.md`, `docs/guides/python.md`, `docs/guides/mcp.md`, `docs/reference/cli.md`, `docs/reference/api.md`, `docs/concepts/architecture.md`, and `docs/contributing.md`
+- the existing BibTeX citation
+
+The README must not include:
+
+- full platform install matrix
+- CLI flag reference tables or long validation rules
+- JSON-RPC/REST protocol details
+- dashboard lifecycle edge cases
+- developer test matrices
+
+- [x] **Step 2: Verify README size**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+lines = [line for line in Path("README.md").read_text(encoding="utf-8").splitlines() if line.strip()]
+print(len(lines))
+assert len(lines) <= 130
+PY
+```
+
+Expected: prints a number no greater than `130`.
+
+### Task 3: Update Agent Guidance
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [x] **Step 1: Add README guardrail**
+
+Under Documentation Updates, add a bullet with this meaning:
+
+```markdown
+- Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
+  contracts in `docs/` pages and link to them from README instead of repeating
+  reference material.
+```
+
+### Task 4: Verify and Review
+
+**Files:**
+- Modify: `docs/plans/readme-slim.md`
+
+- [x] **Step 1: Run targeted tests**
+
+```bash
+PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q
+```
+
+Expected: all tests in the file pass.
+
+- [x] **Step 2: Run docs and formatting gates**
+
+```bash
+pre-commit run --all-files --show-diff-on-failure
+mkdocs build --strict
+```
+
+Expected: both commands exit `0`. The existing upstream Material for MkDocs warning may appear.
+
+- [x] **Step 3: Mark this plan complete**
+
+Check off completed plan items in `docs/plans/readme-slim.md`.
+
+- [x] **Step 4: Request local subagent code review**
+
+Dispatch a local reviewer before opening the PR. Resolve any Critical or Important findings before pushing.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -78,6 +78,18 @@ def test_readme_markdown_code_fences_are_balanced():
     assert len(fences) % 2 == 0
 
 
+def test_readme_stays_a_compact_front_door():
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    normalized_readme = readme.lower()
+    lines = [line for line in readme.splitlines() if line.strip()]
+
+    assert len(lines) <= 130
+    assert "### mcp and service api" not in normalized_readme
+    assert "platform installs at a glance" not in normalized_readme
+    assert "docs/guides/mcp.md" in readme
+    assert "docs/reference/cli.md" in readme
+
+
 def test_sdist_manifest_does_not_package_test_suite():
     manifest_path = PROJECT_ROOT / "MANIFEST.in"
     assert manifest_path.exists()


### PR DESCRIPTION
## Summary
- shrink README into a compact front door with quick CLI/Python/service examples
- point detailed CLI/API/MCP/platform/development guidance to existing docs pages
- add a small README compactness guard and AGENTS.md guidance

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q` failed before README shrink with `assert 235 <= 130`
- README size snippet -> `67`, assertion passed
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` -> 7 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 764 passed, 11 skipped
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `mkdocs build --strict` -> passed, with existing upstream Material for MkDocs warning

## Local review
- Local subagent code review: approved, no Critical/Important/Minor issues.
