### PR TITLE
[docs, metadata] docs: align public surface wording

### DIFF
--- a/docs/citation.md
+++ b/docs/citation.md
@@ -5,7 +5,7 @@ If KeepGPU helps your research or operations, cite the archived software record:
 ```bibtex
 @software{Wangmerlyn_KeepGPU_2025,
   author       = {Wang, Siyuan and Shi, Yaorui and Liu, Yida and Yin, Yuqi},
-  title        = {KeepGPU: a simple CLI app that keeps your GPUs running},
+  title        = {KeepGPU: a polite GPU keeper with CLI, service, and MCP interfaces},
   year         = {2025},
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.17129114},

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,6 +1,6 @@
 # MCP and Service API
 
-KeepGPU ships a local service that powers three interfaces:
+KeepGPU ships a local service that powers four local surfaces:
 
 - MCP over stdio (`keep-gpu-mcp-server`)
 - JSON-RPC over HTTP (`/rpc`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "keep_gpu"
 dynamic = ["version"]  # Let setuptools read the version dynamically
-description = "Keep GPU is a simple CLI app that keeps your GPUs running"
+description = "KeepGPU is a polite GPU keeper with CLI, service, and MCP interfaces"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -87,6 +87,15 @@ def test_license_metadata_uses_spdx_string_supported_by_python_floor():
     assert "setuptools>=77.0.1" in _build_system_requires()
 
 
+def test_project_description_no_longer_describes_cli_only_app():
+    description = _project_config()["description"].lower()
+
+    assert "simple cli app" not in description
+    assert "gpu keeper" in description
+    assert "service" in description
+    assert "mcp" in description
+
+
 def test_readme_markdown_code_fences_are_balanced():
     readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
     fences = [line for line in readme.splitlines() if line.strip().startswith("```")]
@@ -132,6 +141,8 @@ def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
         "getting_started": (PROJECT_ROOT / "docs/getting-started.md").read_text(
             encoding="utf-8"
         ),
+        "citation": (PROJECT_ROOT / "docs/citation.md").read_text(encoding="utf-8"),
+        "mcp": (PROJECT_ROOT / "docs/guides/mcp.md").read_text(encoding="utf-8"),
         "architecture": (PROJECT_ROOT / "docs/concepts/architecture.md").read_text(
             encoding="utf-8"
         ),
@@ -149,6 +160,10 @@ def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
         "A non-zero integer indicates CUDA is available."
         not in public_docs["getting_started"]
     )
+    assert "powers three interfaces" not in public_docs["mcp"]
+    assert "powers four local surfaces" in public_docs["mcp"]
+    assert "simple CLI app" not in public_docs["citation"]
+    assert "polite GPU keeper" in public_docs["citation"]
     assert "burst of CUDA ops" not in public_docs["architecture"]
     assert "[CudaGPUController rank=0]" not in public_docs["architecture"]
     assert "MCP server (experimental)" not in public_docs["contributing"]


### PR DESCRIPTION
## Summary
- update package metadata so KeepGPU is no longer described as only a simple CLI app
- fix MCP/service guide surface-count wording to match the listed MCP, JSON-RPC, REST, and dashboard surfaces
- update citation metadata wording and add low-cost guards against stale CLI-only public descriptions

## Verification
- RED: focused metadata/docs guards failed on stale `simple CLI app` and `powers three interfaces` wording
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` (`10 passed`)
- `PYTHONPATH=$PWD/src mkdocs build --strict` (passed; upstream Material for MkDocs warning emitted)
- `git diff --check`
- `pre-commit run --all-files --show-diff-on-failure`

## Local review
- First local review found stale citation wording and a broad test name; both were fixed.
- Re-review: ready to merge, no findings.
