### PR TITLE
[tests] test: remove metadata packaging parser dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ This file defines how coding agents should work in this repository.
   locations; avoid stale branch names or missing files.
 - Remove placeholder tests that assert no behavior instead of preserving
   count-only coverage.
+- Keep metadata tests self-contained for simple checks; avoid importing parser
+  libraries that are only available through transitive test dependencies.
 - Python files that use PEP 604 annotations such as `X | Y` must include
   `from __future__ import annotations` while the project tooling targets
   Python 3.9.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,6 +74,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
 - Keep project URLs in package metadata pointing to live repository pages.
+- Keep metadata tests self-contained for simple checks; avoid importing parser
+  libraries that are only available through transitive test dependencies.
 
 ## Docs
 

--- a/docs/plans/metadata-test-no-packaging-parser.md
+++ b/docs/plans/metadata-test-no-packaging-parser.md
@@ -1,0 +1,28 @@
+# Metadata Test Parser Cleanup Plan
+
+## Background
+
+`tests/test_package_metadata.py` imports `packaging` only to extract dependency
+names while checking package metadata. The project does not declare `packaging`
+as a direct runtime or dev dependency, so the test currently relies on pytest or
+the environment to provide it transitively.
+
+## Goal
+
+Keep metadata tests self-contained without adding dependency surface.
+
+## Solution
+
+- Add a small parser behavior test for dependency names with versions, extras,
+  markers, and mixed punctuation.
+- Replace the `packaging` imports with a tiny local dependency-name normalizer.
+- Document the guardrail that metadata tests should avoid undeclared parser
+  dependencies for simple checks.
+
+## Todo
+
+- [x] Add RED dependency-name parser test.
+- [x] Remove the test-only `packaging` import.
+- [x] Update agent and contributor guidance.
+- [x] Run targeted metadata tests, pre-commit, docs build, and full tests.
+- [x] Request local subagent code review before opening the PR.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,7 +1,6 @@
+import re
 from pathlib import Path
 
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
 from setuptools.config.pyprojecttoml import read_configuration
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -47,11 +46,28 @@ def _runtime_dependencies():
     return config["project"]["dependencies"]
 
 
+def _runtime_dependency_name(dependency: str) -> str:
+    match = re.match(r"^([a-zA-Z0-9._-]+)", dependency.strip())
+    name = match.group(1) if match else ""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def _runtime_dependency_names():
     return {
-        canonicalize_name(Requirement(dependency).name)
-        for dependency in _runtime_dependencies()
+        _runtime_dependency_name(dependency) for dependency in _runtime_dependencies()
     }
+
+
+def test_runtime_dependency_name_parser_handles_common_requirement_shapes():
+    assert _runtime_dependency_name("rich>=13.8.0") == "rich"
+    assert (
+        _runtime_dependency_name("My_Package.Name[extra]>=1; python_version >= '3.9'")
+        == "my-package-name"
+    )
+    assert _runtime_dependency_name("rich (>=13.8.0)") == "rich"
+    assert (
+        _runtime_dependency_name("pip @ git+https://github.com/pypa/pip.git") == "pip"
+    )
 
 
 def test_rocm_extra_is_declared_without_non_pypi_rocm_smi_dependency():


### PR DESCRIPTION
## Summary
- Remove the test-only `packaging` import from package metadata checks.
- Add a tiny local dependency-name normalizer plus behavior coverage for common requirement shapes.
- Document the self-contained metadata-test guardrail in `AGENTS.md`, contributing docs, and the plan.

## Verification
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py tests/test_ci_workflows.py -q`
- `PYTHONPATH=$PWD/src pytest -q`
- `pre-commit run --all-files --show-diff-on-failure`
- `mkdocs build --strict`

## Review
- Local subagent code review completed with no Critical, Important, or Minor findings.