### PR TITLE
[mcp] fix: keep status health probes off lifecycle lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,8 +272,10 @@ This file defines how coding agents should work in this repository.
   status as `state="runtime_failed"` with `last_error`; the session remains
   visible and stoppable. Busy or unavailable telemetry backoff is normal
   deferred allocation behavior, not a runtime failure.
-- Controller runtime-health hooks used by service status must stay non-blocking
-  and read-only because status refresh runs under the session lock.
+- Controller runtime-health hooks used by service status must stay read-only and
+  should remain lightweight. Service status must not hold the session lifecycle
+  lock while invoking those hooks, and late hook results may only update the
+  same still-active session they inspected.
 - CUDA, ROCm, and MPS controllers must retain fatal post-start worker failures
   by way of `allocation_status()` so `GlobalGPUController.runtime_error()` can
   move service status to `runtime_failed`; normal busy/unknown telemetry backoff

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -156,7 +156,10 @@ If an already-started worker later reports a terminal runtime or allocation
 failure, the retained session is refreshed to `state="runtime_failed"` with
 `last_error`. It remains visible and stoppable. This is distinct from normal
 busy-GPU or unavailable-telemetry backoff, where the controller defers
-allocation and the session stays active.
+allocation and the session stays active. Runtime-health probes are observational:
+status does not hold the session lifecycle lock while running them, and a late
+probe result is ignored if the inspected session has already stopped or been
+replaced.
 
 `stop_keep` returns additive outcome fields:
 

--- a/docs/plans/nonblocking-status-health-refresh.md
+++ b/docs/plans/nonblocking-status-health-refresh.md
@@ -1,0 +1,30 @@
+# Nonblocking Status Health Refresh Plan
+
+## Background
+
+`KeepGPUServer.status()` refreshes runtime failure state by calling controller
+health hooks. Those hooks are intended to be lightweight, but a slow or wedged
+hook currently runs while the session lock is held, so status can block stop,
+start, and stop-all lifecycle operations.
+
+## Goal
+
+Keep status observational: runtime-health probing must not hold the service
+session lock, and a late probe result must not mutate a session that has already
+been stopped or replaced.
+
+## Solution
+
+- Add a regression test with a blocking `runtime_error()` hook and prove
+  `stop_keep(job_id)` still completes while status is waiting on the hook.
+- Snapshot the target session under the lock, run the runtime-health hook outside
+  the lock, then reacquire the lock before applying a runtime-failed state.
+- Render status from the current session state after the probe so stop and
+  replacement races stay truthful.
+- Update agent and MCP/service docs to preserve the lifecycle-lock contract.
+
+## Verification
+
+- Targeted MCP server lifecycle tests.
+- Focused MCP service tests.
+- Pre-commit, docs build, and diff whitespace checks before PR.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -461,17 +461,20 @@ class KeepGPUServer:
                 current.state = state
                 current.last_error = last_error
 
-    @staticmethod
-    def _refresh_session_runtime_state(session: Session) -> None:
-        if session.state != "active":
-            return
+    def _refresh_session_runtime_state(self, job_id: str, session: Session) -> None:
+        with self._sessions_lock:
+            if self._sessions.get(job_id) is not session or session.state != "active":
+                return
         runtime_error = getattr(session.controller, "runtime_error", None)
         if not callable(runtime_error):
             return
         error = runtime_error()
         if error is not None:
-            session.state = "runtime_failed"
-            session.last_error = str(error)
+            with self._sessions_lock:
+                current = self._sessions.get(job_id)
+                if current is session and current.state == "active":
+                    current.state = "runtime_failed"
+                    current.last_error = str(error)
 
     def _mark_stop_timeout(self, job_id: str, session: Session) -> None:
         with self._sessions_lock:
@@ -714,7 +717,16 @@ class KeepGPUServer:
                         job_status["active"] = True
                         return job_status
                     return {"active": False, "job_id": job_id}
-                self._refresh_session_runtime_state(session)
+            self._refresh_session_runtime_state(job_id, session)
+            with self._sessions_lock:
+                session = self._sessions.get(job_id)
+                if not session:
+                    params = self._starting_params.get(job_id)
+                    if params is not None:
+                        job_status = self._starting_status(job_id, params)
+                        job_status["active"] = True
+                        return job_status
+                    return {"active": False, "job_id": job_id}
                 return {
                     "active": True,
                     "job_id": job_id,
@@ -723,8 +735,10 @@ class KeepGPUServer:
                     "last_error": session.last_error,
                 }
         with self._sessions_lock:
