### PR TITLE
[utilization] fix: normalize invalid telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ This file defines how coding agents should work in this repository.
   with a timeout `last_error`, and release a later successful startup in the
   background instead of exposing it as a surprise active keeper.
 - Stop-all may release independent sessions concurrently, but must not duplicate release work for `stopping` sessions and must keep deterministic additive result fields.
-- Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Only `busy_threshold=-1` is the explicit unconditional mode.
+- Keep utilization backoff eco-safe: valid `busy_threshold` values are `-1` or `0..100`; public defaults must use the shared `DEFAULT_BUSY_THRESHOLD` (`25`), and when telemetry is unavailable with `busy_threshold >= 0`, controllers should sleep instead of allocating keep tensors or running keepalive compute. Vendor utilization readings outside finite `0..100`, including boolean-like values, must normalize to unavailable telemetry before controller decisions or GPU listings. Only `busy_threshold=-1` is the explicit unconditional mode.
 - Dashboard telemetry must display unavailable utilization as unknown/`n/a`, not
   as `0%` idle; aggregate utilization summaries must ignore unavailable readings
   and show `n/a` when no finite readings exist, and per-GPU utilization bars
@@ -341,8 +341,8 @@ This file defines how coding agents should work in this repository.
   direct JSON-RPC, or MCP response advertises them: required `id`/`visible_id`
   fields are matching plain non-negative integers, visible ordinals are unique,
   `platform`/`name` are strings, `memory_total` and `memory_used` are integers
-  or null, and `utilization` is finite numeric or null. Malformed records from
-  telemetry helpers are internal server failures.
+  or null, and `utilization` is finite numeric `0..100` or null. Malformed
+  records from telemetry helpers are internal server failures.
 - REST session creation with explicit `gpu_ids` must validate the whole
   `list_gpus()` response envelope and records before deriving allowed visible
   IDs. Malformed listing payloads are structured JSON `500` internal failures,

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -25,7 +25,8 @@ full training workload.
    telemetry resolves `ROCR_VISIBLE_DEVICES` plus one matching
    `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` overlay before querying ROCm
    SMI. Utilization can be unavailable on some platforms and is reported as
-   `null`.
+   `null`; vendor readings outside finite `0..100` are treated as unavailable
+   instead of idle.
 5. **Utilities** – `parse_size` turns strings like `1GiB` or bare byte values into
    internal float32 tensor element counts, while `setup_logger` wires both console
    and file logging with optional colors.
@@ -68,10 +69,11 @@ CLI args ──▶ GlobalGPUController ──▶ [backend controller rank=0]
    unavailable for that cycle.
 5. If utilization exceeds `busy_threshold`, or if utilization is unavailable
    while `busy_threshold` is non-negative, the worker just sleeps for one more
-   `interval` before allocating or running ops. Otherwise it allocates the keep
-   tensor when needed and runs a batch. Public intervals must be finite positive
-   seconds within the Python runtime wait limit, and public VRAM
-   byte-equivalent inputs are capped at 1 PiB before conversion to tensor
+   `interval` before allocating or running ops. Unavailable includes malformed,
+   boolean, non-finite, or out-of-range vendor utilization readings. Otherwise
+   it allocates the keep tensor when needed and runs a batch. Public intervals
+   must be finite positive seconds within the Python runtime wait limit. Public
+   VRAM byte-equivalent inputs are capped at 1 PiB before conversion to tensor
    elements. Public defaults use `busy_threshold=25`. Valid thresholds are `-1`
    or `0..100`; `busy_threshold=-1` is the explicit unconditional mode.
 6. When you call `release()` (or exit the context), every worker sets a stop

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -96,6 +96,8 @@ including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 Malformed JSON-RPC service envelopes and malformed method-specific result
 records are reported as JSON error objects instead of empty success results.
+Utilization values are either `null` or finite percentages from `0` to `100`;
+out-of-range vendor readings are displayed as unavailable telemetry.
 Response IDs must echo the request ID with a valid matching JSON-RPC ID type.
 Service-returned job IDs in `status` and `stop` results are validated with the
 same URL-path-safe rules as user-supplied `--job-id` values.

--- a/docs/plans/utilization-range-normalization.md
+++ b/docs/plans/utilization-range-normalization.md
@@ -1,0 +1,26 @@
+# Utilization Range Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Treat malformed or out-of-range GPU utilization as unavailable telemetry so non-negative backoff remains eco-safe.
+
+**Architecture:** Keep one shared predicate in `session_config.py`. Normalize raw vendor readings at CUDA NVML, ROCm SMI, and GPU-listing ingress; reject malformed public `list_gpus` payloads at the CLI and MCP/REST service boundary.
+
+**Tech Stack:** Python, pytest, Typer CLI, JSON-RPC/MCP service.
+
+---
+
+## Tasks
+
+- [x] Add RED tests for CUDA/ROCm controller decisions with `-1`, `101`, and boolean utilization.
+- [x] Add RED tests for NVML/ROCm telemetry helpers normalizing out-of-range vendor readings to `None`.
+- [x] Add RED tests for CLI, JSON-RPC, and REST GPU-list payload validation rejecting out-of-range utilization fields.
+- [x] Add shared utilization normalization in `src/keep_gpu/utilities/session_config.py`.
+- [x] Route controller backoff, NVML monitor, ROCm monitor, and GPU listing through the shared helper.
+- [x] Update `AGENTS.md` and user docs with the finite `0..100` or `null` utilization contract.
+- [ ] Run targeted suites, full tests, docs build, pre-commit, local subagent review, PR checks, and squash merge.
+
+## Verification
+
+- Red: focused utilization shard failed with 16 expected behavior failures because `-1`/`101`/boolean utilization still flowed as real telemetry.
+- Green: the same focused shard passed with `39 passed`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -116,8 +116,10 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
 reported as `{"error": "..."}`. Malformed JSON-RPC service envelopes are
 reported as JSON error objects instead of empty success results; malformed GPU
-records are reported the same way. Invalid endpoint values, including
-non-integer or out-of-range ports, are reported as JSON errors before RPC.
+records are reported the same way. `utilization` is either `null` or a finite
+number from `0` to `100`; out-of-range telemetry is unavailable, not idle.
+Invalid endpoint values, including non-integer or out-of-range ports, are
+reported as JSON errors before RPC.
 
 ### `keep-gpu service-stop`
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import math
 import os
 import shlex
 import signal
@@ -28,6 +27,7 @@ from keep_gpu.utilities.humanized_input import parse_vram_to_elements
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
+    is_utilization_percent_or_none,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
@@ -797,16 +797,14 @@ def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
             _require_nullable_int_field(gpu, "memory_used", "list_gpus")
             if "utilization" not in gpu:
                 raise _malformed_method_result(
-                    "list_gpus", "utilization must be a number or null"
+                    "list_gpus",
+                    "utilization must be a finite number between 0 and 100 or null",
                 )
             utilization = gpu["utilization"]
-            if utilization is not None and (
-                isinstance(utilization, bool)
-                or not isinstance(utilization, (int, float))
-                or not math.isfinite(utilization)
-            ):
+            if not is_utilization_percent_or_none(utilization):
                 raise _malformed_method_result(
-                    "list_gpus", "utilization must be a number or null"
+                    "list_gpus",
+                    "utilization must be a finite number between 0 and 100 or null",
                 )
         except ServiceResponseError as exc:
             detail = str(exc).split(": ", 1)[-1]

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import argparse
 import atexit
 import json
-import math
 import mimetypes
 import sys
 import threading
@@ -60,6 +59,7 @@ from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableErro
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
     PUBLIC_INTERVAL_MAX_SECONDS,
+    is_utilization_percent_or_none,
     validate_busy_threshold,
     validate_gpu_ids,
     validate_interval,
@@ -192,16 +192,6 @@ def _plain_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _finite_number_or_none(value: Any) -> bool:
-    if value is None:
-        return True
-    if isinstance(value, bool):
-        return False
-    if isinstance(value, int):
-        return True
-    return isinstance(value, float) and math.isfinite(value)
-
-
 def _int_or_none(value: Any) -> bool:
     return value is None or _plain_int(value)
 
@@ -245,9 +235,9 @@ def _validate_list_gpus_records(infos: Any) -> None:
                 )
         if "utilization" not in record:
             _raise_malformed_gpu_record(index, "missing 'utilization'")
-        if not _finite_number_or_none(record["utilization"]):
+        if not is_utilization_percent_or_none(record["utilization"]):
             _raise_malformed_gpu_record(
-                index, "'utilization' must be a finite number or null"
+                index, "'utilization' must be a finite number between 0 and 100 or null"
             )
 
 

--- a/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/base_gpu_controller.py
@@ -1,7 +1,10 @@
 from typing import Optional, Union
 
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
-from keep_gpu.utilities.session_config import validate_interval
+from keep_gpu.utilities.session_config import (
+    normalize_utilization_percent,
+    validate_interval,
+)
 
 
 class BaseGPUController:
@@ -63,6 +66,7 @@ class BaseGPUController:
         """
         if busy_threshold < 0:
             return True
-        if gpu_utilization is None:
+        utilization = normalize_utilization_percent(gpu_utilization)
+        if utilization is None:
             return False
-        return gpu_utilization <= busy_threshold
+        return utilization <= busy_threshold

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -12,6 +12,7 @@ from keep_gpu.utilities.platform_manager import visible_torch_device_count
 from keep_gpu.utilities.rocm_visibility import resolve_rocm_visible_rank_to_smi_index
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
+    normalize_utilization_percent,
     validate_busy_threshold,
     validate_positive_integer,
     validate_rank_type,
@@ -202,7 +203,8 @@ class RocmGPUController(BaseGPUController):
                 if smi_index is None:
                     return None
                 util = self._rocm_smi.rsmi_dev_busy_percent_get(smi_index)
-                return int(util)
+                utilization = normalize_utilization_percent(util)
+                return int(utilization) if utilization is not None else None
             except Exception as exc:  # noqa: BLE001  # pragma: no cover - env-specific
                 logger.debug("ROCm utilization query failed: %s", exc)
                 if attempt == 0:

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -13,6 +13,7 @@ from keep_gpu.utilities.rocm_visibility import (
     resolve_rocm_visible_rank_to_smi_index,
     rocm_monitor_device_count,
 )
+from keep_gpu.utilities.session_config import normalize_utilization_percent
 
 logger = setup_logger(__name__)
 
@@ -109,6 +110,7 @@ def _nvml_info_for_handle(
 ) -> Dict[str, Any]:
     mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
     util = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
+    utilization = normalize_utilization_percent(util)
     name = _decode_nvml_text(pynvml.nvmlDeviceGetName(handle))
     info: Dict[str, Any] = {
         "id": visible_id,
@@ -117,7 +119,7 @@ def _nvml_info_for_handle(
         "name": name,
         "memory_total": int(mem.total),
         "memory_used": int(mem.used),
-        "utilization": int(util),
+        "utilization": int(utilization) if utilization is not None else None,
     }
     if physical_id is not None:
         info["physical_id"] = physical_id
@@ -259,7 +261,9 @@ def _query_rocm() -> List[Dict[str, Any]]:
             if physical_id is not None:
                 # ROCm SMI utilization probes are best effort.
                 try:
-                    util = int(rocm_smi.rsmi_dev_busy_percent_get(physical_id))
+                    util = normalize_utilization_percent(
+                        rocm_smi.rsmi_dev_busy_percent_get(physical_id)
+                    )
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("ROCm util query failed for %s: %s", physical_id, exc)
 
@@ -281,7 +285,7 @@ def _query_rocm() -> List[Dict[str, Any]]:
                 "name": name,
                 "memory_total": int(total) if total is not None else None,
                 "memory_used": int(used) if used is not None else None,
-                "utilization": util,
+                "utilization": int(util) if util is not None else None,
             }
             if physical_id is not None:
                 info["physical_id"] = physical_id

--- a/src/keep_gpu/utilities/gpu_monitor.py
+++ b/src/keep_gpu/utilities/gpu_monitor.py
@@ -12,6 +12,7 @@ from keep_gpu.utilities.cuda_visibility import (
     is_cuda_visible_index_token,
 )
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.session_config import normalize_utilization_percent
 
 logger = setup_logger(__name__)
 
@@ -74,7 +75,8 @@ class NVMLMonitor:
                 if handle is None:
                     return None
                 rates = self._nvml.nvmlDeviceGetUtilizationRates(handle)
-                return int(rates.gpu)
+                utilization = normalize_utilization_percent(rates.gpu)
+                return int(utilization) if utilization is not None else None
             except self._nvml.NVMLError as exc:
                 logger.debug("NVML query failed for GPU %s: %s", index, exc)
                 if attempt == 0 and self._is_uninitialized_error(exc):

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -20,6 +20,22 @@ def _is_plain_number(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def normalize_utilization_percent(value: Any) -> Optional[Union[int, float]]:
+    """Return a valid utilization percentage, or None when unavailable/invalid."""
+    if not _is_plain_number(value):
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if not 0 <= value <= 100:
+        return None
+    return value
+
+
+def is_utilization_percent_or_none(value: Any) -> bool:
+    """Return whether a public utilization field is null or 0..100 finite numeric."""
+    return value is None or normalize_utilization_percent(value) is not None
+
+
 def validate_gpu_ids(gpu_ids: Any) -> Optional[List[int]]:
     """Validate public GPU id input and return a normalized list."""
     if gpu_ids is None:

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -56,6 +56,13 @@ def test_non_negative_busy_threshold_backs_off_above_limit_without_gpu():
     assert CudaGPUController._should_run_batch(None, 10) is False
 
 
+@pytest.mark.parametrize("utilization", [-1, 101, False])
+def test_non_negative_busy_threshold_treats_invalid_utilization_as_unknown(
+    utilization,
+):
+    assert CudaGPUController._should_run_batch(utilization, 10) is False
+
+
 def test_cuda_monitor_preserves_unknown_utilization(monkeypatch):
     monkeypatch.setattr(
         "keep_gpu.single_gpu_controller.cuda_gpu_controller.get_gpu_utilization",

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -1369,6 +1369,34 @@ def test_http_get_api_gpus_runtime_error_returns_json_500(monkeypatch):
             ],
             "duplicate",
         ),
+        (
+            [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "CUDA",
+                    "name": "GPU 0",
+                    "memory_total": None,
+                    "memory_used": None,
+                    "utilization": -1,
+                }
+            ],
+            "between 0 and 100",
+        ),
+        (
+            [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "CUDA",
+                    "name": "GPU 0",
+                    "memory_total": None,
+                    "memory_used": None,
+                    "utilization": 101,
+                }
+            ],
+            "between 0 and 100",
+        ),
     ],
 )
 def test_http_get_api_gpus_malformed_record_returns_json_500(

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -973,6 +973,30 @@ def test_list_gpus_rejects_invalid_visible_ordinals(
             },
             "finite number",
         ),
+        (
+            {
+                "id": 0,
+                "visible_id": 0,
+                "platform": "CUDA",
+                "name": "GPU 0",
+                "memory_total": None,
+                "memory_used": None,
+                "utilization": -1,
+            },
+            "between 0 and 100",
+        ),
+        (
+            {
+                "id": 0,
+                "visible_id": 0,
+                "platform": "CUDA",
+                "name": "GPU 0",
+                "memory_total": None,
+                "memory_used": None,
+                "utilization": 101,
+            },
+            "between 0 and 100",
+        ),
     ],
 )
 def test_jsonrpc_list_gpus_rejects_malformed_gpu_record(

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -164,6 +164,11 @@ def test_rocm_unknown_utilization_backs_off_when_threshold_enabled():
     assert RocmGPUController._should_run_batch(None, 10) is False
 
 
+@pytest.mark.parametrize("utilization", [-1, 101, False])
+def test_rocm_invalid_utilization_backs_off_when_threshold_enabled(utilization):
+    assert RocmGPUController._should_run_batch(utilization, 10) is False
+
+
 def test_rocm_unknown_utilization_runs_when_backoff_disabled():
     assert RocmGPUController._should_run_batch(None, -1) is True
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1309,6 +1309,32 @@ def test_list_gpus_rejects_malformed_payloads(monkeypatch, payload):
                     "name": "GPU 0",
                     "memory_total": 1024,
                     "memory_used": 512,
+                    "utilization": -1,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
+                    "utilization": 101,
+                }
+            ]
+        },
+        {
+            "gpus": [
+                {
+                    "id": 0,
+                    "visible_id": 0,
+                    "platform": "cuda",
+                    "name": "GPU 0",
+                    "memory_total": 1024,
+                    "memory_used": 512,
                     "utilization": float("nan"),
                 }
             ]

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -289,6 +289,24 @@ def test_get_gpu_info_nvml(monkeypatch):
     assert dummy_nvml.shutdown_calls == 1
 
 
+@pytest.mark.parametrize("gpu_util", [-1, 101])
+def test_get_gpu_info_nvml_normalizes_out_of_range_utilization(monkeypatch, gpu_util):
+    dummy_nvml = MultiGPUDummyNVML(count=1)
+
+    def get_utilization_rates(_handle):
+        return DummyNVMLUtil(gpu=gpu_util)
+
+    dummy_nvml.nvmlDeviceGetUtilizationRates = get_utilization_rates
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    _install_cuda_gpu_info_mocks(monkeypatch, count=1)
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["utilization"] is None
+    assert dummy_nvml.shutdown_calls == 1
+
+
 def test_get_gpu_info_nvml_maps_cuda_visible_devices_to_visible_ordinals(
     monkeypatch,
 ):
@@ -506,6 +524,25 @@ def test_get_gpu_info_rocm_maps_visible_ids_to_physical_smi_indexes(monkeypatch)
     assert [info["name"] for info in infos] == ["ROCm 0", "ROCm 1"]
     assert [info["utilization"] for info in infos] == [82, 84]
     assert dummy_rocm.queried_indexes == [2, 4]
+    assert dummy_rocm.shutdown_calls == 1
+
+
+@pytest.mark.parametrize("gpu_util", [-1, 101])
+def test_get_gpu_info_rocm_normalizes_out_of_range_utilization(monkeypatch, gpu_util):
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        count=1,
+        util_by_index={0: gpu_util},
+    )
+
+    infos = gpu_info.get_gpu_info()
+
+    assert len(infos) == 1
+    assert infos[0]["utilization"] is None
+    assert dummy_rocm.queried_indexes == [0]
     assert dummy_rocm.shutdown_calls == 1
 
 

--- a/tests/utilities/test_gpu_monitor.py
+++ b/tests/utilities/test_gpu_monitor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 from keep_gpu.utilities.gpu_monitor import NVMLMonitor
 
 OVERSIZED_NUMERIC_TOKEN = "9" * 100
@@ -120,6 +122,16 @@ def test_monitor_reads_gpu_utilization(monkeypatch):
     assert monitor.get_gpu_utilization(2) == 73
     assert dummy.init_calls == 1
     assert dummy.queried_indexes == [1, 2]
+
+
+@pytest.mark.parametrize("gpu_util", [-1, 101])
+def test_monitor_treats_out_of_range_gpu_utilization_as_unknown(monkeypatch, gpu_util):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dummy = DummyNVML(gpu_util=gpu_util)
+    monitor = NVMLMonitor(dummy)
+
+    assert monitor.get_gpu_utilization(0) is None
+    assert dummy.queried_indexes == [0]
 
 
 def test_monitor_reinitializes_after_external_nvml_shutdown(monkeypatch):


### PR DESCRIPTION
## Summary
- normalize malformed/out-of-range GPU utilization readings to unavailable telemetry before controller decisions and GPU listings
- reject public `list_gpus` payloads whose `utilization` is not `null` or finite `0..100`
- document the tightened telemetry contract in AGENTS and user docs without expanding the README

## Local review
- local subagent review: no critical, important, or minor findings; ready to merge

## Verification
- RED focused shard initially failed with 16 expected behavior failures
- `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py::test_non_negative_busy_threshold_treats_invalid_utilization_as_unknown tests/rocm_controller/test_rocm_backoff.py::test_rocm_invalid_utilization_backs_off_when_threshold_enabled tests/utilities/test_gpu_monitor.py::test_monitor_treats_out_of_range_gpu_utilization_as_unknown tests/utilities/test_gpu_info.py::test_get_gpu_info_nvml_normalizes_out_of_range_utilization tests/utilities/test_gpu_info.py::test_get_gpu_info_rocm_normalizes_out_of_range_utilization tests/test_cli_service_commands.py::test_list_gpus_rejects_malformed_gpu_records tests/mcp/test_server.py::test_jsonrpc_list_gpus_rejects_malformed_gpu_record tests/mcp/test_http_api.py::test_http_get_api_gpus_malformed_record_returns_json_500 -q` => 39 passed
- `PYTHONPATH=$PWD/src pytest tests/cuda_controller/test_throttle.py tests/rocm_controller/test_rocm_backoff.py tests/utilities/test_gpu_monitor.py tests/utilities/test_gpu_info.py tests/test_cli_service_commands.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q` => 528 passed, 2 skipped
- `PYTHONPATH=$PWD/src pytest -q` => 803 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` => passed
- `pre-commit run --all-files --show-diff-on-failure` => passed
- `git diff --check` => passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU utilization readings are now normalized more consistently across the app, with invalid or out-of-range values shown as unavailable.
  * GPU listing and telemetry outputs now use stricter value handling for utilization and memory fields.

* **Bug Fixes**
  * Fixed backoff and batch-run decisions when utilization data is malformed, non-finite, or outside the valid range.
  * Improved error handling for malformed GPU records so invalid telemetry is rejected earlier and reported more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->