### PR TITLE
[cli] fix: reject null-id rpc error envelopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,11 @@ This file defines how coding agents should work in this repository.
   REST `503`, MCP tool `isError=true`) while arbitrary unexpected
   startup/runtime failures remain internal errors.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
-- CLI service RPC clients must reject malformed JSON-RPC service envelopes (wrong `jsonrpc`, mismatched `id`, missing `result`, non-object direct-method `result`, or non-object `error`) instead of treating them as successful empty responses or leaking tracebacks.
+- CLI service RPC clients must reject malformed JSON-RPC service envelopes
+  (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
+  concrete id, missing `result`, non-object direct-method `result`, or
+  non-object `error`) instead of treating them as successful empty responses or
+  leaking tracebacks.
 - CLI commands that consume service-specific JSON-RPC results must validate
   required result fields before rendering user-facing output; malformed
   method-specific payloads should become clean `ServiceResponseError` messages,

--- a/docs/plans/cli-jsonrpc-envelope-validation.md
+++ b/docs/plans/cli-jsonrpc-envelope-validation.md
@@ -84,6 +84,16 @@ Completed so far:
 - Local review after Gemini follow-up GREEN:
   `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_without_id_member tests/test_cli_service_commands.py::test_rpc_call_propagates_error_envelope_with_null_id tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_both_error_and_result tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_mismatched_id -q`,
   `4 passed` after requiring the `id` member on error envelopes.
+- Audit follow-up RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_null_id -q`,
+  `1 failed` because the CLI sent a concrete JSON-RPC request id but accepted an
+  error envelope with `id: null` as a correlated service response.
+- Audit follow-up GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_null_id -q`,
+  `1 passed` after requiring error-envelope ids to match the CLI request id.
+- Audit follow-up malformed-envelope shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_success_envelope_with_mismatched_id tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_null_id tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_without_id_member tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_both_error_and_result tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_non_object_error -q`,
+  `5 passed`.
 - GREEN CLI service-command shard:
   `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
   `55 passed`.
@@ -97,3 +107,11 @@ Completed so far:
   warning and unnav'd plan notices.
 - Pre-commit:
   `pre-commit run --all-files`, passed.
+- Current audit follow-up full CLI shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
+  `174 passed`.
+- Current audit follow-up full test suite:
+  `PYTHONPATH=$PWD/src pytest -q`, `770 passed, 11 skipped`.
+- Current audit follow-up docs and lint:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the known Material
+  warning, and `pre-commit run --all-files --show-diff-on-failure` passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -570,7 +570,7 @@ def _rpc_call(
             )
         if "id" not in response:
             raise ServiceResponseError("Malformed JSON-RPC response: missing id")
-        if response.get("id") not in (payload["id"], None):
+        if response.get("id") != payload["id"]:
             raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
         code = error.get("code")
         if isinstance(code, bool) or not isinstance(code, int):

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -570,7 +570,7 @@ def _rpc_call(
             )
         if "id" not in response:
             raise ServiceResponseError("Malformed JSON-RPC response: missing id")
-        if response.get("id") != payload["id"]:
+        if response["id"] != payload["id"]:
             raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
         code = error.get("code")
         if isinstance(code, bool) or not isinstance(code, int):

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1406,7 +1406,7 @@ def test_rpc_call_rejects_error_envelope_with_non_object_error(monkeypatch):
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
 
 
-def test_rpc_call_propagates_error_envelope_with_null_id(monkeypatch):
+def test_rpc_call_rejects_error_envelope_with_null_id(monkeypatch):
     monkeypatch.setattr(cli.time, "time", lambda: 1.0)
     monkeypatch.setattr(
         cli,
@@ -1418,9 +1418,8 @@ def test_rpc_call_propagates_error_envelope_with_null_id(monkeypatch):
         },
     )
 
-    with pytest.raises(cli.ServiceRPCError, match="Parse error") as exc_info:
+    with pytest.raises(cli.ServiceResponseError, match="mismatched id"):
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
-    assert exc_info.value.code == -32700
 
 
 def test_rpc_call_rejects_error_envelope_without_id_member(monkeypatch):


### PR DESCRIPTION
## Summary
- Reject JSON-RPC error envelopes with `id: null` in the CLI service client when the CLI sent a concrete request id.
- Update CLI envelope regression coverage plus AGENTS/plan guidance for the stricter response-id contract.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_with_null_id -q`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=$PWD/src pytest -q`
- `PYTHONPATH=$PWD/src mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`

## Local Review
- Local subagent review found no must-fix issues and confirmed server-side `id: null` parse-error envelopes remain separate from this CLI client request path.