### PR TITLE
[docs] docs: move citation details out of README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ This file defines how coding agents should work in this repository.
 - For complex features, bug investigations, or refactorings that require detailed documentation (for example, plans, testing guides, summaries), create a dedicated subfolder under `docs/` with a descriptive name (for example, `docs/opencode-poll-loop-refactor/`). Place all related documentation files in that subfolder.
 - Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
   contracts in `docs/` pages and link to them from README instead of repeating
-  reference material.
+  reference material. Keep long citation metadata in `docs/citation.md`, not in
+  README.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -77,17 +77,5 @@ Contributions are welcome, especially around platform fallbacks and scheduler-sp
 
 ## Citation
 
-If you find KeepGPU useful in your research or work, please cite it as:
-
-```bibtex
-@software{Wangmerlyn_KeepGPU_2025,
-  author       = {Wang, Siyuan and Shi, Yaorui and Liu, Yida and Yin, Yuqi},
-  title        = {KeepGPU: a simple CLI app that keeps your GPUs running},
-  year         = {2025},
-  publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.17129114},
-  url          = {https://github.com/Wangmerlyn/KeepGPU},
-  note         = {GitHub repository},
-  keywords     = {ai, hpc, gpu, cluster, cuda, torch, debug}
-}
-```
+If KeepGPU helps your research or operations, see [Citation](docs/citation.md)
+for the BibTeX entry.

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,16 @@
+# Citation
+
+If KeepGPU helps your research or operations, cite the archived software record:
+
+```bibtex
+@software{Wangmerlyn_KeepGPU_2025,
+  author       = {Wang, Siyuan and Shi, Yaorui and Liu, Yida and Yin, Yuqi},
+  title        = {KeepGPU: a simple CLI app that keeps your GPUs running},
+  year         = {2025},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.17129114},
+  url          = {https://github.com/Wangmerlyn/KeepGPU},
+  note         = {GitHub repository},
+  keywords     = {ai, hpc, gpu, cluster, cuda, torch, debug}
+}
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -98,6 +98,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   builds do not need `pip install .`.
 - Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
   stay in the repository but are excluded from the published MkDocs site.
+- Keep README as a concise front door. Put full citation metadata in
+  `docs/citation.md` and link to it from README.
 
 ## MCP server (experimental)
 

--- a/docs/plans/readme-citation-doc.md
+++ b/docs/plans/readme-citation-doc.md
@@ -1,0 +1,28 @@
+# README Citation Cleanup Plan
+
+## Background
+
+`README.md` is the repository front door, but its citation section still embeds
+the full BibTeX entry. That makes the front page longer even though detailed
+citation metadata belongs naturally in the documentation site.
+
+## Goal
+
+Keep README concise while preserving the full citation information in a
+published docs page.
+
+## Solution
+
+- Move the BibTeX entry to `docs/citation.md`.
+- Link to the citation page from README and the MkDocs navigation.
+- Add a small README-shape guard so the full BibTeX block does not drift back
+  into README.
+- Document the rule in agent and contributor guidance.
+
+## Todo
+
+- [x] Add RED README citation guard.
+- [x] Move the BibTeX entry into docs.
+- [x] Update README, MkDocs nav, AGENTS.md, and contributor guidance.
+- [x] Run targeted tests, docs build, and pre-commit.
+- [ ] Request local subagent review before opening the PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - API Reference: reference/api.md
   - Project:
       - Contributing: contributing.md
+      - Citation: citation.md
 
 plugins:
   - search

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -102,8 +102,10 @@ def test_readme_stays_a_compact_front_door():
     assert len(lines) <= 130
     assert "### mcp and service api" not in normalized_readme
     assert "platform installs at a glance" not in normalized_readme
+    assert "```bibtex" not in normalized_readme
     assert "docs/guides/mcp.md" in readme
     assert "docs/reference/cli.md" in readme
+    assert "docs/citation.md" in readme
 
 
 def test_sdist_manifest_does_not_package_test_suite():


### PR DESCRIPTION
## Summary
- Move the full BibTeX citation from `README.md` into a published `docs/citation.md` page.
- Keep README as a concise front door with a short citation pointer.
- Add a small README shape guard plus MkDocs nav and contributor guidance.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=$PWD/src pytest -q`

## Local Review
- Local subagent review found no must-fix issues after the final commit.