### PR TITLE
[cli] fix: validate human command ports uniformly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,10 @@ This file defines how coding agents should work in this repository.
   `--port` through command-level validation so non-integer values return the
   shared structured `{"error": "port must be an integer between 1 and 65535"}`
   object instead of Typer/Click usage text.
+- Human-output service commands (`serve`, `start`, `service-stop`) must also
+  parse `--port` through command-level validation so non-integer values return
+  the shared `Error: port must be an integer between 1 and 65535` message before
+  imports, daemon auto-start, RPC, or daemon ownership operations.
 - CLI service daemon ownership checks must require known PID identity
   components. A PID record with `uid` or `start_time` missing or `null`, or a
   current process probe that cannot recover either value, is not ownership

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -980,19 +980,19 @@ def serve(
         DEFAULT_SERVICE_HOST,
         help="Host interface for KeepGPU local service.",
     ),
-    port: int = typer.Option(
-        DEFAULT_SERVICE_PORT,
+    port: str = typer.Option(
+        str(DEFAULT_SERVICE_PORT),
         help="Port for KeepGPU local service.",
     ),
 ):
     """Run KeepGPU local service (HTTP + JSON-RPC + dashboard)."""
-    from keep_gpu.mcp.server import KeepGPUServer, run_http
-
     try:
         host, port = _validate_cli_service_endpoint(host, port)
     except typer.BadParameter as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")
         raise typer.Exit(code=1) from exc
+
+    from keep_gpu.mcp.server import KeepGPUServer, run_http
 
     console.print(f"[bold cyan]Service URL:[/bold cyan] http://{host}:{port}/")
     console.print(
@@ -1029,8 +1029,8 @@ def start(
         "--host",
         help="KeepGPU service host.",
     ),
-    port: int = typer.Option(
-        DEFAULT_SERVICE_PORT,
+    port: str = typer.Option(
+        str(DEFAULT_SERVICE_PORT),
         "--port",
         help="KeepGPU service port.",
     ),
@@ -1193,7 +1193,7 @@ def list_gpus(
 @app.command("service-stop")
 def service_stop(
     host: str = typer.Option(DEFAULT_SERVICE_HOST, "--host", help="Service host."),
-    port: int = typer.Option(DEFAULT_SERVICE_PORT, "--port", help="Service port."),
+    port: str = typer.Option(str(DEFAULT_SERVICE_PORT), "--port", help="Service port."),
     force: bool = typer.Option(
         False,
         "--force",

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import re
 
@@ -396,6 +397,49 @@ def test_start_command_rejects_invalid_port_before_auto_start(monkeypatch):
     assert called == {"ensure": False, "rpc": False}
 
 
+def test_start_command_rejects_non_integer_port_before_auto_start(monkeypatch):
+    called = {"ensure": False, "rpc": False}
+
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: called.__setitem__("ensure", True),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: called.__setitem__("rpc", True),
+    )
+
+    result = runner.invoke(cli.app, ["start", "--port", "abc"])
+
+    assert result.exit_code == 1
+    assert "port must be an integer between 1 and 65535" in result.output
+    assert "Traceback" not in result.output
+    assert called == {"ensure": False, "rpc": False}
+
+
+@pytest.mark.parametrize("invalid_port", ["abc", "0"])
+def test_serve_rejects_invalid_port_before_server_import(monkeypatch, invalid_port):
+    original_import = builtins.__import__
+    imported = {"server": False}
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "keep_gpu.mcp.server":
+            imported["server"] = True
+            raise AssertionError("server should not be imported before validation")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    result = runner.invoke(cli.app, ["serve", "--port", invalid_port])
+
+    assert result.exit_code == 1
+    assert "port must be an integer between 1 and 65535" in result.output
+    assert "Traceback" not in result.output
+    assert imported["server"] is False
+
+
 def test_validate_cli_service_host_delegates_to_shared_validator():
     assert cli._validate_cli_service_host("localhost") == "localhost"
 
@@ -591,6 +635,28 @@ def test_service_stop_rejects_invalid_host_before_daemon_operations(monkeypatch)
     assert result.exit_code == 1
     assert "host must be a DNS hostname or IPv4 address" in result.output
     assert called == {"available": False, "stop": False}
+
+
+def test_service_stop_rejects_non_integer_port_before_daemon_operations(monkeypatch):
+    called = {"rpc": False, "stop": False}
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        return {}
+
+    def fake_stop(*args, **kwargs):
+        called["stop"] = True
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop)
+
+    result = runner.invoke(cli.app, ["service-stop", "--port", "abc", "--force"])
+
+    assert result.exit_code == 1
+    assert "port must be an integer between 1 and 65535" in result.output
+    assert "Traceback" not in result.output
+    assert called == {"rpc": False, "stop": False}
 
 
 def test_http_json_request_wraps_malformed_url_as_service_unreachable():


### PR DESCRIPTION
## Summary
- route `serve`, `start`, and `service-stop` `--port` parsing through shared endpoint validation instead of Typer integer parsing
- validate `serve` endpoint inputs before importing the HTTP server module
- add regression coverage for non-integer ports and pre-side-effect validation boundaries

## Verification
- RED before fix: 4 tests failed because non-integer ports exited via Typer usage and `serve --port 0` imported the server before validation
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -k 'non_integer_port_before_auto_start or serve_rejects_invalid_port_before_server_import or non_integer_port_before_daemon_operations or invalid_port_before_auto_start or service_json_commands_reject_non_integer_port'` -> 8 passed
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py` -> 211 passed
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `mkdocs build` -> passed (upstream MkDocs Material warning only)
- `git diff --check` -> passed

## Local Review
- Bacon: no Critical/Important/Minor issues; ready for PR
