### PR TITLE
[citation] docs: refresh Zenodo metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@ This file defines how coding agents should work in this repository.
   as the detailed routing hub; README may keep only a high-level platform
   sentence and should use the canonical `KeepGPU` product title. Keep platform
   caveats, sentinel-value explanations, and long citation metadata in `docs/`,
-  not in README. Avoid badge clutter; keep badges to PyPI, docs status, and the
-  Zenodo DOI badge.
+  not in README. Keep `docs/citation.md` aligned with the current Zenodo
+  concept DOI metadata. Avoid badge clutter; keep badges to PyPI, docs status,
+  and the Zenodo DOI badge.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,16 +1,16 @@
 # Citation
 
-If KeepGPU helps your research or operations, cite the archived software record:
+If this polite GPU keeper helps your research or operations, cite the archived
+software record:
 
 ```bibtex
-@software{Wangmerlyn_KeepGPU_2025,
-  author       = {Wang, Siyuan and Shi, Yaorui and Liu, Yida and Yin, Yuqi},
-  title        = {KeepGPU: a polite GPU keeper with CLI, service, and MCP interfaces},
-  year         = {2025},
+@software{Wangmerlyn_KeepGPU_v0_5_1,
+  author       = {{Wang Siyuan} and {shiyaorui} and {Liu Yida} and {ChitandaErumanga}},
+  title        = {Wangmerlyn/KeepGPU: KeepGPU v0.5.1},
+  year         = {2026},
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.17129114},
-  url          = {https://github.com/Wangmerlyn/KeepGPU},
-  note         = {GitHub repository},
-  keywords     = {ai, hpc, gpu, cluster, cuda, torch, debug}
+  url          = {https://zenodo.org/doi/10.5281/zenodo.17129114},
+  note         = {Software, MIT License}
 }
 ```

--- a/docs/plans/zenodo-citation-metadata.md
+++ b/docs/plans/zenodo-citation-metadata.md
@@ -1,0 +1,25 @@
+# Zenodo Citation Metadata Plan
+
+## Background
+
+The README keeps the Zenodo concept DOI badge as a compact first-viewport
+signal. The detailed BibTeX entry lives in `docs/citation.md`, but it drifted
+from the current Zenodo metadata for the concept DOI.
+
+## Goal
+
+Keep README compact while making the citation page match the current Zenodo
+concept DOI export for KeepGPU v0.5.1.
+
+## Solution
+
+- Add a small metadata guard for the citation page.
+- Update `docs/citation.md` with the current Zenodo title, creator list, year,
+  DOI, URL, license, and software note.
+- Keep README unchanged except for preserving its existing Zenodo badge.
+
+## Checks
+
+- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q -k 'readme or citation or metadata'`
+- `PYTHONPATH=$PWD/src mkdocs build --strict`
+- `pre-commit run --all-files --show-diff-on-failure`

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -146,6 +146,20 @@ def test_readme_stays_a_compact_front_door():
     assert "https://keepgpu.readthedocs.io/en/latest/citation/" in readme
 
 
+def test_citation_page_matches_current_zenodo_concept_doi_metadata():
+    citation = (PROJECT_ROOT / "docs/citation.md").read_text(encoding="utf-8")
+
+    assert "10.5281/zenodo.17129114" in citation
+    assert "Wangmerlyn/KeepGPU: KeepGPU v0.5.1" in citation
+    assert "year         = {2026}" in citation
+    assert "Wang Siyuan" in citation
+    assert "shiyaorui" in citation
+    assert "Liu Yida" in citation
+    assert "ChitandaErumanga" in citation
+    assert "Yin, Yuqi" not in citation
+    assert "year         = {2025}" not in citation
+
+
 def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
     public_docs = {
         "index": (PROJECT_ROOT / "docs/index.md").read_text(encoding="utf-8"),


### PR DESCRIPTION
## Summary
- Refresh `docs/citation.md` to match the current Zenodo concept DOI metadata for KeepGPU v0.5.1.
- Add a compact package metadata guard so stale 2025/Yin citation metadata cannot drift back in.
- Update AGENTS guidance to keep detailed citation metadata in docs and aligned with Zenodo, while preserving the compact README and Zenodo badge.

## Local review
- Local subagent review found no Critical, Important, or Minor issues.
- Reviewer verified the README is unchanged and the Zenodo DOI badge remains present.
- Reviewer cross-checked the live Zenodo API record and DOI BibTeX export.

## Verification
- RED before docs fix: `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py::test_citation_page_matches_current_zenodo_concept_doi_metadata -q` failed against stale citation metadata.
- GREEN targeted test: same command passed.
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q -k 'readme or citation or metadata'`: 11 passed.
- `PYTHONPATH=$PWD/src pytest tests/test_package_metadata.py -q`: 11 passed.
- `PYTHONPATH=$PWD/src pytest -q`: 846 passed, 11 skipped.
- `PYTHONPATH=$PWD/src mkdocs build --strict`: passed with the existing Material for MkDocs upstream warning.
- `pre-commit run --all-files --show-diff-on-failure`: passed.
- `git diff --check`: passed.
