### PR TITLE
[rest] fix: classify GPU listing unavailability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,9 @@ This file defines how coding agents should work in this repository.
 - Supported REST API routes/methods must return structured JSON error objects
   for validation, unknown-endpoint, and unexpected runtime failures; do not let
   handler exceptions drop the HTTP connection.
+- `GET /api/gpus` must report expected `DeviceEnumerationUnavailableError`
+  failures as structured JSON `503` responses; arbitrary listing runtime
+  failures remain structured `500` errors.
 - The dashboard request wrapper must prefer structured REST `error.message`
   strings over raw JSON bodies so users see actionable start/refresh/release
   failures instead of protocol payloads.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -199,6 +199,8 @@ curl http://127.0.0.1:8765/api/sessions
 `id`/`visible_id`. Optional `physical_id` or `uuid` fields describe the
 underlying vendor device only; clients should not send those metadata values as
 `gpu_ids`.
+If visible-device enumeration is temporarily unavailable, the route returns a
+structured JSON `503` response instead of a generic internal error.
 On CUDA, NVML records are exposed only when Torch CUDA can start the same
 visible ordinal set, so NVML-only devices are omitted instead of advertised as
 usable session targets.

--- a/docs/plans/gpu-listing-unavailable-503.md
+++ b/docs/plans/gpu-listing-unavailable-503.md
@@ -1,0 +1,27 @@
+# GPU Listing Unavailable REST Plan
+
+## Background
+
+`POST /api/sessions` already treats expected GPU enumeration failures as
+service-unavailable startup conditions, but `GET /api/gpus` let the same
+`DeviceEnumerationUnavailableError` fall through the generic REST runtime-error
+handler as HTTP 500.
+
+## Goal
+
+Keep `/api/gpus` structured and actionable: expected enumeration unavailability
+returns HTTP 503, while arbitrary listing failures remain structured HTTP 500.
+
+## Solution
+
+- Add a RED HTTP regression for `GET /api/gpus` raising
+  `DeviceEnumerationUnavailableError`.
+- Catch that expected exception in the `/api/gpus` route before the generic
+  runtime-error handler.
+- Update the REST/MCP docs and agent guidance for the new classification.
+
+## Verification
+
+- Focused `/api/gpus` unavailable and runtime-error tests.
+- MCP HTTP API shard.
+- Full tests, pre-commit, docs build, and whitespace check before PR.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,7 +157,7 @@ enumeration, with error code `-32000`; arbitrary runtime failures remain
 | Endpoint | Method | Purpose |
 | --- | --- | --- |
 | `/health` | GET | Service liveness probe. |
-| `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unselectable CUDA/ROCm records are omitted; unsupported fields are `null`; the dashboard treats unavailable utilization as `n/a`, not `0%`). |
+| `/api/gpus` | GET | GPU telemetry (`id`/`visible_id` are start-compatible visible ordinals; optional `physical_id`/`uuid` are metadata; unselectable CUDA/ROCm records are omitted; unsupported fields are `null`; expected enumeration unavailability is a structured `503`; the dashboard treats unavailable utilization as `n/a`, not `0%`). |
 | `/api/sessions` | GET | Tracked keep sessions, including `state="starting"` during startup, `state="runtime_failed"` plus `last_error` for retained worker failures, and `state`/`last_error` for in-progress or failed stops. |
 | `/api/sessions/{job_id}` | GET | One session status, including `state` and `last_error` when active, starting, runtime-failed, or retained after stop problems. |
 | `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. Explicit `gpu_ids` are checked against a validated `list_gpus()` response; a valid empty list is `503`, while malformed listing payloads are structured `500` errors before any session starts. |

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1199,7 +1199,18 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 self._json_response(200, {"ok": True})
                 return
             if path == "/api/gpus":
-                self._json_response(200, server_ref.list_gpus())
+                try:
+                    self._json_response(200, server_ref.list_gpus())
+                except DeviceEnumerationUnavailableError as exc:
+                    self._json_response(
+                        503,
+                        {
+                            "error": {
+                                "message": str(exc),
+                                "type": DeviceEnumerationUnavailableError.__name__,
+                            }
+                        },
+                    )
                 return
             if path == "/api/sessions":
                 if self._reject_session_route_components(parsed):

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -1445,6 +1445,30 @@ def test_http_get_api_gpus_runtime_error_returns_json_500(monkeypatch):
     assert payload["error"]["type"] == "RuntimeError"
 
 
+def test_http_get_api_gpus_enumeration_unavailable_returns_json_503(monkeypatch):
+    server = make_server()
+    monkeypatch.setattr(
+        server,
+        "list_gpus",
+        lambda: (_ for _ in ()).throw(
+            DeviceEnumerationUnavailableError("Unable to enumerate visible GPUs")
+        ),
+    )
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}/api/gpus")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 503
+    assert payload["error"]["message"] == "Unable to enumerate visible GPUs"
+    assert payload["error"]["type"] == "DeviceEnumerationUnavailableError"
+
+
 @pytest.mark.parametrize(
     ("records", "message_fragment"),
     [


### PR DESCRIPTION
## Summary
- Return structured JSON `503` from `GET /api/gpus` when GPU enumeration is expectedly unavailable.
- Preserve structured JSON `500` for arbitrary `list_gpus()` runtime failures.
- Update AGENTS.md and REST/MCP docs with the `/api/gpus` error classification.

## Local Review
- Local subagent review reported no Critical, Important, or Minor findings; ready for PR.

## Test Plan
- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_enumeration_unavailable_returns_json_503 -q` -> failed with `assert 500 == 503` before the fix.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_enumeration_unavailable_returns_json_503 tests/mcp/test_http_api.py::test_http_get_api_gpus_runtime_error_returns_json_500 -q` -> `2 passed`
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'gpus or runtime_error or startup_unavailable'` -> `26 passed, 89 deselected`
- `PYTHONPATH=$PWD/src pytest -q` -> `843 passed, 11 skipped`
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=$PWD/src mkdocs build --strict` -> passed with the known Material for MkDocs 2.0 warning
- `git diff --check` -> passed
