### PR TITLE
[docs] docs: keep README minimal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,9 @@ This file defines how coding agents should work in this repository.
   reference material. Prefer one quick-start command plus guide links over
   standalone Python, service, dashboard, or MCP sections. Use `docs/index.md`
   as the detailed routing hub; README may keep only a high-level platform
-  sentence and should use the canonical `KeepGPU` product title. Keep long
-  citation metadata in `docs/citation.md`, not in README.
+  sentence and should use the canonical `KeepGPU` product title. Keep platform
+  caveats, sentinel-value explanations, and long citation metadata in `docs/`,
+  not in README. Avoid badge clutter; PyPI and docs status are enough.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -2,33 +2,23 @@
 
 [![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)
 [![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)
-[![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)
 
-KeepGPU is a small, polite GPU keeper for shared machines: reserve the VRAM you
-ask for, back off when the device is busy, and release cleanly when you are
+KeepGPU is a small, polite GPU keeper for shared machines. It reserves the VRAM
+you ask for, backs off when devices are busy, and releases cleanly when you are
 done.
-
-It works with CUDA, ROCm/HIP, and Apple Silicon MPS when PyTorch can see the
-target device.
 
 ## Quick Start
 
 ```console
 pip install keep-gpu
-keep-gpu --gpu-ids 0 --vram 1GiB --busy-threshold 25 --interval 60
+keep-gpu --gpu-ids 0 --vram 1GiB --interval 60
 ```
 
-The command blocks until you press `Ctrl+C`, then releases the reserved memory.
-MPS utilization telemetry is unavailable; use `--busy-threshold -1` only
-when you intentionally want unconditional keepalive compute.
+Press `Ctrl+C` to release. CUDA, ROCm/HIP, and Apple Silicon MPS are supported
+when PyTorch can see the target device.
 
-## Learn More
+## Documentation
 
-- [Documentation](https://keepgpu.readthedocs.io/en/latest/) covers the CLI,
-  Python API, service dashboard, JSON-RPC, REST, and MCP server.
-- [Getting Started](https://keepgpu.readthedocs.io/en/latest/getting-started/)
-  has install options and the first hardware sanity check.
-- [Contributing](https://keepgpu.readthedocs.io/en/latest/contributing/) covers
-  local setup, tests, docs builds, and PR guidance.
-- [Citation](https://keepgpu.readthedocs.io/en/latest/citation/) has the BibTeX
-  entry.
+- [Documentation](https://keepgpu.readthedocs.io/en/latest/) is the full guide hub.
+- [Getting Started](https://keepgpu.readthedocs.io/en/latest/getting-started/) covers install options and the first hardware check.
+- [Citation](https://keepgpu.readthedocs.io/en/latest/citation/) has the BibTeX entry.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -98,9 +98,10 @@ expectations so you can get productive quickly and avoid surprises in CI.
   builds do not need `pip install .`.
 - Internal agent plans and skill reports under `docs/plans/` and `docs/skills/`
   stay in the repository but are excluded from the published MkDocs site.
-- Keep README as a concise front door. Put detailed interface examples and
-  contracts in the focused docs pages, use `docs/index.md` for detailed
-  navigation, and keep full citation metadata in `docs/citation.md`.
+- Keep README as a concise front door. Put detailed interface examples,
+  platform caveats, sentinel-value explanations, and contracts in the focused
+  docs pages. Use `docs/index.md` for detailed navigation, keep full citation
+  metadata in `docs/citation.md`, and avoid badge clutter beyond PyPI/docs.
 
 ## MCP server
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -109,26 +109,33 @@ def test_readme_stays_a_compact_front_door():
     lines = [line for line in readme.splitlines() if line.strip()]
 
     assert readme.startswith("# KeepGPU\n")
-    assert len(lines) <= 38
-    assert readme.count("[![") <= 3
+    assert len(lines) <= 20
+    assert readme.count("[![") <= 2
     assert "## choose an interface" not in normalized_readme
     assert "| need | start here |" not in normalized_readme
     assert "cuda" in normalized_readme
     assert "rocm/hip" in normalized_readme
     assert "mps" in normalized_readme
-    assert "mps utilization telemetry is unavailable" in normalized_readme
+    assert "mps utilization telemetry is unavailable" not in normalized_readme
     assert "small, polite gpu keeper" in normalized_readme
     assert "## quick start" in normalized_readme
+    assert "## documentation" in normalized_readme
     assert "pip install keep-gpu" in normalized_readme
     assert re.search(r"^keep-gpu\s+--gpu-ids\s+0\b", readme, re.MULTILINE)
-    assert "--busy-threshold -1" in normalized_readme
+    assert "--busy-threshold -1" not in normalized_readme
     assert "ctrl+c" in normalized_readme
     assert "## python" not in normalized_readme
     assert "## service, dashboard, and mcp" not in normalized_readme
     assert "### mcp and service api" not in normalized_readme
     assert "platform installs at a glance" not in normalized_readme
+    assert "service dashboard" not in normalized_readme
+    assert "mcp server" not in normalized_readme
+    assert "json-rpc" not in normalized_readme
+    assert "rest api" not in normalized_readme
+    assert "rest endpoint" not in normalized_readme
     assert "```bibtex" not in normalized_readme
     assert "skillcheck" not in normalized_readme
+    assert "zenodo.org/badge" not in normalized_readme
     assert not re.search(r"\]\(\.?\.?/?docs/", readme)
     assert "https://keepgpu.readthedocs.io/en/latest/" in readme
     assert "https://keepgpu.readthedocs.io/en/latest/getting-started/" in readme


### PR DESCRIPTION
## Summary\n- simplify README into a 17-line front door with install/run and docs links\n- move policy toward keeping platform caveats, sentinel values, and citation metadata in docs\n- tighten metadata tests so README stays compact without brittle protocol substring checks\n\n## Verification\n- PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q\n- PYTHONPATH=$PWD/src mkdocs build --strict\n- git diff --check\n- pre-commit run --all-files --show-diff-on-failure\n\n## Local review\n- Read-only docs coverage explorer confirmed removed README details are covered in docs.\n- Local code reviewer found one brittle test guard; fixed and re-reviewed clean.\n