### PR TITLE
[docs] docs: declare mkdocs directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ This file defines how coding agents should work in this repository.
   Python 3.9.
 - MkDocs/mkdocstrings must resolve API references from the checkout's `src/`
   tree so docs-only builds work with `docs/requirements.txt` alone.
+- `docs/requirements.txt` must list docs tools invoked directly by CI or
+  contributors, including `mkdocs`; do not rely on theme/plugin transitive
+  dependencies for documented commands.
 
 ### Git Hygiene & Security
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,6 +81,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   ```bash
   pip install -r docs/requirements.txt
   ```
+- Keep directly invoked documentation tools in `docs/requirements.txt`; for
+  example, `mkdocs build` should not depend on the theme package to install the
+  `mkdocs` CLI transitively.
 - Live preview:
   ```bash
   mkdocs serve

--- a/docs/plans/docs-explicit-mkdocs.md
+++ b/docs/plans/docs-explicit-mkdocs.md
@@ -1,0 +1,26 @@
+# Explicit MkDocs Dependency Plan
+
+## Background
+
+The documentation workflow installs `docs/requirements.txt` and then invokes
+`mkdocs build --strict`. The requirements file currently relies on
+`mkdocs-material` to provide the `mkdocs` CLI transitively.
+
+## Goal
+
+Keep documentation builds self-contained and explicit by declaring the tools the
+docs workflow invokes directly.
+
+## Solution
+
+- Add a workflow test that checks `docs/requirements.txt` includes `mkdocs`.
+- Add `mkdocs` as a direct documentation dependency.
+- Document the guardrail in agent and contributor guidance.
+
+## Todo
+
+- [x] Add RED docs requirements guard.
+- [x] Add the direct MkDocs dependency.
+- [x] Update agent and contributor guidance.
+- [x] Run targeted workflow tests, docs build, pre-commit, and full tests.
+- [x] Request local subagent code review before opening the PR.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+mkdocs
 mkdocs-material
 mkdocstrings[python]

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -50,3 +50,16 @@ def test_root_requirements_guard_allows_harmless_references():
         "# historical note: pip install -r requirements.txt is forbidden"
     )
     assert not _installs_root_requirements_file("pip install -r docs/requirements.txt")
+
+
+def test_docs_requirements_include_direct_mkdocs_dependency():
+    docs_requirements = (PROJECT_ROOT / "docs/requirements.txt").read_text(
+        encoding="utf-8"
+    )
+    active_requirement_names = [
+        re.split(r"\s*(?:[<>=!~;\\[]|$)", line.strip(), maxsplit=1)[0]
+        for line in docs_requirements.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert "mkdocs" in active_requirement_names


### PR DESCRIPTION
## Summary
- Add `mkdocs` as a direct documentation dependency because CI and contributors invoke the CLI directly.
- Add a workflow guard that checks `docs/requirements.txt` includes a direct `mkdocs` requirement name.
- Document the direct-docs-tool dependency rule in `AGENTS.md`, contributing docs, and the plan.

## Verification
- `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py tests/test_package_metadata.py -q`
- `PYTHONPATH=$PWD/src pytest -q`
- `pre-commit run --all-files --show-diff-on-failure`
- `mkdocs build --strict`

## Review
- Local subagent code review completed with no Critical, Important, or Minor findings.