-            for session in self._sessions.values():
-                self._refresh_session_runtime_state(session)
+            session_items = list(self._sessions.items())
+        for jid, session in session_items:
+            self._refresh_session_runtime_state(jid, session)
+        with self._sessions_lock:
             return {
                 "active_jobs": [
                     self._starting_status(jid, params)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -259,6 +259,108 @@ def test_status_retains_first_runtime_failure_without_refreshing_again():
     assert controller.runtime_error_calls == 1
 
 
+@pytest.mark.parametrize("status_scope", ["single", "all"])
+def test_status_runtime_health_hook_does_not_block_stop_keep(status_scope):
+    runtime_hook_entered = threading.Event()
+    release_runtime_hook = threading.Event()
+    status_result = {}
+    stop_result = {}
+
+    class BlockingRuntimeHealthController(DummyController):
+        def runtime_error(self):
+            runtime_hook_entered.set()
+            release_runtime_hook.wait(timeout=2.0)
+            return RuntimeError("late runtime failure")
+
+    server = KeepGPUServer(
+        controller_factory=cast(
+            Any, lambda **kwargs: BlockingRuntimeHealthController(**kwargs)
+        )
+    )
+    job_id = server.start_keep(job_id="slow-health", gpu_ids=[0])["job_id"]
+
+    def check_status():
+        if status_scope == "single":
+            status_result.update(value=server.status(job_id))
+            return
+        status_result.update(value=server.status())
+
+    status_thread = threading.Thread(target=check_status)
+    status_thread.start()
+    stop_thread = threading.Thread(
+        target=lambda: stop_result.update(value=server.stop_keep(job_id))
+    )
+    try:
+        assert runtime_hook_entered.wait(timeout=1.0)
+
+        stop_thread.start()
+
+        assert _wait_until(lambda: "value" in stop_result, timeout_s=0.2)
+        assert stop_result["value"]["stopped"] == [job_id]
+        assert server._sessions == {}
+    finally:
+        release_runtime_hook.set()
+        stop_thread.join(timeout=1.0)
+        status_thread.join(timeout=1.0)
+
+    assert not stop_thread.is_alive()
+    assert not status_thread.is_alive()
+    if status_scope == "single":
+        assert status_result["value"] == {"active": False, "job_id": job_id}
+    else:
+        assert status_result["value"] == {"active_jobs": []}
+
+
+def test_late_runtime_health_result_does_not_mutate_reused_job_id():
+    runtime_hook_entered = threading.Event()
+    release_runtime_hook = threading.Event()
+    status_result = {}
+    controller_count = 0
+
+    class BlockingRuntimeHealthController(DummyController):
+        def __init__(self, **kwargs):
+            nonlocal controller_count
+
+            super().__init__(**kwargs)
+            controller_count += 1
+            self.should_block_runtime = controller_count == 1
+
+        def runtime_error(self):
+            if self.should_block_runtime:
+                runtime_hook_entered.set()
+                release_runtime_hook.wait(timeout=2.0)
+                return RuntimeError("stale runtime failure")
+            return None
+
+    server = KeepGPUServer(
+        controller_factory=cast(
+            Any, lambda **kwargs: BlockingRuntimeHealthController(**kwargs)
+        )
+    )
+    job_id = server.start_keep(job_id="reused-job", gpu_ids=[0])["job_id"]
+    status_thread = threading.Thread(
+        target=lambda: status_result.update(value=server.status(job_id))
+    )
+    status_thread.start()
+    try:
+        assert runtime_hook_entered.wait(timeout=1.0)
+        assert server.stop_keep(job_id)["stopped"] == [job_id]
+
+        assert server.start_keep(job_id=job_id, gpu_ids=[1]) == {"job_id": job_id}
+
+        release_runtime_hook.set()
+        status_thread.join(timeout=1.0)
+    finally:
+        release_runtime_hook.set()
+        status_thread.join(timeout=1.0)
+
+    assert not status_thread.is_alive()
+    assert status_result["value"]["state"] == "active"
+    assert status_result["value"]["last_error"] is None
+    assert status_result["value"]["params"]["gpu_ids"] == [1]
+    assert server.status(job_id)["state"] == "active"
+
+
 def test_status_runtime_health_does_not_overwrite_retained_stop_states():
     class RuntimeFailedController(DummyController):
         def runtime_error(self):


### PR DESCRIPTION
## Summary
- Move service runtime-health probing out of the session lifecycle lock.
- Guard late runtime-health results so they only update the same still-active session they inspected.
- Add race regressions for blocked status calls, stop_keep, and same-job-id reuse.
- Document the status/health lock contract in AGENTS.md and the MCP/service guide.

## Verification
- RED: new regression failed before fix because stop_keep could not complete while status was blocked in a runtime-health hook.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> `247 passed`
- `PYTHONPATH=$PWD/src pytest tests/mcp tests/global_controller tests/single_gpu_controller -q` -> `325 passed, 1 skipped`
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` -> `196 passed`
- `PYTHONPATH=$PWD/src pytest tests/utilities/test_session_config.py tests/utilities/test_gpu_info.py tests/utilities/test_gpu_monitor.py -q` -> `130 passed, 1 skipped`
- `PYTHONPATH=$PWD/src pytest -q` -> `836 passed, 11 skipped`
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with the known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed

## Local Review
- Local subagent review: no Critical/Important/Minor findings after follow-up coverage for same-job-id reuse.
