### PR TITLE
[docs] ci: bound mkdocs major version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,9 @@ This file defines how coding agents should work in this repository.
   used directly by CI or contributors, including `mkdocs` and
   `pymdown-extensions`; do not rely on theme/plugin transitive dependencies for
   documented commands or configured extensions.
+- Bound known incompatible docs-tool major versions in `docs/requirements.txt`;
+  MkDocs must remain `<2` while the Material warning says MkDocs 2 breaks
+  plugins/themes.
 
 ### Git Hygiene & Security
 

--- a/docs/plans/docs-mkdocs-major-bound.md
+++ b/docs/plans/docs-mkdocs-major-bound.md
@@ -1,0 +1,37 @@
+# Docs MkDocs Major Bound Plan
+
+## Background
+
+`mkdocs build --strict` passes, but Material for MkDocs emits a warning that
+MkDocs 2.0 will break plugins and theme overrides. CI installs
+`docs/requirements.txt` directly, and the file asked for unbounded `mkdocs`.
+
+## Goal
+
+Keep docs CI stable by bounding the known incompatible MkDocs major while leaving
+the docs toolchain simple and direct.
+
+## Tasks
+
+- [x] Create an isolated worktree branch from latest `main`.
+- [x] Reproduce the current Material/MkDocs 2.0 warning.
+- [x] Add a RED guard requiring the known incompatible MkDocs major bound.
+- [x] Add `mkdocs<2` and update `AGENTS.md`.
+- [x] Run docs/tests.
+- [ ] Run local subagent review.
+- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
+      clean the worktree.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py::test_docs_requirements_bound_known_incompatible_mkdocs_major -q`
+  failed because the active requirement was `mkdocs`.
+- GREEN:
+  the same command passed after changing the requirement to `mkdocs<2`.
+- Broader checks:
+  `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py -q` passed with
+  `8 passed` after the guard was hardened against `mkdocs<20` and `mkdocs<2.1`;
+  `PYTHONPATH=$PWD/src pytest -q` passed with `782 passed, 11 skipped`;
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed while still showing the
+  existing Material proactive warning.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs<2
 mkdocs-material
 mkdocstrings[python]
 pymdown-extensions

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -5,6 +5,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 ROOT_REQUIREMENTS_INSTALL_RE = re.compile(
     r"\b(?:python\s+-m\s+)?pip\s+install\s+-r\s+(?:\./)?requirements\.txt\b"
 )
+MKDOCS_MAJOR_TWO_BOUND_RE = re.compile(r"<\s*2(?:\.0+)?(?:\s|,|$)")
 
 
 def _installs_root_requirements_file(workflow: str) -> bool:
@@ -22,10 +23,25 @@ def _active_requirement_names(requirements: str) -> list[str]:
     ]
 
 
+def _active_requirement_line(requirements: str, name: str) -> str:
+    for line in requirements.splitlines():
+        requirement = line.split("#", 1)[0].strip()
+        if not requirement:
+            continue
+        requirement_name = re.split(r"\s*(?:[<>=!~;\\[]|$)", requirement, maxsplit=1)[0]
+        if requirement_name == name:
+            return requirement
+    raise AssertionError(f"missing requirement: {name}")
+
+
 def _has_active_pymdown_extension(mkdocs_config: str) -> bool:
     return any(
         "pymdownx." in line.split("#", 1)[0] for line in mkdocs_config.splitlines()
     )
+
+
+def _bounds_below_mkdocs_two(requirement: str) -> bool:
+    return bool(MKDOCS_MAJOR_TWO_BOUND_RE.search(requirement))
 
 
 def test_precommit_workflow_does_not_install_runtime_package():
@@ -72,6 +88,23 @@ def test_docs_requirements_include_direct_mkdocs_dependency():
     )
 
     assert "mkdocs" in _active_requirement_names(docs_requirements)
+
+
+def test_docs_requirements_bound_known_incompatible_mkdocs_major():
+    docs_requirements = (PROJECT_ROOT / "docs/requirements.txt").read_text(
+        encoding="utf-8"
+    )
+
+    assert _bounds_below_mkdocs_two(
+        _active_requirement_line(docs_requirements, "mkdocs")
+    )
+
+
+def test_mkdocs_major_bound_guard_rejects_similar_but_unsafe_bounds():
+    assert _bounds_below_mkdocs_two("mkdocs<2")
+    assert _bounds_below_mkdocs_two("mkdocs >=1.6,<2.0")
+    assert not _bounds_below_mkdocs_two("mkdocs<20")
+    assert not _bounds_below_mkdocs_two("mkdocs<2.1")
 
 
 def test_docs_requirements_include_configured_pymdown_extensions():


### PR DESCRIPTION
## Summary
- bound docs CI to `mkdocs<2` because the current Material toolchain warns that MkDocs 2 breaks plugins/themes
- add a focused workflow guard that accepts `<2` / `<2.0` but rejects unsafe lookalikes like `<20` and `<2.1`
- document the docs-tooling major-bound convention in AGENTS and the plan doc

## Local subagent review
- initial review found weak substring matching (`mkdocs<20`, then `<2.1` false positives)
- hardened the regex and samples; final review reported no critical/important/minor findings

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py::test_docs_requirements_bound_known_incompatible_mkdocs_major -q` failed on unbounded `mkdocs`
- `PYTHONPATH=$PWD/src pytest tests/test_ci_workflows.py -q` -> 8 passed
- `PYTHONPATH=$PWD/src pytest -q` -> 783 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed; current Material still prints its proactive MkDocs 2 warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for keeping the docs toolchain on a compatible major version.
  * Added a short plan describing the checks and rollout steps for this docs compatibility update.

* **Bug Fixes**
  * Locked the documentation build to a safe major version to avoid known issues with newer releases.

* **Tests**
  * Added validation to ensure the docs dependency stays within the supported version range and rejects unsafe alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->