### PR TITLE
[docs] docs: slim README overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,9 @@ This file defines how coding agents should work in this repository.
 - For complex features, bug investigations, or refactorings that require detailed documentation (for example, plans, testing guides, summaries), create a dedicated subfolder under `docs/` with a descriptive name (for example, `docs/opencode-poll-loop-refactor/`). Place all related documentation files in that subfolder.
 - Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
   contracts in `docs/` pages and link to them from README instead of repeating
-  reference material. Keep long citation metadata in `docs/citation.md`, not in
-  README.
+  reference material. Prefer one quick-start command plus guide links over
+  standalone Python, service, dashboard, or MCP sections. Keep long citation
+  metadata in `docs/citation.md`, not in README.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Wangmerlyn/KeepGPU)
 [![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/Wangmerlyn/KeepGPU?utm_source=oss&utm_medium=github&utm_campaign=Wangmerlyn%2FKeepGPU&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
-[![SkillCheck Passed](https://raw.githubusercontent.com/olgasafonova/skillcheck-free/main/skill-check/passed.svg)](https://github.com/olgasafonova/skillcheck-free)
 
 KeepGPU keeps shared GPUs reserved while you prepare data, debug, or coordinate pipelines by holding a small, polite keep-alive workload instead of a full training job.
 
@@ -14,68 +13,46 @@ KeepGPU keeps shared GPUs reserved while you prepare data, debug, or coordinate 
 - Guard interactive or staged work from idle GPU reclaim policies.
 - Reserve only the VRAM you ask for, with a low-power `1GiB` default.
 - Back off when utilization shows the device is busy, unless you explicitly opt into unconditional keepalive.
-- Use the same session contract from the CLI, Python controllers, and MCP service.
 
 ## Quick Start
 
-Install the package:
-
 ```bash
 pip install keep-gpu
-```
-
-Run a blocking keep-alive in the current shell:
-
-```bash
 keep-gpu --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
 ```
 
-Use service mode when a workflow needs the command to return immediately:
+The command blocks until you press `Ctrl+C`, then releases the reserved memory.
+For non-blocking sessions, dashboard controls, and agent integrations, use the
+guides below.
 
-```bash
-keep-gpu start --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
-keep-gpu status
-keep-gpu stop --all
-keep-gpu service-stop
-```
+## Choose an Interface
 
-## Python
-
-```python
-from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
-
-with GlobalGPUController(gpu_ids=[0], vram_to_keep="1GiB", interval=60):
-    preprocess_dataset()
-    run_pipeline_stage()
-```
-
-## Service, Dashboard, and MCP
-
-Service mode provides local session control for agents and long-running shells. Start it explicitly with `keep-gpu serve`, or let `keep-gpu start` auto-start it for local use.
-
-Open the dashboard while service mode is running:
-
-```text
-http://127.0.0.1:8765/
-```
-
-The MCP server is available as `keep-gpu-mcp-server` over stdio, with optional HTTP mode for browser and local service access. See [MCP and Service API](docs/guides/mcp.md) for protocol and deployment details.
+| Need | Start here |
+| --- | --- |
+| First install and sanity check | [Getting Started](https://keepgpu.readthedocs.io/en/latest/getting-started/) |
+| Shell workflows and service mode | [CLI Guide](https://keepgpu.readthedocs.io/en/latest/guides/cli/) |
+| Python context managers/controllers | [Python Guide](https://keepgpu.readthedocs.io/en/latest/guides/python/) |
+| Dashboard, REST, JSON-RPC, and MCP | [MCP and Service API](https://keepgpu.readthedocs.io/en/latest/guides/mcp/) |
+| Full command list | [CLI Reference](https://keepgpu.readthedocs.io/en/latest/reference/cli/) |
+| Public Python API | [Python API Reference](https://keepgpu.readthedocs.io/en/latest/reference/api/) |
+| Design and lifecycle model | [Architecture](https://keepgpu.readthedocs.io/en/latest/concepts/architecture/) |
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md)
-- [CLI Guide](docs/guides/cli.md)
-- [Python Guide](docs/guides/python.md)
-- [MCP and Service API](docs/guides/mcp.md)
-- [CLI Reference](docs/reference/cli.md)
-- [Python API Reference](docs/reference/api.md)
-- [Architecture](docs/concepts/architecture.md)
+The published documentation is available at
+[keepgpu.readthedocs.io](https://keepgpu.readthedocs.io/). The same pages live
+under [`docs/`](https://github.com/Wangmerlyn/KeepGPU/tree/main/docs) in this
+repository.
 
 ## Contributing
 
-Contributions are welcome, especially around platform fallbacks and scheduler-specific recipes. See [Contributing](docs/contributing.md) for setup, tests, and PR guidance.
+Contributions are welcome, especially around platform fallbacks and
+scheduler-specific recipes. See
+[Contributing](https://keepgpu.readthedocs.io/en/latest/contributing/) for
+setup, tests, and PR guidance.
 
 ## Citation
 
-If KeepGPU helps your research or operations, see [Citation](docs/citation.md)
-for the BibTeX entry.
+If KeepGPU helps your research or operations, see
+[Citation](https://keepgpu.readthedocs.io/en/latest/citation/) for the BibTeX
+entry.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -98,8 +98,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
   builds do not need `pip install .`.
 - Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
   stay in the repository but are excluded from the published MkDocs site.
-- Keep README as a concise front door. Put full citation metadata in
-  `docs/citation.md` and link to it from README.
+- Keep README as a concise front door. Put detailed interface examples and
+  contracts in the focused docs pages, and keep full citation metadata in
+  `docs/citation.md`.
 
 ## MCP server (experimental)
 

--- a/docs/plans/readme-slim.md
+++ b/docs/plans/readme-slim.md
@@ -2,33 +2,35 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Turn `README.md` into a clean front door while keeping detailed CLI, Python, MCP, platform, and development guidance in published docs.
+**Goal:** Keep `README.md` as a clean front door while detailed CLI, Python, MCP, platform, and development guidance live in focused docs pages.
 
-**Architecture:** Keep README as a compact product overview with links to existing docs. Move no behavior into new code paths and avoid creating a new docs page unless an existing destination is missing. Add a tiny metadata test so the README does not quietly grow back into a reference manual.
+**Architecture:** README should provide a short pitch, one quick-start command, and links to existing docs. Existing docs already cover service mode, Python controllers, dashboard, MCP, references, contributing, and citation, so this change does not add a new page. A metadata test prevents README from drifting back into a reference manual.
 
 **Tech Stack:** Markdown, MkDocs, pytest, pre-commit.
 
 ---
 
-### Task 1: Add README Shape Guard
+### Task 1: Tighten README Shape Guard
 
 **Files:**
 - Modify: `tests/test_package_metadata.py`
 
-- [x] **Step 1: Add a failing test**
+- [x] **Step 1: Add the stricter failing test**
 
-Add this test after `test_readme_markdown_code_fences_are_balanced`:
+`test_readme_stays_a_compact_front_door` must enforce:
 
 ```python
-def test_readme_stays_a_compact_front_door():
-    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
-    lines = [line for line in readme.splitlines() if line.strip()]
-
-    assert len(lines) <= 130
-    assert "### MCP and service API" not in readme
-    assert "Platform installs at a glance" not in readme
-    assert "docs/guides/mcp.md" in readme
-    assert "docs/reference/cli.md" in readme
+assert len(lines) <= 60
+assert "## python" not in normalized_readme
+assert "## service, dashboard, and mcp" not in normalized_readme
+assert "### mcp and service api" not in normalized_readme
+assert "platform installs at a glance" not in normalized_readme
+assert "```bibtex" not in normalized_readme
+assert "skillcheck" not in normalized_readme
+assert "](docs/" not in readme
+assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
+assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
+assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 ```
 
 - [x] **Step 2: Verify RED**
@@ -39,73 +41,70 @@ Run:
 PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q
 ```
 
-Expected: FAIL because the current README has more than 130 nonblank lines.
+Expected: FAIL because the previous README still had standalone Python and
+service/dashboard/MCP sections.
 
-### Task 2: Slim README and Keep Links
+### Task 2: Slim README to a Front Door
 
 **Files:**
 - Modify: `README.md`
 
-- [x] **Step 1: Replace README with a compact front door**
+- [x] **Step 1: Keep only front-door content**
 
-Keep these sections only:
+README keeps:
 
-- `# Keep GPU`
-- badges and one-sentence product pitch
-- `## Why KeepGPU`
-- `## Quick Start`
-- `## Python`
-- `## Service, Dashboard, and MCP`
-- `## Documentation`
-- `## Contributing`
-- `## Citation`
+- title and badges
+- one-sentence product pitch
+- three `Why KeepGPU` bullets
+- one install/start command block
+- a compact interface table linking to existing docs
+- short documentation, contributing, and citation links
+- package-renderer-safe absolute links for docs, contributing, and citation
+- only badges with live image URLs
 
-The README must include:
+README does not keep:
 
-- one blocking CLI example
-- one service-mode example
-- one Python snippet
-- dashboard URL
-- links to `docs/getting-started.md`, `docs/guides/cli.md`, `docs/guides/python.md`, `docs/guides/mcp.md`, `docs/reference/cli.md`, `docs/reference/api.md`, `docs/concepts/architecture.md`, and `docs/contributing.md`
-- the existing BibTeX citation
+- standalone Python section
+- standalone service/dashboard/MCP section
+- service-mode command sequence
+- Python controller snippet
+- dashboard URL block
+- full citation metadata
+- platform install matrix
+- CLI/API/MCP contract detail
+- repository-relative `docs/...` links in README
+- broken badges
 
-The README must not include:
-
-- full platform install matrix
-- CLI flag reference tables or long validation rules
-- JSON-RPC/REST protocol details
-- dashboard lifecycle edge cases
-- developer test matrices
-
-- [x] **Step 2: Verify README size**
+- [x] **Step 2: Verify GREEN**
 
 Run:
 
 ```bash
+PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q
 python - <<'PY'
 from pathlib import Path
-lines = [line for line in Path("README.md").read_text(encoding="utf-8").splitlines() if line.strip()]
+lines = [
+    line
+    for line in Path("README.md").read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
 print(len(lines))
-assert len(lines) <= 130
+assert len(lines) <= 60
 PY
 ```
 
-Expected: prints a number no greater than `130`.
+Expected: pytest passes and the line counter prints no more than `60`.
 
-### Task 3: Update Agent Guidance
+### Task 3: Align Contributor and Agent Guidance
 
 **Files:**
 - Modify: `AGENTS.md`
+- Modify: `docs/contributing.md`
 
-- [x] **Step 1: Add README guardrail**
+- [x] **Step 1: Update guidance**
 
-Under Documentation Updates, add a bullet with this meaning:
-
-```markdown
-- Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
-  contracts in `docs/` pages and link to them from README instead of repeating
-  reference material.
-```
+Both docs should say README is a concise front door and detailed interface
+examples/contracts belong in focused docs pages, not repeated in README.
 
 ### Task 4: Verify and Review
 
@@ -124,15 +123,38 @@ Expected: all tests in the file pass.
 
 ```bash
 pre-commit run --all-files --show-diff-on-failure
-mkdocs build --strict
+PYTHONPATH=$PWD/src mkdocs build --strict
 ```
 
-Expected: both commands exit `0`. The existing upstream Material for MkDocs warning may appear.
+Expected: both commands exit `0`. The existing upstream Material for MkDocs
+warning may appear.
 
-- [x] **Step 3: Mark this plan complete**
+- [x] **Step 3: Request local subagent code review**
 
-Check off completed plan items in `docs/plans/readme-slim.md`.
+Dispatch a local reviewer before opening the PR. Resolve any Critical or
+Important findings before pushing.
 
-- [x] **Step 4: Request local subagent code review**
+## Verification
 
-Dispatch a local reviewer before opening the PR. Resolve any Critical or Important findings before pushing.
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q`,
+  `1 failed` because the previous README still had a standalone Python section.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q`,
+  `1 passed`; the README nonblank line counter printed `44` after package-safe
+  links were added.
+- Targeted metadata tests:
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`, `8 passed`.
+- Docs and formatting:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the known Material
+  warning; `pre-commit run --all-files --show-diff-on-failure` passed; `git diff
+  --check` passed.
+- Local review follow-up:
+  the first local review found that repository-relative README links were unsafe for
+  package renderers because README is the PyPI long description. README links now
+  use absolute ReadTheDocs/GitHub URLs, and the metadata guard rejects
+  repository-relative `](docs/` links.
+- Second local review follow-up:
+  the reviewer found the pre-existing SkillCheck badge image returned `404`.
+  The broken badge was removed, and the README guard now rejects `skillcheck`.
+  Remaining README badge images returned `200` with a `GET` request.

--- a/docs/plans/readme-slim.md
+++ b/docs/plans/readme-slim.md
@@ -27,7 +27,7 @@ assert "### mcp and service api" not in normalized_readme
 assert "platform installs at a glance" not in normalized_readme
 assert "```bibtex" not in normalized_readme
 assert "skillcheck" not in normalized_readme
-assert "](docs/" not in readme
+assert not re.search(r"\]\(\.?\.?/?docs/", readme)
 assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
 assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
 assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
@@ -158,3 +158,6 @@ Important findings before pushing.
   the reviewer found the pre-existing SkillCheck badge image returned `404`.
   The broken badge was removed, and the README guard now rejects `skillcheck`.
   Remaining README badge images returned `200` with a `GET` request.
+- Hosted review follow-up:
+  Gemini noted that a plain `](docs/` check would miss `./docs/` and `../docs/`
+  links. The guard now uses a regex for relative docs links.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -106,7 +106,7 @@ def test_readme_stays_a_compact_front_door():
     assert "platform installs at a glance" not in normalized_readme
     assert "```bibtex" not in normalized_readme
     assert "skillcheck" not in normalized_readme
-    assert "](docs/" not in readme
+    assert not re.search(r"\]\(\.?\.?/?docs/", readme)
     assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
     assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
     assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -99,13 +99,17 @@ def test_readme_stays_a_compact_front_door():
     normalized_readme = readme.lower()
     lines = [line for line in readme.splitlines() if line.strip()]
 
-    assert len(lines) <= 130
+    assert len(lines) <= 60
+    assert "## python" not in normalized_readme
+    assert "## service, dashboard, and mcp" not in normalized_readme
     assert "### mcp and service api" not in normalized_readme
     assert "platform installs at a glance" not in normalized_readme
     assert "```bibtex" not in normalized_readme
-    assert "docs/guides/mcp.md" in readme
-    assert "docs/reference/cli.md" in readme
-    assert "docs/citation.md" in readme
+    assert "skillcheck" not in normalized_readme
+    assert "](docs/" not in readme
+    assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
+    assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
+    assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 
 
 def test_sdist_manifest_does_not_package_test_suite():


### PR DESCRIPTION
## Summary
- Slim README into a package-safe front door with one quick-start command and guide links.
- Move detailed Python/service/dashboard/MCP examples out of README by linking to existing docs.
- Tighten README metadata guard and remove the broken SkillCheck badge.
- Align AGENTS, contributing guidance, and the README plan.

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`
- `PYTHONPATH=$PWD/src mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
- live GET check for README badge images and key docs links

## Local Review
- Local review found package-renderer-unsafe relative docs links; fixed with absolute ReadTheDocs/GitHub URLs.
- Local review found the pre-existing SkillCheck badge image returned 404; removed and guarded.
- Final local review found no must-fix issues.