### PR TITLE
[docs] docs: use canonical README title

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ This file defines how coding agents should work in this repository.
   reference material. Prefer one quick-start command plus guide links over
   standalone Python, service, dashboard, or MCP sections. Use `docs/index.md`
   as the detailed routing hub; README may keep only a high-level platform
-  sentence. Keep long citation metadata in `docs/citation.md`, not in README.
+  sentence and should use the canonical `KeepGPU` product title. Keep long
+  citation metadata in `docs/citation.md`, not in README.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Keep GPU
+# KeepGPU
 
 [![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)
 [![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -99,6 +99,7 @@ def test_readme_stays_a_compact_front_door():
     normalized_readme = readme.lower()
     lines = [line for line in readme.splitlines() if line.strip()]
 
+    assert readme.startswith("# KeepGPU\n")
     assert len(lines) <= 38
     assert readme.count("[![") <= 3
     assert "## choose an interface" not in normalized_readme


### PR DESCRIPTION
## Summary
- change the README H1 to the canonical `KeepGPU` product title
- add a metadata guard so the README title does not drift while staying slim
- clarify the README policy in `AGENTS.md` without adding docs sprawl

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q` failed on `assert readme.startswith("# KeepGPU\\n")` before the README edit
- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q` (`1 passed`)
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` (`9 passed`)
- `PYTHONPATH=$PWD/src mkdocs build --strict` (passed; upstream Material for MkDocs warning emitted)
- `git diff --check`
- `pre-commit run --all-files --show-diff-on-failure`

## Local review
- Local subagent review: ready to merge, no findings.
