### PR TITLE
[docs] docs: clarify MPS unconditional keepalive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,10 @@ This file defines how coding agents should work in this repository.
   - MCP server: `keep-gpu-mcp-server` (`src/keep_gpu/mcp/server.py`)
 - If behavior changes in one interface, update related docs/tests for that interface and check if parity is required in the others.
 - Public overview docs should describe CUDA, ROCm, and Mac M/MPS support without
-  making KeepGPU sound CUDA-only or treating MCP as experimental.
+  making KeepGPU sound CUDA-only or treating MCP as experimental. Mac M/MPS docs
+  must also explain that utilization telemetry is unavailable, so users need
+  `busy_threshold=-1` only when they intentionally want unconditional MPS
+  keepalive work.
 - Keep the MCP server compatible with standard MCP lifecycle/tool methods
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.
@@ -369,7 +372,9 @@ This file defines how coding agents should work in this repository.
   non-PyPI `rocm-smi` distribution in package extras; treat `rocm_smi` as
   system-provided by the ROCm stack, and imports must fail gracefully on
   non-ROCm machines.
-- Apple Silicon/MPS telemetry is best-effort; return a guarded MACM record with nullable memory/utilization fields rather than hiding the device.
+- Apple Silicon/MPS memory telemetry is best-effort, and MPS utilization is
+  unavailable/null; return a guarded MACM record with nullable fields rather
+  than hiding the device.
 - CI runners generally do not have GPUs. GPU-dependent logic must have safe fallbacks and tests must avoid hard-failing in no-GPU environments.
 
 ### Testing Expectations in This Repository

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ keep-gpu --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
 ```
 
 The command blocks until you press `Ctrl+C`, then releases the reserved memory.
+MPS utilization telemetry is unavailable; use `--busy-threshold -1` only
+when you intentionally want unconditional keepalive compute.
 
 ## Learn More
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,11 @@ understand the minimum knobs you need to keep a GPU occupied.
    ```bash
    keep-gpu --interval 30 --vram 512MB
    ```
-   You should see Rich logs showing the GPUs being kept awake.
+   On CUDA or ROCm, you should see Rich logs showing the GPUs being kept awake.
+   Mac M series utilization telemetry is unavailable, so the default
+   non-negative `busy_threshold` backs off instead of allocating keep tensors or
+   running MPS compute. Use `--busy-threshold -1` only when you intentionally
+   want unconditional Mac M keepalive work.
 
 !!! tip "Lower-power keep-alive"
     KeepGPU uses intervalled elementwise ops (not big matmul floods) so you can
@@ -115,6 +119,8 @@ keep-gpu --interval 120 --gpu-ids 0 --vram 1GiB
 
 Leave the command running while you prepare data or review notebooks. When you are
 ready to hand the GPU back, hit `Ctrl+C`—controllers will release VRAM and exit.
+On Mac M series, add `--busy-threshold -1` only when you intentionally want
+unconditional MPS keepalive work despite unavailable utilization telemetry.
 
 ## Non-blocking workflow for agents
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -107,10 +107,12 @@ def test_readme_stays_a_compact_front_door():
     assert "cuda" in normalized_readme
     assert "rocm/hip" in normalized_readme
     assert "mps" in normalized_readme
+    assert "mps utilization telemetry is unavailable" in normalized_readme
     assert "small, polite gpu keeper" in normalized_readme
     assert "## quick start" in normalized_readme
     assert "pip install keep-gpu" in normalized_readme
     assert re.search(r"^keep-gpu\s+--gpu-ids\s+0\b", readme, re.MULTILINE)
+    assert "--busy-threshold -1" in normalized_readme
     assert "ctrl+c" in normalized_readme
     assert "## python" not in normalized_readme
     assert "## service, dashboard, and mcp" not in normalized_readme
@@ -152,6 +154,12 @@ def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
     assert "MCP server (experimental)" not in public_docs["contributing"]
     assert "RocmGPUController" in public_docs["index"]
     assert "MacMGPUController" in public_docs["index"]
+    assert re.search(
+        r"Mac M series.*utilization telemetry.*unavailable",
+        public_docs["getting_started"],
+        re.IGNORECASE | re.DOTALL,
+    )
+    assert "--busy-threshold -1" in public_docs["getting_started"]
 
 
 def test_sdist_manifest_does_not_package_test_suite():


### PR DESCRIPTION
## Summary
- clarify that MPS utilization telemetry is unavailable and the default non-negative busy threshold backs off
- keep README compact while adding the one sentence needed for the quick-start command
- add low-cost public docs guards so the Mac M/MPS unconditional-mode note does not drift

## Verification
- RED: Getting Started docs guard failed before the docs edit
- RED: README guard failed before the README edit
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` (`9 passed`)
- `PYTHONPATH=$PWD/src mkdocs build --strict` (passed; upstream Material for MkDocs warning emitted)
- `git diff --check`
- `pre-commit run --all-files --show-diff-on-failure`

## Local review
- Local subagent review: ready to merge; minor test-brittleness note addressed with a semantic Getting Started regex guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Mac M-series guidance in the README and getting-started docs.
  * Noted that MPS utilization telemetry is unavailable and explained when to use `--busy-threshold -1`.
  * Updated wording around Apple Silicon/MPS memory reporting to reflect best-effort behavior.

* **Tests**
  * Added regression checks to ensure the updated documentation remains accurate and includes the new Mac M-series guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->