### PR TITLE
[cli] fix: reject coerced daemon pid records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,7 @@ This file defines how coding agents should work in this repository.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.
-- Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process.
+- Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process. PID records must store exact plain JSON integer `pid` and `port` values; lossy numeric coercions such as floats or booleans are not ownership-verified.
 - Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -78,7 +78,9 @@ keep-gpu service-stop
 
 If sessions are still active, timed out, or failed to stop cleanly, resolve them
 first or use `--force`. Force mode skips the session RPC checks, but it still
-stops only an ownership-verified daemon that KeepGPU auto-started.
+stops only an ownership-verified daemon that KeepGPU auto-started. Malformed
+PID records, including float or boolean PID/port values, are ignored instead of
+being coerced into a process signal target.
 
 ### List telemetry
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -126,7 +126,9 @@ reported as JSON errors before RPC.
 Stops the ownership-verified local daemon process created by auto-start logic.
 Invalid endpoint values are rejected locally before service checks or
 ownership-verified stop operations. Non-force shutdown requires session checks
-to finish cleanly with no timed-out or failed stops.
+to finish cleanly with no timed-out or failed stops. Malformed PID records with
+float or boolean PID/port values are ignored rather than coerced before
+signaling.
 
 | Option | Description |
 | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -179,14 +179,19 @@ def _read_service_pid_record(host: str, port: int) -> Optional[Dict[str, Any]]:
         payload = json.loads(raw)
     except (OSError, json.JSONDecodeError, ValueError):
         return None
-    if isinstance(payload, int):
+    if isinstance(payload, int) and not isinstance(payload, bool) and payload > 0:
         return {"pid": payload, "legacy": True}
     if not isinstance(payload, dict):
         return None
-    try:
-        payload["pid"] = int(payload["pid"])
-        payload["port"] = int(payload["port"])
-    except (KeyError, TypeError, ValueError):
+    pid = payload.get("pid")
+    port_value = payload.get("port")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None
+    if (
+        not isinstance(port_value, int)
+        or isinstance(port_value, bool)
+        or port_value <= 0
+    ):
         return None
     return payload
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2144,6 +2144,73 @@ def test_stop_service_process_requires_structured_ownership_record(
     assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("pid", 4321.9),
+        ("pid", True),
+        ("port", 8765.0),
+        ("port", True),
+    ],
+)
+def test_stop_service_process_rejects_coerced_ownership_record_numbers(
+    monkeypatch, tmp_path, field, invalid_value
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "argv": cli._service_command("127.0.0.1", 8765),
+        "uid": 1000,
+        "start_time": "12345",
+    }
+    payload[field] = invalid_value
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+
+    alive = {"value": True}
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: alive["value"])
+    kills = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        alive["value"] = False
+
+    monkeypatch.setattr(cli.os, "kill", fake_kill)
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0.5)
+
+    assert stopped is False
+    assert kills == []
+
+
+@pytest.mark.parametrize("invalid_port", [0, -1])
+def test_read_service_pid_record_rejects_non_positive_port(
+    monkeypatch, tmp_path, invalid_port
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": invalid_port,
+        "argv": cli._service_command("127.0.0.1", 8765),
+        "uid": 1000,
+        "start_time": "12345",
+    }
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    assert cli._read_service_pid_record("127.0.0.1", 8765) is None
+
+
 def test_stop_service_process_rejects_record_missing_identity(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
     payload = {


### PR DESCRIPTION
## Summary
- reject malformed daemon ownership records that use float or boolean PID/port values instead of coercing them with `int(...)`
- add no-signal regression coverage for pid float, pid bool, port float, and port bool records
- document the exact PID-record ownership contract in AGENTS and CLI service-stop docs

## Verification
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -k 'coerced_ownership_record_numbers or requires_structured_ownership_record'` -> 5 passed
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py` -> 205 passed
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed
- `mkdocs build` -> passed (upstream MkDocs Material warning only)

## Local Review
- Volta: no Critical/Important issues; one Minor coverage suggestion
- Planck: confirmed the coverage suggestion is resolved and ready for PR/merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon shutdown safety by ignoring malformed ownership records instead of treating them as valid stop targets.
  * Non-force stops now wait for clean session ավարտ? avoid timed-out or failed stops.
  * Force-stop only applies to verified auto-started daemons, reducing accidental shutdowns.

* **Documentation**
  * Clarified CLI guidance for daemon stop behavior and how invalid PID/port values are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->