### PR TITLE
[docs] docs: align public platform story

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ This file defines how coding agents should work in this repository.
   - Python API/controllers (`src/keep_gpu/single_gpu_controller/`, `src/keep_gpu/global_gpu_controller/`)
   - MCP server: `keep-gpu-mcp-server` (`src/keep_gpu/mcp/server.py`)
 - If behavior changes in one interface, update related docs/tests for that interface and check if parity is required in the others.
+- Public overview docs should describe CUDA, ROCm, and Mac M/MPS support without
+  making KeepGPU sound CUDA-only or treating MCP as experimental.
 - Keep the MCP server compatible with standard MCP lifecycle/tool methods
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,8 +1,9 @@
 # How KeepGPU Works
 
 At runtime, KeepGPU spins up one lightweight worker per GPU. Each worker keeps a
-tensor allocated and runs a burst of CUDA ops, then sleeps. This convinces most
-schedulers that the GPU is still busy, without burning a full training workload.
+tensor allocated and runs a short backend-specific keepalive burst, then sleeps.
+This convinces most schedulers that the GPU is still busy, without burning a
+full training workload.
 
 ## Components
 
@@ -30,8 +31,8 @@ schedulers that the GPU is still busy, without burning a full training workload.
    and file logging with optional colors.
 
 ```text
-CLI args ──▶ GlobalGPUController ──▶ [CudaGPUController rank=0]
-                                      [CudaGPUController rank=1]
+CLI args ──▶ GlobalGPUController ──▶ [backend controller rank=0]
+                                      [backend controller rank=1]
                                       [...]
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,7 +102,7 @@ expectations so you can get productive quickly and avoid surprises in CI.
   contracts in the focused docs pages, and keep full citation metadata in
   `docs/citation.md`.
 
-## MCP server (experimental)
+## MCP server
 
 - Start: `keep-gpu-mcp-server` (stdin/stdout JSON-RPC)
 - HTTP option: `keep-gpu-mcp-server --mode http --host 0.0.0.0 --port 8765`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,18 +5,19 @@ understand the minimum knobs you need to keep a GPU occupied.
 
 ## Requirements
 
-- NVIDIA drivers + CUDA runtime visible to PyTorch.
 - Python 3.9+ (matching the version in your environment/cluster image).
-- CUDA utilization monitoring uses NVML by way of `nvidia-ml-py` (the `pynvml` module);
-  `nvidia-smi` is useful only as an external driver sanity check. ROCm telemetry
-  uses `rocm_smi` when the ROCm/system stack provides it, and KeepGPU handles a
-  missing module gracefully.
+- A PyTorch build that matches your target platform: CUDA, ROCm/HIP, Mac M
+  series MPS, or CPU-only for import and docs workflows.
+- CUDA utilization monitoring uses NVML by way of `nvidia-ml-py` (the `pynvml`
+  module); `nvidia-smi` is useful only as an external driver sanity check. ROCm
+  telemetry uses `rocm_smi` when the ROCm/system stack provides it, and KeepGPU
+  handles a missing module gracefully.
 
 !!! info "Platforms"
-    CUDA is the primary path; ROCm requires a ROCm-enabled PyTorch build. The
-    `rocm` extra remains available as an install-compatible marker but does not
-    install ROCm SMI from PyPI. Mac M series (M1/M2/M3/M4) is supported by way of
-    the `macm` extra using Metal Performance Shaders (MPS).
+    CUDA is the most common path; ROCm requires a ROCm-enabled PyTorch build.
+    The `rocm` extra remains available as an install-compatible marker but does
+    not install ROCm SMI from PyPI. Mac M series (M1/M2/M3/M4) is supported by
+    way of the `macm` extra using Metal Performance Shaders (MPS).
     CPU-only environments can import the package but controllers will not start.
 
 ## Install
@@ -74,7 +75,8 @@ understand the minimum knobs you need to keep a GPU occupied.
    ```bash
    python -c "import torch; print(torch.cuda.device_count())"
    ```
-   A non-zero integer indicates CUDA is available.
+   A non-zero integer indicates at least one CUDA or ROCm/HIP device is visible
+   to PyTorch.
 
    On Mac M series:
    ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 > Keep a GPU busy so the scheduler, lab mate, or cluster watchdog does not take it away.
 
 KeepGPU is a tiny-but-focused toolkit that continuously allocates VRAM and launches
-low-cost CUDA workloads so that a GPU always looks “in use.” You can run it as a CLI
-while you prep data, or embed the controllers directly in Python to guard resources
-during longer CPU-bound sections of your workflow.
+low-cost platform-specific keep-alive work so that a GPU always looks “in use.”
+You can run it as a CLI while you prep data, or embed the controllers directly
+in Python to guard resources during longer CPU-bound sections of your workflow.
 
 ## Why it matters
 
@@ -21,7 +21,8 @@ during longer CPU-bound sections of your workflow.
 
 - Rich CLI based on Typer + Rich (blocking and non-blocking session workflows).
 - `GlobalGPUController` that spins up a keep-alive worker per GPU.
-- `CudaGPUController` context manager for fine-grained orchestration inside scripts.
+- `CudaGPUController`, `RocmGPUController`, and `MacMGPUController` context
+  managers for fine-grained orchestration inside scripts.
 - Helpers for parsing human VRAM sizes (`1GiB`, `850MB`, etc.) and platform detection.
 - Power-aware keep-alive loop: periodic elementwise ops to signal “busy” without flooding matmuls or spiking thermals.
 

--- a/docs/plans/docs-platform-parity.md
+++ b/docs/plans/docs-platform-parity.md
@@ -1,0 +1,32 @@
+# Docs Platform Parity Plan
+
+## Background
+
+KeepGPU supports CLI, Python controllers, and MCP as first-class surfaces across
+CUDA, ROCm, and Mac M/MPS paths. A few public docs entry points still used
+CUDA-only framing or described MCP as experimental.
+
+## Goal
+
+Keep the public docs concise while making the platform and interface story match
+the current product surface.
+
+## Tasks
+
+- [x] Create an isolated worktree branch from latest `main`.
+- [x] Add a RED docs guard for stale CUDA-only and MCP-experimental wording.
+- [x] Update overview, getting-started, architecture, contributing, and AGENTS
+      wording.
+- [x] Run docs/tests.
+- [ ] Run local subagent review.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp -q`,
+  failed because `docs/index.md` still used `low-cost CUDA workloads`.
+- GREEN:
+  the same command passed after the public docs used platform-neutral wording
+  and described MCP as a first-class interface.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -112,6 +112,36 @@ def test_readme_stays_a_compact_front_door():
     assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 
 
