### PR TITLE
[readme] docs: restore Zenodo DOI badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ This file defines how coding agents should work in this repository.
   as the detailed routing hub; README may keep only a high-level platform
   sentence and should use the canonical `KeepGPU` product title. Keep platform
   caveats, sentinel-value explanations, and long citation metadata in `docs/`,
-  not in README. Avoid badge clutter; PyPI and docs status are enough.
+  not in README. Avoid badge clutter; keep badges to PyPI, docs status, and the
+  Zenodo DOI badge.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)
 [![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)
+[![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)
 
 KeepGPU is a small, polite GPU keeper for shared machines. It reserves the VRAM
 you ask for, backs off when devices are busy, and releases cleanly when you are

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,7 +101,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep README as a concise front door. Put detailed interface examples,
   platform caveats, sentinel-value explanations, and contracts in the focused
   docs pages. Use `docs/index.md` for detailed navigation, keep full citation
-  metadata in `docs/citation.md`, and avoid badge clutter beyond PyPI/docs.
+  metadata in `docs/citation.md`, and avoid badge clutter beyond PyPI, docs
+  status, and Zenodo DOI.
 
 ## MCP server
 

--- a/docs/plans/restore-zenodo-readme-badge.md
+++ b/docs/plans/restore-zenodo-readme-badge.md
@@ -1,0 +1,24 @@
+# Restore Zenodo README Badge Plan
+
+## Background
+
+The slim README guard removed badge clutter, but the Zenodo DOI badge is useful
+for citation and research-facing credibility.
+
+## Goal
+
+Restore the Zenodo badge without turning README back into a reference page.
+
+## Solution
+
+- Keep README's existing compact front-door copy.
+- Add only the Zenodo DOI badge beside PyPI and docs status.
+- Update the metadata guard so it requires the exact PyPI, docs status, and DOI
+  badge lines.
+- Keep detailed citation metadata in `docs/citation.md`.
+
+## Verification
+
+- Targeted package metadata tests.
+- README badge URL smoke check.
+- Pre-commit and diff whitespace checks before PR.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -107,10 +107,15 @@ def test_readme_stays_a_compact_front_door():
     readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
     normalized_readme = readme.lower()
     lines = [line for line in readme.splitlines() if line.strip()]
+    badge_lines = [line for line in readme.splitlines() if line.startswith("[![")]
 
     assert readme.startswith("# KeepGPU\n")
-    assert len(lines) <= 20
-    assert readme.count("[![") <= 2
+    assert len(lines) <= 21
+    assert badge_lines == [
+        "[![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)",
+        "[![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)",
+        "[![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)",
+    ]
     assert "## choose an interface" not in normalized_readme
     assert "| need | start here |" not in normalized_readme
     assert "cuda" in normalized_readme
@@ -135,7 +140,6 @@ def test_readme_stays_a_compact_front_door():
     assert "rest endpoint" not in normalized_readme
     assert "```bibtex" not in normalized_readme
     assert "skillcheck" not in normalized_readme
-    assert "zenodo.org/badge" not in normalized_readme
     assert not re.search(r"\]\(\.?\.?/?docs/", readme)
     assert "https://keepgpu.readthedocs.io/en/latest/" in readme
     assert "https://keepgpu.readthedocs.io/en/latest/getting-started/" in readme


### PR DESCRIPTION
## Summary
- Restore the Zenodo DOI badge to the compact README.
- Keep README guarded as a small front door by requiring the exact three allowed badge lines.
- Align AGENTS.md and contributing docs so the Zenodo badge is intentionally preserved.

## Verification
- RED: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q` failed before README edit because the Zenodo badge was missing.
- Badge smoke check: PyPI, docs, and Zenodo badge image/target URLs returned HTTP 200.
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q` -> `10 passed`
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with the known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `git diff --check` -> passed

## Local Review
- Local subagent review: no Critical/Important/Minor findings on final pushed branch tip.
