### PR TITLE
[cli] fix: reject invalid rpc response id types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,10 @@ This file defines how coding agents should work in this repository.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes
   (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
-  concrete id, missing `result`, non-object direct-method `result`, or
-  non-object `error`) instead of treating them as successful empty responses or
-  leaking tracebacks.
+  concrete id, response IDs that compare equal but use an invalid JSON-RPC id
+  type such as float or boolean, missing `result`, non-object direct-method
+  `result`, or non-object `error`) instead of treating them as successful empty
+  responses or leaking tracebacks.
 - CLI commands that consume service-specific JSON-RPC results must validate
   required result fields before rendering user-facing output; malformed
   method-specific payloads should become clean `ServiceResponseError` messages,

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -96,6 +96,7 @@ including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes and malformed method-specific result
 records are reported as JSON error objects instead of empty success results.
+Response IDs must echo the request ID with a valid matching JSON-RPC ID type.
 Service-returned job IDs in `status` and `stop` results are validated with the
 same URL-path-safe rules as user-supplied `--job-id` values.
 Invalid service endpoints, including non-integer ports, are also reported as

--- a/docs/plans/cli-jsonrpc-response-id-type.md
+++ b/docs/plans/cli-jsonrpc-response-id-type.md
@@ -1,0 +1,36 @@
+# CLI JSON-RPC Response ID Type Plan
+
+## Background
+
+The CLI service client already rejects missing, null, and mismatched JSON-RPC
+response IDs. It compared response IDs with Python equality, so invalid JSON-RPC
+ID types such as `1000.0` or `true` could compare equal to integer request IDs
+and be accepted.
+
+## Goal
+
+Reject JSON-RPC service responses unless the response ID both equals the request
+ID and uses the same valid ID type.
+
+## Tasks
+
+- [x] Create an isolated worktree branch from latest `main`.
+- [x] Add RED tests for float and boolean response IDs on success and error
+      envelopes.
+- [x] Add a minimal shared response-ID matcher for `_rpc_call()`.
+- [x] Update `AGENTS.md`, CLI guide, and this plan.
+- [x] Run targeted tests and broader checks.
+- [ ] Run local subagent review.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED:
+  the four invalid-id cases now covered by
+  `test_rpc_call_rejects_envelope_with_invalid_id_type` failed in the initial
+  two-test draft because invalid response ID types were accepted.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_invalid_id_type -q`
+  passed with `4 passed` after `_rpc_call()` required matching response ID type
+  and value.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -570,13 +570,13 @@ def _rpc_call(
             )
         if "id" not in response:
             raise ServiceResponseError("Malformed JSON-RPC response: missing id")
-        if response["id"] != payload["id"]:
+        if not _jsonrpc_response_id_matches(response["id"], payload["id"]):
             raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
         code = error.get("code")
         if isinstance(code, bool) or not isinstance(code, int):
             code = None
         raise ServiceRPCError(error.get("message", str(error)), code=code)
-    if response.get("id") != payload["id"]:
+    if not _jsonrpc_response_id_matches(response.get("id"), payload["id"]):
         raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
     if "result" not in response:
         raise ServiceResponseError("Malformed JSON-RPC response: missing result")
@@ -586,6 +586,10 @@ def _rpc_call(
             "Malformed JSON-RPC response: result must be an object"
         )
     return result
+
+
+def _jsonrpc_response_id_matches(response_id: Any, request_id: Any) -> bool:
+    return type(response_id) is type(request_id) and response_id == request_id
 
 
 def _malformed_method_result(method: str, detail: str) -> ServiceResponseError:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1453,6 +1453,28 @@ def test_rpc_call_rejects_error_envelope_with_null_id(monkeypatch):
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
 
 
+@pytest.mark.parametrize("body", [{"result": {}}, {"error": {"message": "boom"}}])
+@pytest.mark.parametrize(
+    ("request_time", "response_id"),
+    [
+        (1.0, 1000.0),
+        (0.001, True),
+    ],
+)
+def test_rpc_call_rejects_envelope_with_invalid_id_type(
+    monkeypatch, body, request_time, response_id
+):
+    monkeypatch.setattr(cli.time, "time", lambda: request_time)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": response_id, **body},
+    )
+
+    with pytest.raises(cli.ServiceResponseError, match="mismatched id"):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
 def test_rpc_call_rejects_error_envelope_without_id_member(monkeypatch):
     monkeypatch.setattr(cli.time, "time", lambda: 1.0)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- reject JSON-RPC service response IDs whose value compares equal but uses the wrong type, such as `1000.0` or `true` for an integer request ID
- apply the stricter ID matcher before accepting success envelopes or surfacing service error envelopes
- add compact regression coverage plus AGENTS/CLI plan docs

## Local subagent review
- reviewer found no critical, important, or minor issues after plan-doc cleanup
- reviewer re-ran `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_invalid_id_type -q` -> 4 passed

## Verification
- RED: invalid response-id-type cases failed before the matcher because Python equality accepted them
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_rpc_call_rejects_envelope_with_invalid_id_type -q` -> 4 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> 184 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 780 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed