### PR TITLE
[http] fix: reject encoded api routes as json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,12 @@ This file defines how coding agents should work in this repository.
   JSON `405 Method Not Allowed` responses with `Allow`, and exact `/api` plus
   unknown `/api/*` routes return structured JSON `404 Unknown endpoint`
   responses.
+- Encoded or otherwise noncanonical route spellings whose raw or decoded target
+  is API-shaped (`/api`, `/api/...`, `/api;...`, `/api?...`, or `/api#...`)
+  must return structured JSON `404 Unknown endpoint` responses instead of
+  serving the dashboard/static fallback or `BaseHTTPRequestHandler` HTML errors.
+  Canonical API paths may still validate encoded `job_id` path components
+  normally.
 - Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)
   must call the shared unsupported-method helper before local unknown-endpoint
   404 branches, so known paths never regress to 404 or body-parse errors solely

--- a/docs/plans/api-encoded-path-json-errors.md
+++ b/docs/plans/api-encoded-path-json-errors.md
@@ -1,0 +1,30 @@
+# API Encoded Path JSON Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep encoded API-shaped HTTP routes inside the structured JSON API error boundary.
+
+**Architecture:** Reuse the existing noncanonical-route pattern from `/rpc`. Treat raw paths that are not canonical API routes but whose raw or decoded target is API-shaped (`/api`, `/api/...`, `/api;...`, `/api?...`, or `/api#...`) as noncanonical API routes, returning REST-shaped JSON `404 Unknown endpoint` before dashboard/static fallback or `BaseHTTPRequestHandler` HTML errors.
+
+**Tech Stack:** Python, `http.server`, pytest, MkDocs.
+
+---
+
+## Tasks
+
+- [x] Add RED HTTP tests proving encoded API route spellings such as `GET /api%2Fsessions`, `GET /api%3Bdebug`, `GET /api%3Fsessions`, and `OPTIONS /api%3Bdebug` return HTML or wrong statuses on current `main`.
+- [x] Add decoded noncanonical API-route detection to `_JSONRPCHandler`.
+- [x] Route GET, POST, DELETE, and unsupported-method handling through the new guard while preserving canonical encoded `job_id` validation.
+- [x] Update `AGENTS.md`, HTTP reference docs, and this plan with the routing contract.
+- [x] Run targeted suite, full verification, docs build, diff check, and pre-commit before PR.
+- [x] Run local subagent review before PR.
+
+## Verification
+
+- Baseline: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with `95 passed`.
+- Red: expanded encoded API route shard failed with three `200` dashboard responses and two `501` stdlib HTML unsupported-method responses.
+- Green: expanded encoded API route shard passed with `17 passed`; nearby routing compatibility shard passed with `12 passed`.
+- HTTP API suite: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with `113 passed`.
+- Full suite: `PYTHONPATH=$PWD/src pytest -q` passed with `821 passed, 11 skipped`.
+- Docs/build: `PYTHONPATH=$PWD/src mkdocs build --strict` passed; Material for MkDocs emitted its upstream MkDocs 2.0 warning.
+- Hygiene: `git diff --check` passed; `pre-commit run --all-files --show-diff-on-failure` passed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,7 +141,10 @@ digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
 Supported REST route/method errors are JSON objects: validation errors return
 `400`, unknown API routes return `404`, expected startup-unavailable session
 creation returns `503`, and unexpected service/runtime failures return `500`
-instead of dropping the connection.
+instead of dropping the connection. Encoded noncanonical spellings such as
+`/api%2Fsessions`, `/api%3Bdebug`, or `/api%3Fsessions` are treated as
+unknown API routes and return JSON `404` responses rather than the dashboard
+HTML shell.
 The dashboard consumes those JSON objects and displays `error.message` when it is
 present, falling back to the plain response body or HTTP status only when needed.
 Direct JSON-RPC service calls report the same expected hardware/platform

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -998,6 +998,16 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
     def _is_api_path(path: str) -> bool:
         return path == "/api" or path.startswith("/api/")
 
+    @classmethod
+    def _is_noncanonical_api_route(cls, parsed) -> bool:
+        if cls._is_api_path(parsed.path):
+            return False
+        route_paths = (parsed.path, unquote(parsed.path))
+        return any(
+            path.startswith(("/api/", "/api;", "/api?", "/api#"))
+            for path in route_paths
+        ) or any(path == "/api" for path in route_paths)
+
     @staticmethod
     def _is_noncanonical_rpc_route(parsed) -> bool:
         route_paths = (parsed.path, unquote(parsed.path))
@@ -1019,6 +1029,16 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         )
         return True
 
+    def _reject_noncanonical_api_route(self, parsed, write_body: bool = True) -> bool:
+        if not self._is_noncanonical_api_route(parsed):
+            return False
+        self._json_response(
+            404,
+            {"error": {"message": "Unknown endpoint"}},
+            write_body=write_body,
+        )
+        return True
+
     def _send_api_rpc_unsupported_method_response(self) -> bool:
         if not hasattr(self, "path") or not hasattr(self, "command"):
             return False
@@ -1026,6 +1046,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         path = parsed.path
         write_body = self.command != "HEAD"
         if self._reject_noncanonical_rpc_route(parsed, write_body=write_body):
+            return True
+        if self._reject_noncanonical_api_route(parsed, write_body=write_body):
             return True
         allowed_methods = self._allowed_methods_for_path(path)
         if allowed_methods is not None:
@@ -1153,6 +1175,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         try:
             if self._reject_noncanonical_rpc_route(parsed):
                 return
+            if self._reject_noncanonical_api_route(parsed):
+                return
             if path == "/rpc":
                 self._send_api_rpc_unsupported_method_response()
                 return
@@ -1199,6 +1223,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         path = parsed.path
         try:
             if self._reject_noncanonical_rpc_route(parsed):
+                return
+            if self._reject_noncanonical_api_route(parsed):
                 return
             if self._send_known_route_unsupported_method_response(path):
                 return
@@ -1331,6 +1357,8 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         path = parsed.path
         try:
             if self._reject_noncanonical_rpc_route(parsed):
+                return
+            if self._reject_noncanonical_api_route(parsed):
                 return
             if self._send_known_route_unsupported_method_response(path):
                 return

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -375,6 +375,119 @@ def test_http_unknown_api_routes_reject_unsupported_methods_with_json_404(method
     }
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api%2Fsessions",
+        "/api%2Funknown",
+        "/api%2Fsessions%2Fjob",
+        "/api%3Bdebug",
+        "/api%3Fsessions",
+        "/api%23sessions",
+    ],
+)
+def test_http_encoded_api_routes_return_json_404_without_static_fallback(path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("GET", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+def test_http_encoded_api_route_unsupported_method_returns_json_404():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(
+            "OPTIONS", f"{base}/api%2Fsessions"
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/api%3Bdebug", "/api%3Fsessions", "/api%23sessions"],
+)
+def test_http_encoded_api_separator_unsupported_method_returns_json_404(path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("OPTIONS", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/api%2Fsessions"),
+        ("POST", "/api%3Bdebug"),
+        ("POST", "/api%3Fsessions"),
+        ("POST", "/api%23sessions"),
+        ("DELETE", "/api%2Fsessions"),
+        ("DELETE", "/api%3Bdebug"),
+        ("DELETE", "/api%3Fsessions"),
+        ("DELETE", "/api%23sessions"),
+    ],
+)
+def test_http_encoded_api_route_implemented_methods_return_json_404(method, path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response(method, f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
+
+
 def test_http_multisegment_session_route_rejects_unsupported_method_with_json_404():
     server = make_server()
     httpd, thread, base = _start_http_server(server)


### PR DESCRIPTION
## Summary
- reject noncanonical encoded API-shaped HTTP routes before dashboard/static fallback or stdlib HTML errors
- keep canonical `/api/sessions/{encoded_job_id}` paths on the existing job-id validation path
- document the route-boundary contract in `AGENTS.md`, the HTTP reference, and a focused plan doc

## Verification
- RED route shard failed with three `200` dashboard responses and two `501` stdlib HTML responses before the fix
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_encoded_api_routes_return_json_404_without_static_fallback tests/mcp/test_http_api.py::test_http_encoded_api_separator_unsupported_method_returns_json_404 tests/mcp/test_http_api.py::test_http_encoded_api_route_implemented_methods_return_json_404 -q` (`17 passed`)
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` (`113 passed`)
- `PYTHONPATH=$PWD/src pytest -q` (`821 passed, 11 skipped`)
- `PYTHONPATH=$PWD/src mkdocs build --strict` (passed; upstream Material for MkDocs warning emitted)
- `git diff --check`
- `pre-commit run --all-files --show-diff-on-failure`

## Local review
- Local subagent review: ready to merge, no critical/important/minor findings.
