### PR TITLE
[mcp] fix: classify extra session paths as unknown routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ This file defines how coding agents should work in this repository.
   `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
   JSON `405 Method Not Allowed` responses with `Allow`, and exact `/api` plus
   unknown `/api/*` routes return structured JSON `404 Unknown endpoint`
-  responses.
+  responses. `/api/sessions/{job_id}` accepts exactly one raw path component;
+  raw extra segments such as `/api/sessions/foo/bar` are unknown routes.
 - Encoded or otherwise noncanonical route spellings whose raw or decoded target
   is API-shaped (`/api`, `/api/...`, `/api;...`, `/api?...`, or `/api#...`)
   must return structured JSON `404 Unknown endpoint` responses instead of

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -9,7 +9,8 @@ KeepGPU ships a local service that powers four local surfaces:
 
 This is the same backend used by `keep-gpu start/status/stop/list-gpus`.
 Exact `/api` and unknown `/api/*` paths return structured JSON `404` errors
-instead of dashboard HTML.
+instead of dashboard HTML. `/api/sessions/{job_id}` uses one raw path component;
+extra raw path segments are unknown endpoints.
 Missing packaged asset URLs also return JSON `404` responses instead of the
 dashboard shell.
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -976,17 +976,22 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             self.wfile.write(data)
 
     @staticmethod
-    def _allowed_methods_for_path(path: str) -> Optional[Tuple[str, ...]]:
+    def _is_session_member_path(path: str) -> bool:
+        prefix = "/api/sessions/"
+        if not path.startswith(prefix):
+            return False
+        encoded_job_id = path[len(prefix) :]
+        return encoded_job_id != "" and "/" not in encoded_job_id
+
+    @classmethod
+    def _allowed_methods_for_path(cls, path: str) -> Optional[Tuple[str, ...]]:
         if path == "/health":
             return ("GET",)
         if path == "/api/gpus":
             return ("GET",)
         if path == "/api/sessions":
             return ("GET", "POST", "DELETE")
-        if path.startswith("/api/sessions/"):
-            encoded_job_id = path[len("/api/sessions/") :]
-            if encoded_job_id == "" or "/" in encoded_job_id:
-                return None
+        if cls._is_session_member_path(path):
             return ("GET", "DELETE")
         if path == "/":
             return ("GET", "POST")
@@ -1147,13 +1152,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
 
     def _job_id_from_session_path(self, path: str) -> str:
         prefix = "/api/sessions/"
-        if not path.startswith(prefix):
-            raise ValueError("Missing job_id")
         encoded_job_id = path[len(prefix) :]
-        if encoded_job_id == "" or encoded_job_id.endswith("/"):
-            raise ValueError("Missing job_id")
-        if "/" in encoded_job_id:
-            raise ValueError("Invalid job_id path")
         job_id = unquote(encoded_job_id)
         validated = validate_job_id(job_id)
         if validated is None:
@@ -1193,7 +1192,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     return
                 self._json_response(200, server_ref.status())
                 return
-            if path.startswith("/api/sessions/"):
+            if self._is_session_member_path(path):
                 if self._reject_session_route_components(parsed):
                     return
                 try:
@@ -1368,7 +1367,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     return
                 self._json_response(200, server_ref.stop_keep(job_id=None))
                 return
-            if path.startswith("/api/sessions/"):
+            if self._is_session_member_path(path):
                 if self._reject_session_route_components(parsed):
                     return
                 try:

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -511,6 +511,22 @@ def test_http_multisegment_session_route_rejects_unsupported_method_with_json_40
     }
 
 
+def test_http_get_rejects_extra_session_path_segment_with_json_404():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_json("GET", f"{base}/api/sessions/foo/bar")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+
+
 def test_http_head_api_sessions_rejects_with_json_405_headers_and_empty_body():
     server = make_server()
     httpd, thread, base = _start_http_server(server)
@@ -1352,8 +1368,8 @@ def test_http_session_trailing_slash_rejected():
         status_code, error_payload = _request_json(
             "DELETE", f"{base}/api/sessions/{job_id}/"
         )
-        assert status_code == 400
-        assert "Missing job_id" in error_payload["error"]["message"]
+        assert status_code == 404
+        assert error_payload == {"error": {"message": "Unknown endpoint"}}
 
         _, status_payload = _request_json("GET", f"{base}/api/sessions")
         assert status_payload["active_jobs"]
@@ -2047,8 +2063,8 @@ def test_http_delete_rejects_extra_session_path_segment_without_stopping_session
             "DELETE", f"{base}/api/sessions/prefix/{active_job_id}"
         )
 
-        assert status_code == 400
-        assert "job_id" in payload["error"]["message"]
+        assert status_code == 404
+        assert payload == {"error": {"message": "Unknown endpoint"}}
         assert server.status(active_job_id)["active"] is True
         assert controller.released is False
     finally:


### PR DESCRIPTION
## Summary
- classify `/api/sessions/{job_id}` as exactly one raw path component after `/api/sessions/`
- return structured JSON `404 Unknown endpoint` for raw extra session path segments and trailing slash member routes
- keep encoded invalid job IDs on the existing validation path, and preserve no-release behavior for DELETE extra-segment routes

## Verification
- RED before fix: route slice failed because GET/DELETE extra segments returned 400 instead of 404
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -k 'multisegment_session_route or extra_session_path_segment or encoded_job_id_path'` -> 3 passed
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py` -> 244 passed
- `mkdocs build` -> passed (upstream MkDocs Material warning only)
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed

## Local Review
- Plato: no Critical/Important/Minor issues; ready for PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to session API paths with extra path segments now return a consistent `404 Unknown endpoint` JSON response.
  * Session route matching is stricter, preventing malformed paths from being treated as valid job IDs.
  * Updated API behavior for `GET` and `DELETE` requests to align with the documented unknown-route handling.

* **Documentation**
  * Clarified HTTP API guidance for session routes and unknown-path responses in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->