### PR TITLE
[docs] docs: declare pymdown extensions directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,10 @@ This file defines how coding agents should work in this repository.
   Python 3.9.
 - MkDocs/mkdocstrings must resolve API references from the checkout's `src/`
   tree so docs-only builds work with `docs/requirements.txt` alone.
-- `docs/requirements.txt` must list docs tools invoked directly by CI or
-  contributors, including `mkdocs`; do not rely on theme/plugin transitive
-  dependencies for documented commands.
+- `docs/requirements.txt` must list docs tools and configured MkDocs extensions
+  used directly by CI or contributors, including `mkdocs` and
+  `pymdown-extensions`; do not rely on theme/plugin transitive dependencies for
+  documented commands or configured extensions.
 
 ### Git Hygiene & Security
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,9 +83,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   ```bash
   pip install -r docs/requirements.txt
   ```
-- Keep directly invoked documentation tools in `docs/requirements.txt`; for
-  example, `mkdocs build` should not depend on the theme package to install the
-  `mkdocs` CLI transitively.
+- Keep directly invoked documentation tools and configured MkDocs extensions in
+  `docs/requirements.txt`; for example, `mkdocs build` and configured
+  `pymdownx.*` extensions should not depend on theme packages transitively.
 - Live preview:
   ```bash
   mkdocs serve

--- a/docs/plans/docs-explicit-pymdown.md
+++ b/docs/plans/docs-explicit-pymdown.md
@@ -1,0 +1,28 @@
+# Explicit Pymdown Extensions Dependency Plan
+
+## Background
+
+`mkdocs.yml` configures `pymdownx.tabbed` and `pymdownx.emoji` directly, while
+`docs/requirements.txt` relies on `mkdocs-material` to provide
+`pymdown-extensions` transitively.
+
+## Goal
+
+Keep documentation builds self-contained and explicit by declaring MkDocs
+extensions that the project configures directly.
+
+## Solution
+
+- Extend the docs requirements guard to require `pymdown-extensions` when
+  `mkdocs.yml` configures `pymdownx.*` extensions.
+- Add `pymdown-extensions` as a direct docs dependency.
+- Document the direct-extension dependency rule in agent and contributor
+  guidance.
+
+## Todo
+
+- [x] Add RED docs extension dependency guard.
+- [x] Add the direct `pymdown-extensions` dependency.
+- [x] Update agent and contributor guidance.
+- [x] Run targeted workflow tests, docs build, pre-commit, and full tests.
+- [x] Request local subagent code review before opening the PR.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
 mkdocstrings[python]
+pymdown-extensions

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -14,6 +14,20 @@ def _installs_root_requirements_file(workflow: str) -> bool:
     return bool(ROOT_REQUIREMENTS_INSTALL_RE.search("\n".join(executable_lines)))
 
 
+def _active_requirement_names(requirements: str) -> list[str]:
+    return [
+        re.split(r"\s*(?:[<>=!~;\\[]|$)", line.split("#", 1)[0].strip(), maxsplit=1)[0]
+        for line in requirements.splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+
+
+def _has_active_pymdown_extension(mkdocs_config: str) -> bool:
+    return any(
+        "pymdownx." in line.split("#", 1)[0] for line in mkdocs_config.splitlines()
+    )
+
+
 def test_precommit_workflow_does_not_install_runtime_package():
     workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
     if not workflow_path.exists():
@@ -56,10 +70,20 @@ def test_docs_requirements_include_direct_mkdocs_dependency():
     docs_requirements = (PROJECT_ROOT / "docs/requirements.txt").read_text(
         encoding="utf-8"
     )
-    active_requirement_names = [
-        re.split(r"\s*(?:[<>=!~;\\[]|$)", line.strip(), maxsplit=1)[0]
-        for line in docs_requirements.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    ]
 
-    assert "mkdocs" in active_requirement_names
+    assert "mkdocs" in _active_requirement_names(docs_requirements)
+
+
+def test_docs_requirements_include_configured_pymdown_extensions():
+    mkdocs_config = (PROJECT_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    docs_requirements = (PROJECT_ROOT / "docs/requirements.txt").read_text(
+        encoding="utf-8"
+    )
+
+    if _has_active_pymdown_extension(mkdocs_config):
+        assert "pymdown-extensions" in _active_requirement_names(docs_requirements)
+
+
+def test_docs_requirements_guard_ignores_commented_pymdown_extensions():
+    assert not _has_active_pymdown_extension("# - pymdownx.tabbed\n")
+    assert not _has_active_pymdown_extension("  - admonition # - pymdownx.tabbed\n")


### PR DESCRIPTION
## Summary
- Declare `pymdown-extensions` as a direct docs dependency because `mkdocs.yml` configures `pymdownx.*` extensions.
- Add a small CI guard that requires the dependency only when active `pymdownx.*` config is present.
- Keep agent/contributor guidance aligned on explicit docs build dependencies.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py -q`
- `pre-commit run --all-files --show-diff-on-failure`
- `mkdocs build --strict`
- `PYTHONPATH=$PWD/src pytest -q`

## Local Review
- Local subagent final review found no must-fix issues before PR creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation build requirements now explicitly include configured MkDocs extensions, with direct support for `pymdown-extensions`.
  * Added a short plan outlining the updated docs dependency approach.

* **Bug Fixes**
  * Clarified guidance so documentation builds don’t rely on transitive packages being present.
  * Added checks to ensure commented-out extension settings don’t trigger dependency requirements.

* **Tests**
  * Expanded CI coverage for documentation dependency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->