### PR TITLE
[cli] fix: validate service result job ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,8 @@ This file defines how coding agents should work in this repository.
 - CLI method-specific result validation must include nested records consumed by
   downstream tools: `status.active_jobs` entries, disjoint `stop_keep` job-id
   outcome lists whose `errors` keys exactly match `failed`, and `list_gpus` GPU
-  records with visible ordinal metadata. Known nested `status.params` fields
+  records with visible ordinal metadata. Service-returned job IDs must satisfy
+  the shared URL-path-safe job-id contract. Known nested `status.params` fields
   must match the public session contract while extra fields remain
   forward-compatible.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -96,6 +96,8 @@ including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes and malformed method-specific result
 records are reported as JSON error objects instead of empty success results.
+Service-returned job IDs in `status` and `stop` results are validated with the
+same URL-path-safe rules as user-supplied `--job-id` values.
 Invalid service endpoints, including non-integer ports, are also reported as
 JSON errors before any RPC or stop-all fallback runs.
 When KeepGPU can identify the underlying device, it reports `physical_id` or

--- a/docs/plans/cli-service-result-job-id-validation.md
+++ b/docs/plans/cli-service-result-job-id-validation.md
@@ -1,0 +1,53 @@
+# CLI Service Result Job ID Validation Plan
+
+## Background
+
+CLI service commands already validate user-supplied `--job-id` values and
+`start_keep` result IDs with the shared URL-path-safe session contract. The
+method-specific validators for `status` and `stop_keep` only checked
+service-returned job IDs as strings, so malformed strings such as `bad/id`
+could be emitted as successful machine-readable CLI output.
+
+## Goal
+
+Reject malformed service-returned job IDs in CLI `status` and `stop` results as
+clean `ServiceResponseError` JSON errors before rendering user-facing output.
+
+## Solution
+
+- Add RED cases for URL-unsafe string IDs in all-session `status`, single-job
+  `status`, and `stop_keep` outcome/error records.
+- Reuse the centralized `validate_job_id()` contract inside CLI
+  method-specific result validators.
+- Keep `_rpc_call()` limited to generic JSON-RPC envelope validation.
+- Update CLI and agent guidance so future service-result validation keeps job
+  IDs aligned with the public session contract.
+
+## Tasks
+
+- [x] Create an isolated worktree branch from latest `main`.
+- [x] Add RED malformed service-returned job-id tests.
+- [x] Implement minimal CLI result job-id validation.
+- [x] Update `AGENTS.md`, CLI guide, and this plan.
+- [x] Run targeted tests, broader CLI tests, docs build, and pre-commit.
+- [x] Run local subagent review.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_status_rejects_malformed_active_job_entries tests/test_cli_service_commands.py::test_status_job_rejects_malformed_payloads tests/test_cli_service_commands.py::test_stop_job_rejects_malformed_job_id_lists_and_errors -q`,
+  `5 failed, 13 passed` because URL-unsafe string IDs were accepted.
+- GREEN:
+  the same command passed with `18 passed` after `status` and `stop_keep`
+  result validators reused `validate_job_id()`.
+- Broader CLI shard:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q`,
+  `179 passed`.
+- Full test suite:
+  `PYTHONPATH=$PWD/src pytest -q`, `775 passed, 11 skipped`.
+- Docs and formatting:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the known Material
+  warning; `pre-commit run --all-files --show-diff-on-failure` passed; `git diff
+  --check` passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -628,7 +628,8 @@ def _require_nullable_string_field(
 
 def _validate_result_job_id(job_id: str, method: str, prefix: str) -> str:
     try:
-        return validate_job_id(job_id) or job_id
+        validate_job_id(job_id)
+        return job_id
     except ValueError as exc:
         raise _malformed_method_result(method, f"{prefix}: {exc}") from exc
 
@@ -690,9 +691,10 @@ def _validate_status_result(
             raise _malformed_method_result("status", "active must be a bool")
         if not isinstance(result.get("job_id"), str):
             raise _malformed_method_result("status", "job_id must be a string")
-        _validate_result_job_id(result["job_id"], "status", "job_id")
         if result["active"]:
             _validate_status_session_record(result, "status", "result")
+        else:
+            _validate_result_job_id(result["job_id"], "status", "job_id")
     else:
         active_jobs = _require_list_field(result, "active_jobs", "status")
         for index, active_job in enumerate(active_jobs):

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -626,6 +626,13 @@ def _require_nullable_string_field(
     return value
 
 
+def _validate_result_job_id(job_id: str, method: str, prefix: str) -> str:
+    try:
+        return validate_job_id(job_id) or job_id
+    except ValueError as exc:
+        raise _malformed_method_result(method, f"{prefix}: {exc}") from exc
+
+
 def _require_plain_int_field(result: Dict[str, Any], field: str, method: str) -> int:
     value = result.get(field)
     if isinstance(value, bool) or not isinstance(value, int):
@@ -664,13 +671,14 @@ def _validate_status_session_record(
     record: Dict[str, Any], method: str, prefix: str
 ) -> None:
     try:
-        _require_string_field(record, "job_id", method)
+        job_id = _require_string_field(record, "job_id", method)
         params = _require_dict_field(record, "params", method)
         _require_string_field(record, "state", method)
         _require_nullable_string_field(record, "last_error", method)
     except ServiceResponseError as exc:
         detail = str(exc).split(": ", 1)[-1]
         raise _malformed_method_result(method, f"{prefix}.{detail}") from exc
+    _validate_result_job_id(job_id, method, f"{prefix}.job_id")
     _validate_status_params(params, method, f"{prefix}.params")
 
 
@@ -682,6 +690,7 @@ def _validate_status_result(
             raise _malformed_method_result("status", "active must be a bool")
         if not isinstance(result.get("job_id"), str):
             raise _malformed_method_result("status", "job_id must be a string")
+        _validate_result_job_id(result["job_id"], "status", "job_id")
         if result["active"]:
             _validate_status_session_record(result, "status", "result")
     else:
@@ -709,6 +718,7 @@ def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
                 raise _malformed_method_result(
                     "stop_keep", f"{field}[{index}] must be a string"
                 )
+            _validate_result_job_id(job_id, "stop_keep", f"{field}[{index}]")
             if job_id in field_jobs:
                 raise _malformed_method_result(
                     "stop_keep", f"{field}[{index}] duplicates job id"
@@ -724,6 +734,7 @@ def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
     for job_id, error in errors.items():
         if not isinstance(job_id, str):
             raise _malformed_method_result("stop_keep", "errors keys must be strings")
+        _validate_result_job_id(job_id, "stop_keep", f"errors[{job_id!r}]")
         if not isinstance(error, str):
             raise _malformed_method_result(
                 "stop_keep", f"errors[{job_id!r}] must be a string"

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -717,6 +717,16 @@ def test_status_rejects_malformed_all_session_payloads(monkeypatch, payload):
         {
             "active_jobs": [
                 {
+                    "job_id": "bad/id",
+                    "params": {},
+                    "state": "active",
+                    "last_error": None,
+                }
+            ]
+        },
+        {
+            "active_jobs": [
+                {
                     "params": {},
                     "state": "active",
                     "last_error": None,
@@ -811,6 +821,14 @@ def test_status_rejects_malformed_known_session_params(monkeypatch, session_para
         {},
         {"active": "yes", "job_id": "job-1"},
         {"active": True, "job_id": 1},
+        {"active": False, "job_id": "bad/id"},
+        {
+            "active": True,
+            "job_id": "bad/id",
+            "params": {},
+            "state": "active",
+            "last_error": None,
+        },
     ],
 )
 def test_status_job_rejects_malformed_payloads(monkeypatch, payload):
@@ -947,8 +965,21 @@ def test_stop_job_rejects_malformed_payloads(monkeypatch, payload):
     "payload",
     [
         {"stopped": [1], "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": ["bad/id"], "timed_out": [], "failed": [], "errors": {}},
         {"stopped": [], "timed_out": [None], "failed": [], "errors": {}},
         {"stopped": [], "timed_out": [], "failed": [False], "errors": {}},
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": ["bad/id"],
+            "errors": {"bad/id": "boom"},
+        },
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": [],
+            "errors": {"bad/id": "boom"},
+        },
         {"stopped": [], "timed_out": [], "failed": [], "errors": {"job-1": 1}},
     ],
 )


### PR DESCRIPTION
## Summary
- reject service-returned job IDs in CLI status/stop payloads unless they satisfy the shared URL-path-safe job-id contract
- keep generic JSON-RPC envelope validation inside `_rpc_call()` unchanged
- add focused regression coverage and update AGENTS/CLI plan docs

## Local subagent review
- local code-path reviewer: no critical/important/minor findings after follow-up
- local docs/test reviewer: ready to merge from review scope

## Verification
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> 180 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 776 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed