### PR TITLE
[docs] docs: keep README compact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ This file defines how coding agents should work in this repository.
 - Keep `README.md` as a concise front door. Put detailed CLI/API/MCP/platform
   contracts in `docs/` pages and link to them from README instead of repeating
   reference material. Prefer one quick-start command plus guide links over
-  standalone Python, service, dashboard, or MCP sections. Keep long citation
-  metadata in `docs/citation.md`, not in README.
+  standalone Python, service, dashboard, or MCP sections. Use `docs/index.md`
+  as the detailed routing hub; README may keep only a high-level platform
+  sentence. Keep long citation metadata in `docs/citation.md`, not in README.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -3,56 +3,30 @@
 [![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)
 [![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)
 [![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Wangmerlyn/KeepGPU)
-[![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/Wangmerlyn/KeepGPU?utm_source=oss&utm_medium=github&utm_campaign=Wangmerlyn%2FKeepGPU&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
-KeepGPU keeps shared GPUs reserved while you prepare data, debug, or coordinate pipelines by holding a small, polite keep-alive workload instead of a full training job.
+KeepGPU is a small, polite GPU keeper for shared machines: reserve the VRAM you
+ask for, back off when the device is busy, and release cleanly when you are
+done.
 
-## Why KeepGPU
-
-- Guard interactive or staged work from idle GPU reclaim policies.
-- Reserve only the VRAM you ask for, with a low-power `1GiB` default.
-- Back off when utilization shows the device is busy, unless you explicitly opt into unconditional keepalive.
+It works with CUDA, ROCm/HIP, and Apple Silicon MPS when PyTorch can see the
+target device.
 
 ## Quick Start
 
-```bash
+```console
 pip install keep-gpu
 keep-gpu --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
 ```
 
 The command blocks until you press `Ctrl+C`, then releases the reserved memory.
-For non-blocking sessions, dashboard controls, and agent integrations, use the
-guides below.
 
-## Choose an Interface
+## Learn More
 
-| Need | Start here |
-| --- | --- |
-| First install and sanity check | [Getting Started](https://keepgpu.readthedocs.io/en/latest/getting-started/) |
-| Shell workflows and service mode | [CLI Guide](https://keepgpu.readthedocs.io/en/latest/guides/cli/) |
-| Python context managers/controllers | [Python Guide](https://keepgpu.readthedocs.io/en/latest/guides/python/) |
-| Dashboard, REST, JSON-RPC, and MCP | [MCP and Service API](https://keepgpu.readthedocs.io/en/latest/guides/mcp/) |
-| Full command list | [CLI Reference](https://keepgpu.readthedocs.io/en/latest/reference/cli/) |
-| Public Python API | [Python API Reference](https://keepgpu.readthedocs.io/en/latest/reference/api/) |
-| Design and lifecycle model | [Architecture](https://keepgpu.readthedocs.io/en/latest/concepts/architecture/) |
-
-## Documentation
-
-The published documentation is available at
-[keepgpu.readthedocs.io](https://keepgpu.readthedocs.io/). The same pages live
-under [`docs/`](https://github.com/Wangmerlyn/KeepGPU/tree/main/docs) in this
-repository.
-
-## Contributing
-
-Contributions are welcome, especially around platform fallbacks and
-scheduler-specific recipes. See
-[Contributing](https://keepgpu.readthedocs.io/en/latest/contributing/) for
-setup, tests, and PR guidance.
-
-## Citation
-
-If KeepGPU helps your research or operations, see
-[Citation](https://keepgpu.readthedocs.io/en/latest/citation/) for the BibTeX
-entry.
+- [Documentation](https://keepgpu.readthedocs.io/en/latest/) covers the CLI,
+  Python API, service dashboard, JSON-RPC, REST, and MCP server.
+- [Getting Started](https://keepgpu.readthedocs.io/en/latest/getting-started/)
+  has install options and the first hardware sanity check.
+- [Contributing](https://keepgpu.readthedocs.io/en/latest/contributing/) covers
+  local setup, tests, docs builds, and PR guidance.
+- [Citation](https://keepgpu.readthedocs.io/en/latest/citation/) has the BibTeX
+  entry.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -99,8 +99,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
   stay in the repository but are excluded from the published MkDocs site.
 - Keep README as a concise front door. Put detailed interface examples and
-  contracts in the focused docs pages, and keep full citation metadata in
-  `docs/citation.md`.
+  contracts in the focused docs pages, use `docs/index.md` for detailed
+  navigation, and keep full citation metadata in `docs/citation.md`.
 
 ## MCP server
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,13 @@ in Python to guard resources during longer CPU-bound sections of your workflow.
 
 ## What’s inside
 
-- Rich CLI based on Typer + Rich (blocking and non-blocking session workflows).
-- `GlobalGPUController` that spins up a keep-alive worker per GPU.
+- Rich CLI based on Typer + Rich for blocking and non-blocking session
+  workflows.
+- `GlobalGPUController` that spins up a keep-alive worker per selected GPU.
 - `CudaGPUController`, `RocmGPUController`, and `MacMGPUController` context
   managers for fine-grained orchestration inside scripts.
+- Service dashboard, REST endpoints, JSON-RPC methods, and MCP server for
+  browser controls, scripts, and agent integrations.
 - Helpers for parsing human VRAM sizes (`1GiB`, `850MB`, etc.) and platform detection.
 - Power-aware keep-alive loop: periodic elementwise ops to signal “busy” without flooding matmuls or spiking thermals.
 
@@ -34,8 +37,9 @@ in Python to guard resources during longer CPU-bound sections of your workflow.
   for pinning cards on clusters, workstations, or Jupyter.
 - :material-code-tags: **[Python API Recipes](guides/python.md)** – Drop-in snippets
   for wrapping preprocessing stages or orchestration scripts.
-- :material-monitor-dashboard: **Dashboard + API** – Run `keep-gpu serve` and open
-  `http://127.0.0.1:8765/` for session controls and telemetry.
+- :material-monitor-dashboard: **[Dashboard + API](guides/mcp.md)** – Run
+  `keep-gpu serve` and open `http://127.0.0.1:8765/` for session controls and
+  telemetry.
 - :material-lan: **[MCP and Service API](guides/mcp.md)** – JSON-RPC + REST endpoints
   for agents and remote orchestration.
 - :material-diagram-project: **[How KeepGPU Works](concepts/architecture.md)** –

--- a/docs/plans/readme-slim.md
+++ b/docs/plans/readme-slim.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Keep `README.md` as a clean front door while detailed CLI, Python, MCP, platform, and development guidance live in focused docs pages.
+**Goal:** Keep `README.md` as a very small clean front door while detailed CLI, Python, MCP, platform, and development guidance live in focused docs pages.
 
-**Architecture:** README should provide a short pitch, one quick-start command, and links to existing docs. Existing docs already cover service mode, Python controllers, dashboard, MCP, references, contributing, and citation, so this change does not add a new page. A metadata test prevents README from drifting back into a reference manual.
+**Architecture:** README should provide a short pitch, one high-level platform sentence, one quick-start command, and links to existing docs. Existing docs cover service mode, Python controllers, dashboard, MCP, references, contributing, and citation; `docs/index.md` is the routing hub. A metadata test prevents README from drifting back into a reference manual or becoming too thin to work as the PyPI description.
 
 **Tech Stack:** Markdown, MkDocs, pytest, pre-commit.
 
@@ -20,7 +20,18 @@
 `test_readme_stays_a_compact_front_door` must enforce:
 
 ```python
-assert len(lines) <= 60
+assert len(lines) <= 38
+assert readme.count("[![") <= 3
+assert "## choose an interface" not in normalized_readme
+assert "| need | start here |" not in normalized_readme
+assert "cuda" in normalized_readme
+assert "rocm/hip" in normalized_readme
+assert "mps" in normalized_readme
+assert "small, polite gpu keeper" in normalized_readme
+assert "## quick start" in normalized_readme
+assert "pip install keep-gpu" in normalized_readme
+assert re.search(r"^keep-gpu\s+--gpu-ids\s+0\b", readme, re.MULTILINE)
+assert "ctrl+c" in normalized_readme
 assert "## python" not in normalized_readme
 assert "## service, dashboard, and mcp" not in normalized_readme
 assert "### mcp and service api" not in normalized_readme
@@ -28,8 +39,8 @@ assert "platform installs at a glance" not in normalized_readme
 assert "```bibtex" not in normalized_readme
 assert "skillcheck" not in normalized_readme
 assert not re.search(r"\]\(\.?\.?/?docs/", readme)
-assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
-assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
+assert "https://keepgpu.readthedocs.io/en/latest/" in readme
+assert "https://keepgpu.readthedocs.io/en/latest/getting-started/" in readme
 assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 ```
 
@@ -41,8 +52,8 @@ Run:
 PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q
 ```
 
-Expected: FAIL because the previous README still had standalone Python and
-service/dashboard/MCP sections.
+Expected: FAIL because the previous README still exceeded the stricter compact
+budget and did not keep a high-level platform sentence.
 
 ### Task 2: Slim README to a Front Door
 
@@ -53,12 +64,11 @@ service/dashboard/MCP sections.
 
 README keeps:
 
-- title and badges
+- title and at most three badges
 - one-sentence product pitch
-- three `Why KeepGPU` bullets
+- one high-level CUDA, ROCm/HIP, and MPS platform sentence
 - one install/start command block
-- a compact interface table linking to existing docs
-- short documentation, contributing, and citation links
+- short documentation, getting started, contributing, and citation links
 - package-renderer-safe absolute links for docs, contributing, and citation
 - only badges with live image URLs
 
@@ -71,9 +81,22 @@ README does not keep:
 - dashboard URL block
 - full citation metadata
 - platform install matrix
+- docs route table
 - CLI/API/MCP contract detail
 - repository-relative `docs/...` links in README
 - broken badges
+
+### Task 2b: Keep Docs Landing Page as the Route Map
+
+**Files:**
+- Modify: `docs/index.md`
+
+- [x] **Step 1: Keep detailed routing in docs**
+
+`docs/index.md` should list all first-class surfaces: CLI, Python
+controllers/API, service dashboard, REST, JSON-RPC, and MCP server. Dashboard
+and API routing should link to the MCP/service guide instead of sitting as
+plain text.
 
 - [x] **Step 2: Verify GREEN**
 
@@ -89,11 +112,11 @@ lines = [
     if line.strip()
 ]
 print(len(lines))
-assert len(lines) <= 60
+assert len(lines) <= 38
 PY
 ```
 
-Expected: pytest passes and the line counter prints no more than `60`.
+Expected: pytest passes and the line counter prints no more than `38`.
 
 ### Task 3: Align Contributor and Agent Guidance
 
@@ -103,8 +126,9 @@ Expected: pytest passes and the line counter prints no more than `60`.
 
 - [x] **Step 1: Update guidance**
 
-Both docs should say README is a concise front door and detailed interface
-examples/contracts belong in focused docs pages, not repeated in README.
+Both docs should say README is a concise front door, `docs/index.md` is the
+detailed routing hub, and detailed interface examples/contracts belong in
+focused docs pages instead of README.
 
 ### Task 4: Verify and Review
 
@@ -136,15 +160,27 @@ Important findings before pushing.
 
 ## Verification
 
-- RED:
+- RED for stricter compactness:
   `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q`,
-  `1 failed` because the previous README still had a standalone Python section.
-- GREEN:
+  `1 failed` because the previous README had 43 nonblank lines under the new
+  `<=38` limit.
+- RED for platform signal:
   `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q`,
-  `1 passed`; the README nonblank line counter printed `44` after package-safe
-  links were added.
+  `1 failed` because the slimmer README did not yet mention CUDA, ROCm/HIP,
+  and MPS.
+- GREEN for final README shape:
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q`,
+  `1 passed`; the README nonblank line counter printed `24`.
 - Targeted metadata tests:
-  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`, `8 passed`.
+  `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`, `9 passed`.
+- Local review fix:
+  a local reviewer found that a content-free synthetic README could still pass
+  the compactness guard. The guard now requires the product pitch, Quick Start
+  heading, install command, runnable `keep-gpu --gpu-ids 0 ...` command, and
+  `Ctrl+C` release guidance. A synthetic bypass check confirmed those missing
+  essentials fail the assertions.
+- Full Python tests:
+  `PYTHONPATH=$PWD/src pytest -q`, `783 passed, 11 skipped`.
 - Docs and formatting:
   `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the known Material
   warning; `pre-commit run --all-files --show-diff-on-failure` passed; `git diff

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -99,7 +99,18 @@ def test_readme_stays_a_compact_front_door():
     normalized_readme = readme.lower()
     lines = [line for line in readme.splitlines() if line.strip()]
 
-    assert len(lines) <= 60
+    assert len(lines) <= 38
+    assert readme.count("[![") <= 3
+    assert "## choose an interface" not in normalized_readme
+    assert "| need | start here |" not in normalized_readme
+    assert "cuda" in normalized_readme
+    assert "rocm/hip" in normalized_readme
+    assert "mps" in normalized_readme
+    assert "small, polite gpu keeper" in normalized_readme
+    assert "## quick start" in normalized_readme
+    assert "pip install keep-gpu" in normalized_readme
+    assert re.search(r"^keep-gpu\s+--gpu-ids\s+0\b", readme, re.MULTILINE)
+    assert "ctrl+c" in normalized_readme
     assert "## python" not in normalized_readme
     assert "## service, dashboard, and mcp" not in normalized_readme
     assert "### mcp and service api" not in normalized_readme
@@ -107,8 +118,8 @@ def test_readme_stays_a_compact_front_door():
     assert "```bibtex" not in normalized_readme
     assert "skillcheck" not in normalized_readme
     assert not re.search(r"\]\(\.?\.?/?docs/", readme)
-    assert "https://keepgpu.readthedocs.io/en/latest/guides/mcp/" in readme
-    assert "https://keepgpu.readthedocs.io/en/latest/reference/cli/" in readme
+    assert "https://keepgpu.readthedocs.io/en/latest/" in readme
+    assert "https://keepgpu.readthedocs.io/en/latest/getting-started/" in readme
     assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 
 


### PR DESCRIPTION
## Summary
- slim README into a small PyPI/GitHub front door with one pitch, platform signal, quick start, and a few durable links
- move fuller interface routing into docs/index.md and align AGENTS/contributing guidance
- harden the README metadata guard against both bloat and over-slimming

## Verification
- PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q
- PYTHONPATH=$PWD/src pytest -q
- PYTHONPATH=$PWD/src mkdocs build --strict (passes with the known Material MkDocs 2 warning)
- pre-commit run --all-files --show-diff-on-failure
- git diff --check

## Local review
- Local subagent review found one Important guard gap; fixed by requiring the pitch, Quick Start, install command, runnable keep-gpu command, and Ctrl+C release guidance.
- Re-review reported no Critical, Important, or Minor findings and confirmed the synthetic over-slim README is rejected.
