### PR TITLE
[mcp] fix: share port validation errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,9 @@ This file defines how coding agents should work in this repository.
   current process probe that cannot recover either value, is not ownership
   verified and must not be signaled as a managed daemon.
 - MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
-  before socket bind, matching the CLI service endpoint contract.
+  before socket bind, matching the CLI service endpoint contract. The MCP
+  argparse layer must pass raw `--port` values to the shared validator so
+  non-integer ports use the shared error message instead of argparse type errors.
 - `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
 - If `keep-gpu start` auto-starts a service daemon and the following
   `start_keep` RPC returns expected startup-unavailable JSON-RPC code

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -28,6 +28,9 @@ keep-gpu serve --host 127.0.0.1 --port 8765
 keep-gpu-mcp-server --mode http --host 127.0.0.1 --port 8765
 ```
 
+HTTP endpoint inputs are validated before socket bind. `--host` must be a DNS
+hostname or IPv4 address, and `--port` must be an integer in `1..65535`.
+
 ## MCP protocol over stdio
 
 MCP clients should start with `initialize`, then discover KeepGPU actions with

--- a/docs/plans/mcp-port-validation.md
+++ b/docs/plans/mcp-port-validation.md
@@ -1,0 +1,30 @@
+# MCP Port Validation Plan
+
+## Background
+
+The MCP HTTP executable validates endpoint values before binding, but
+`argparse` currently parses `--port` with `type=int`. Non-integer values such as
+`true` therefore fail with argparse's raw conversion message instead of the
+shared KeepGPU endpoint-validation contract.
+
+## Goal
+
+Route MCP HTTP `--port` values through the same shared validation used by other
+public endpoint surfaces, including non-integer values.
+
+## Solution
+
+- Tighten the MCP executable endpoint test to assert the shared error message.
+- Let argparse keep `--port` as raw input and validate it with
+  `validate_endpoint()`.
+- Update MCP docs and agent guidance so future parser changes preserve the
+  shared endpoint contract.
+
+## Checks
+
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_http_main_rejects_invalid_endpoint_before_binding -q`
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k endpoint`
+- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/utilities/test_endpoint_validation.py -q`
+- `PYTHONPATH=$PWD/src pytest -q`
+- `PYTHONPATH=$PWD/src mkdocs build --strict`
+- `pre-commit run --all-files --show-diff-on-failure`

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1459,7 +1459,7 @@ def run_http(server: KeepGPUServer, host: str = "127.0.0.1", port: int = 8765) -
         server.shutdown()
 
 
-def _validate_mcp_http_endpoint(host: str, port: int) -> tuple[str, int]:
+def _validate_mcp_http_endpoint(host: str, port: Any) -> tuple[str, int]:
     return validate_endpoint(host, port)
 
 
@@ -1473,7 +1473,7 @@ def main() -> None:
         help="Transport mode (default: stdio)",
     )
     parser.add_argument("--host", default="127.0.0.1", help="HTTP host (http mode)")
-    parser.add_argument("--port", type=int, default=8765, help="HTTP port (http mode)")
+    parser.add_argument("--port", default=8765, help="HTTP port (http mode)")
     args = parser.parse_args()
 
     if args.mode == "http":

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -58,15 +58,17 @@ def _wait_until(condition, timeout_s=1.0):
 
 
 @pytest.mark.parametrize(
-    "endpoint_args",
+    ("endpoint_args", "expected_error"),
     [
-        ["--port", "0"],
-        ["--port", "70000"],
-        ["--port", "true"],
-        ["--host", "bad host"],
+        (["--port", "0"], "port must be an integer between 1 and 65535"),
+        (["--port", "70000"], "port must be an integer between 1 and 65535"),
+        (["--port", "true"], "port must be an integer between 1 and 65535"),
+        (["--host", "bad host"], "host must be a DNS hostname or IPv4 address"),
     ],
 )
-def test_http_main_rejects_invalid_endpoint_before_binding(monkeypatch, endpoint_args):
+def test_http_main_rejects_invalid_endpoint_before_binding(
+    monkeypatch, capsys, endpoint_args, expected_error
+):
     run_http_calls = []
 
     monkeypatch.setattr(
@@ -86,6 +88,7 @@ def test_http_main_rejects_invalid_endpoint_before_binding(monkeypatch, endpoint
 
     assert exc_info.value.code != 0
     assert run_http_calls == []
+    assert expected_error in capsys.readouterr().err
 
 
 def test_http_main_passes_valid_endpoint_to_run_http(monkeypatch):


### PR DESCRIPTION
## Summary
- Route MCP HTTP executable `--port` values through shared endpoint validation instead of argparse integer coercion.
- Assert shared host/port error messages before socket bind, including non-integer ports like `--port true`.
- Update MCP docs, AGENTS guidance, and the implementation plan. README remains compact and the Zenodo DOI badge is preserved.

## Local review
- Local subagent review found no Critical or Important issues.
- One Minor annotation note was resolved by updating `_validate_mcp_http_endpoint(..., port: Any)` to match the raw argparse boundary.
- Follow-up local review confirmed no new issues and marked the branch ready to merge.

## Verification
- Baseline before test tightening: `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_http_main_rejects_invalid_endpoint_before_binding -q`: 4 passed.
- RED before fix: tightened endpoint test failed only for `--port true`, showing argparse `invalid int value` instead of the shared endpoint message.
- GREEN targeted test: same command passed.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py::test_http_main_rejects_invalid_endpoint_before_binding tests/mcp/test_server.py::test_http_main_passes_valid_endpoint_to_run_http -q`: 5 passed.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q -k endpoint`: 5 passed, 130 deselected.
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py tests/utilities/test_endpoint_validation.py -q`: 179 passed.
- `PYTHONPATH=$PWD/src pytest -q`: 846 passed, 11 skipped.
- `PYTHONPATH=$PWD/src mkdocs build --strict`: passed with the existing Material for MkDocs upstream warning.
- `pre-commit run --all-files --show-diff-on-failure`: passed.
- `git diff --check`: passed.