+def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
+    public_docs = {
+        "index": (PROJECT_ROOT / "docs/index.md").read_text(encoding="utf-8"),
+        "getting_started": (PROJECT_ROOT / "docs/getting-started.md").read_text(
+            encoding="utf-8"
+        ),
+        "architecture": (PROJECT_ROOT / "docs/concepts/architecture.md").read_text(
+            encoding="utf-8"
+        ),
+        "contributing": (PROJECT_ROOT / "docs/contributing.md").read_text(
+            encoding="utf-8"
+        ),
+    }
+
+    assert "low-cost CUDA workloads" not in public_docs["index"]
+    assert (
+        "NVIDIA drivers + CUDA runtime visible to PyTorch"
+        not in public_docs["getting_started"]
+    )
+    assert (
+        "A non-zero integer indicates CUDA is available."
+        not in public_docs["getting_started"]
+    )
+    assert "burst of CUDA ops" not in public_docs["architecture"]
+    assert "[CudaGPUController rank=0]" not in public_docs["architecture"]
+    assert "MCP server (experimental)" not in public_docs["contributing"]
+    assert "RocmGPUController" in public_docs["index"]
+    assert "MacMGPUController" in public_docs["index"]
+
+
 def test_sdist_manifest_does_not_package_test_suite():
     manifest_path = PROJECT_ROOT / "MANIFEST.in"
     assert manifest_path.exists()


### PR DESCRIPTION
## Summary
- make public docs entry points describe KeepGPU as CUDA/ROCm/Mac M capable instead of CUDA-only
- remove the experimental label from the MCP contributor docs
- add a compact guard test so stale CUDA-only/MCP-experimental wording does not drift back

## Local subagent review
- initial review found one remaining CUDA-only sanity-check sentence and one CUDA-only architecture diagram label
- fixed both, strengthened the guard, and final review reported no critical/important/minor findings

## Verification
- RED: docs guard failed on stale `low-cost CUDA workloads` wording
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp -q` -> 1 passed
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` -> 9 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 781 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed