### PR TITLE
[ci] ci: remove root requirements fallback

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install pytest
         pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install -e .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ This file defines how coding agents should work in this repository.
 - Pre-commit CI should install only the `pre-commit` runner; hooks provision
   their own tool environments, so do not install KeepGPU runtime dependencies
   just to lint.
+- Keep Python test CI dependency installs explicit. Do not reintroduce a root
+  `requirements.txt` fallback; runtime and test dependencies belong in
+  `pyproject.toml`, while docs dependencies belong in `docs/requirements.txt`.
 - Source distributions should not ship the test suite by default; package data
   should enumerate required runtime assets such as the MCP dashboard files.
 - Keep license metadata as a plain SPDX string and keep the advertised Python

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep pre-commit CI lean: install the `pre-commit` runner only, and let hooks
   provision their own tool environments instead of installing KeepGPU runtime
   dependencies.
+- Keep Python CI installs explicit: do not add a root `requirements.txt`
+  fallback. Use `pyproject.toml` for runtime/test dependencies and
+  `docs/requirements.txt` for documentation builds.
 - Keep build metadata lean: list directly used third-party build/runtime
   distributions, do not rely on transitive dependencies, and do not list
   Python standard library modules such as `argparse`.

--- a/docs/plans/ci-no-root-requirements.md
+++ b/docs/plans/ci-no-root-requirements.md
@@ -1,0 +1,28 @@
+# CI Root Requirements Cleanup Plan
+
+## Background
+
+KeepGPU uses `pyproject.toml` for package dependencies and `docs/requirements.txt`
+for documentation builds. The Python application workflow still has a legacy
+fallback that installs root `requirements.txt` if someone adds that file later,
+which can silently widen the test dependency surface.
+
+## Goal
+
+Keep Python CI dependency installation explicit and lean by removing the root
+`requirements.txt` fallback and adding a guard against reintroducing it.
+
+## Solution
+
+- Add a CI workflow test that fails if the Python application workflow installs
+  root `requirements.txt`.
+- Remove the conditional `pip install -r requirements.txt` line.
+- Document the guardrail in `AGENTS.md` and `docs/contributing.md`.
+
+## Todo
+
+- [x] Add RED workflow guard.
+- [x] Remove the legacy root requirements install fallback.
+- [x] Update agent and contributor guidance.
+- [x] Run targeted workflow tests and pre-commit.
+- [x] Request local subagent code review before opening the PR.

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2,6 +2,16 @@ import re
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ROOT_REQUIREMENTS_INSTALL_RE = re.compile(
+    r"\b(?:python\s+-m\s+)?pip\s+install\s+-r\s+(?:\./)?requirements\.txt\b"
+)
+
+
+def _installs_root_requirements_file(workflow: str) -> bool:
+    executable_lines = [
+        line for line in workflow.splitlines() if not line.lstrip().startswith("#")
+    ]
+    return bool(ROOT_REQUIREMENTS_INSTALL_RE.search("\n".join(executable_lines)))
 
 
 def test_precommit_workflow_does_not_install_runtime_package():
@@ -20,3 +30,23 @@ def test_precommit_workflow_does_not_install_runtime_package():
         "python -m pip install --upgrade pip",
         "pip install pre-commit",
     ]
+
+
+def test_python_workflow_does_not_install_root_requirements_file():
+    workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yml"
+    if not workflow_path.exists():
+        workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yaml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    assert not _installs_root_requirements_file(workflow)
+
+
+def test_root_requirements_guard_allows_harmless_references():
+    assert _installs_root_requirements_file("pip install -r requirements.txt")
+    assert _installs_root_requirements_file(
+        "python -m pip install -r ./requirements.txt"
+    )
+    assert not _installs_root_requirements_file(
+        "# historical note: pip install -r requirements.txt is forbidden"
+    )
+    assert not _installs_root_requirements_file("pip install -r docs/requirements.txt")


### PR DESCRIPTION
## Summary
- Remove the legacy root `requirements.txt` fallback from the Python app workflow.
- Add a CI workflow regression guard so the fallback stays out.
- Document the explicit dependency-surface rule in `AGENTS.md`, contributing docs, and the plan.

## Verification
- `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py tests/test_package_metadata.py -q`
- `PYTHONPATH=$PWD/src pytest -q`
- `pre-commit run --all-files --show-diff-on-failure`
- `mkdocs build --strict`

## Review
- Local subagent code review completed with no Critical, Important, or Minor findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python CI setup to use explicit dependency installation, reducing the risk of unexpected build failures.
* **Tests**
  * Added a CI check to prevent reintroducing fallback installs from a root-level dependency file.
* **Documentation**
  * Updated contributor guidance and internal standards to reflect the new CI dependency-installation approach.
  * Added a short plan outlining the CI cleanup and guardrails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->