### PR TITLE
[cli] fix: recover service start identity without proc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,10 @@ This file defines how coding agents should work in this repository.
 - CLI service daemon ownership checks must require known PID identity
   components. A PID record with `uid` or `start_time` missing or `null`, or a
   current process probe that cannot recover either value, is not ownership
-  verified and must not be signaled as a managed daemon.
+  verified and must not be signaled as a managed daemon. Process probes should
+  use guarded platform fallbacks when `/proc` is unavailable, but only known
+  matching identity values may authorize a signal; UID must be a plain integer
+  and start identity must be a non-empty string.
 - MCP executable HTTP endpoint inputs (`--host`, `--port`) must be validated
   before socket bind, matching the CLI service endpoint contract. The MCP
   argparse layer must pass raw `--port` values to the shared validator so
@@ -299,7 +302,7 @@ This file defines how coding agents should work in this repository.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.
-- Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process. PID records must store exact plain JSON integer `pid` and `port` values; lossy numeric coercions such as floats or booleans are not ownership-verified.
+- Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process. PID records must store exact plain JSON integer `pid`, `port`, and `uid` values plus a non-empty string `start_time`; lossy numeric coercions such as floats or booleans are not ownership-verified. Non-`/proc` process metadata fallbacks are allowed only when they recover known UID and start-identity values.
 - Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -79,8 +79,10 @@ keep-gpu service-stop
 If sessions are still active, timed out, or failed to stop cleanly, resolve them
 first or use `--force`. Force mode skips the session RPC checks, but it still
 stops only an ownership-verified daemon that KeepGPU auto-started. Malformed
-PID records, including float or boolean PID/port values, are ignored instead of
-being coerced into a process signal target.
+PID records, including float or boolean numeric identity values, are ignored
+instead of being coerced into a process signal target. On systems without
+`/proc`, KeepGPU may recover daemon identity from platform process metadata, but
+unknown identity still refuses to signal.
 
 ### List telemetry
 
@@ -170,6 +172,6 @@ of `keep-gpu status`.
   KeepGPU does not rewrite visibility masks in blocking mode. In service mode,
   ordinals are interpreted in the already-running service process environment.
 - **Start cannot reach service**: run `keep-gpu serve --host 127.0.0.1 --port 8765`.
-- **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop`. Use `keep-gpu service-stop --force` only for an unresponsive auto-started daemon; it still refuses to signal a PID that KeepGPU cannot verify as its own.
+- **Need to close background service**: run `keep-gpu stop --all` first, then `keep-gpu service-stop`. Use `keep-gpu service-stop --force` only for an unresponsive auto-started daemon; it still refuses to signal a PID whose identity cannot be verified or recovered as KeepGPU-owned.
 - **OOM during keep**: reduce `--vram` or free GPU memory before starting.
 - **No utilization data**: on CUDA, ensure `nvidia-ml-py`/`pynvml` can initialize NVML; `nvidia-smi` can help sanity-check the driver outside KeepGPU. Malformed, duplicate/equivalent, or ambiguous `CUDA_VISIBLE_DEVICES` masks are reported as unavailable utilization rather than guessed. On ROCm, ensure the ROCm/system stack provides `rocm_smi` and avoid conflicting `HIP_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` masks; KeepGPU handles missing `rocm_smi` gracefully. ROCm telemetry resolves visible ranks through `ROCR_VISIBLE_DEVICES` plus one HIP/CUDA overlay and reports unavailable utilization rather than guessing when the mapping is malformed or ambiguous. Valid `busy_threshold` values are `-1` or `0..100`, and omitted CLI values default to `25`. With non-negative `busy_threshold`, KeepGPU sleeps before allocation or compute when utilization is unavailable. On Mac M series, utilization is expected to be `null`, so use `--busy-threshold -1` only when you intentionally want unconditional keepalive compute.

--- a/docs/plans/cli-ps-start-identity.md
+++ b/docs/plans/cli-ps-start-identity.md
@@ -1,0 +1,75 @@
+# CLI Process Start Identity Fallback Plan
+
+## Background
+
+KeepGPU stores a structured PID record for auto-started service daemons before
+later service-stop or cleanup paths send signals. The record includes UID and a
+process start identity so a reused PID is not mistaken for a managed daemon.
+
+UID lookup already falls back to `ps` when `/proc` is unavailable, but start
+identity lookup returns `None` as soon as `/proc/<pid>/stat` is missing. On
+non-`/proc` platforms, that makes KeepGPU record `start_time: null` and then
+correctly refuse to signal the daemon later. The safety rule is sound; the
+identity probe is too Linux-specific.
+
+## Goal
+
+Recover a stable process start identity on platforms without `/proc` while
+preserving the invariant that KeepGPU never signals a daemon unless the stored
+record and the current process both have known matching identity components.
+
+## Solution
+
+- Add RED tests for `ps`-based start identity recovery and guarded fallback
+  failure.
+- Add a narrow `ps -p <pid> -o lstart=` fallback after the existing `/proc`
+  lookup path fails.
+- Keep `None` on empty or failed fallback output so unverifiable daemons remain
+  unsignaled.
+- Require recorded/current UID values to be plain integers and recorded/current
+  start identity values to be non-empty strings before ownership can match.
+- Update agent and CLI docs with the platform fallback behavior.
+
+## Tasks
+
+- [x] Create an isolated `.worktrees/codex/cli-ps-start-identity` branch from
+  latest `origin/main`.
+- [x] Add RED tests for non-`/proc` start identity recovery.
+- [x] Implement the minimal start identity fallback.
+- [x] Update `AGENTS.md` and CLI docs without expanding the README.
+- [x] Run targeted CLI tests, full tests, docs build, and pre-commit.
+- [x] Request local subagent review and resolve findings.
+- [ ] Open a PR, resolve hosted comments/checks, squash merge, and clean up.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'process_start_identity or ps_start_identity'`
+  failed with 2 failures because `_process_start_identity()` returned `None`
+  without trying `ps`, and the stop path refused to signal the managed daemon
+  with a missing recorded start identity.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'process_start_identity or ps_start_identity'`
+  passed with 5 passed.
+- Review hardening RED:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_service_process_rejects_malformed_identity_record_components -q`
+  failed with 5 failures because malformed identity values could compare equal
+  and reach signal paths.
+- Ownership GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'process_start_identity or ps_start_identity or malformed_identity_record_components or unknown_recorded_identity_components or unknown_current_identity_components or stops_matching_owned_daemon'`
+  passed with 15 passed.
+- CLI service:
+  `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed
+  with 206 passed.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 856 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the existing
+  Material for MkDocs warning.
+- Hooks:
+  `pre-commit run --all-files --show-diff-on-failure` and `git diff --check`
+  passed.
+- Local review:
+  first pass found no must-fix issues and suggested stricter identity type
+  checks; after implementing that hardening, a second local review found no
+  must-fix issues.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,8 +127,10 @@ Stops the ownership-verified local daemon process created by auto-start logic.
 Invalid endpoint values are rejected locally before service checks or
 ownership-verified stop operations. Non-force shutdown requires session checks
 to finish cleanly with no timed-out or failed stops. Malformed PID records with
-float or boolean PID/port values are ignored rather than coerced before
-signaling.
+float or boolean numeric identity values are ignored rather than coerced before
+signaling. On systems without `/proc`, KeepGPU may recover daemon identity from
+platform process metadata, but it still signals only when recovered identity is
+known and exactly matches the stored ownership record.
 
 | Option | Description |
 | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -100,11 +100,19 @@ def _service_command(host: str, port: int) -> List[str]:
 def _process_start_identity(pid: int) -> Optional[str]:
     try:
         stat_path = Path(f"/proc/{pid}/stat")
-        if not stat_path.exists():
-            return None
-        raw_stat = stat_path.read_text(encoding="utf-8", errors="replace")
-        after_comm = raw_stat.rsplit(")", 1)[1].strip().split()
-        return after_comm[19]
+        if stat_path.exists():
+            raw_stat = stat_path.read_text(encoding="utf-8", errors="replace")
+            after_comm = raw_stat.rsplit(")", 1)[1].strip().split()
+            return after_comm[19]
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            text=True,
+        )
+        start_time = out.strip()
+        return start_time or None
     except Exception:
         return None
 
@@ -475,19 +483,19 @@ def _record_matches_running_process(
         return False
 
     recorded_uid = record.get("uid")
-    if recorded_uid is None:
+    if not isinstance(recorded_uid, int) or isinstance(recorded_uid, bool):
         return False
     current_uid = _process_uid(pid)
-    if current_uid is None:
+    if not isinstance(current_uid, int) or isinstance(current_uid, bool):
         return False
     if recorded_uid != current_uid:
         return False
 
     recorded_start = record.get("start_time")
-    if recorded_start is None:
+    if not isinstance(recorded_start, str) or not recorded_start:
         return False
     current_start = _process_start_identity(pid)
-    if current_start is None:
+    if not isinstance(current_start, str) or not current_start:
         return False
     if recorded_start != current_start:
         return False

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2193,6 +2193,119 @@ def test_process_uid_returns_none_when_target_uid_is_unknown(monkeypatch):
     assert cli._process_uid(4321) is None
 
 
+def test_process_start_identity_uses_ps_when_proc_stat_is_unavailable(monkeypatch):
+    class MissingProcStatPath:
+        def __init__(self, _path):
+            pass
+
+        def exists(self):
+            return False
+
+    calls = []
+
+    def fake_check_output(args, **kwargs):
+        calls.append((args, kwargs))
+        return "Wed Jul  1 05:00:00 2026\n"
+
+    monkeypatch.setattr(cli, "Path", MissingProcStatPath)
+    monkeypatch.setattr(cli.subprocess, "check_output", fake_check_output)
+
+    assert cli._process_start_identity(4321) == "Wed Jul  1 05:00:00 2026"
+    assert calls == [
+        (
+            ["ps", "-p", "4321", "-o", "lstart="],
+            {"text": True},
+        )
+    ]
+
+
+@pytest.mark.parametrize("ps_output", ["\n", "   \n"])
+def test_process_start_identity_returns_none_for_empty_ps_output(
+    monkeypatch, ps_output
+):
+    class MissingProcStatPath:
+        def __init__(self, _path):
+            pass
+
+        def exists(self):
+            return False
+
+    monkeypatch.setattr(cli, "Path", MissingProcStatPath)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "check_output",
+        lambda *args, **kwargs: ps_output,
+    )
+
+    assert cli._process_start_identity(4321) is None
+
+
+def test_process_start_identity_returns_none_when_target_start_time_is_unknown(
+    monkeypatch,
+):
+    class MissingProcStatPath:
+        def __init__(self, _path):
+            pass
+
+        def exists(self):
+            return False
+
+    monkeypatch.setattr(cli, "Path", MissingProcStatPath)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("ps failed")),
+    )
+
+    assert cli._process_start_identity(4321) is None
+
+
+def test_stop_service_process_uses_ps_start_identity_when_proc_is_unavailable(
+    monkeypatch, tmp_path
+):
+    class MissingProcPath:
+        def __init__(self, _path):
+            pass
+
+        def exists(self):
+            return False
+
+        def stat(self):
+            raise OSError("no proc")
+
+    def fake_check_output(args, **kwargs):
+        if args == ["ps", "-p", "4321", "-o", "uid="]:
+            return "1001\n"
+        if args == ["ps", "-p", "4321", "-o", "lstart="]:
+            return "Wed Jul  1 05:00:00 2026\n"
+        raise AssertionError(f"unexpected ps command: {args!r}")
+
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "Path", MissingProcPath)
+    monkeypatch.setattr(cli.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+
+    alive = {"value": True}
+    kills = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        alive["value"] = False
+
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: alive["value"])
+    monkeypatch.setattr(cli.os, "kill", fake_kill)
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0.5)
+
+    assert stopped is True
+    assert kills == [(4321, cli.signal.SIGTERM)]
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
 def test_stop_service_process_requires_structured_ownership_record(
     monkeypatch, tmp_path
 ):
@@ -2255,6 +2368,53 @@ def test_stop_service_process_rejects_coerced_ownership_record_numbers(
 
     assert stopped is False
     assert kills == []
+
+
+@pytest.mark.parametrize(
+    ("recorded_uid", "current_uid", "recorded_start", "current_start"),
+    [
+        (1000.0, 1000, "12345", "12345"),
+        (True, 1, "12345", "12345"),
+        (1000, 1000, "", ""),
+        (1000, 1000, 12345, 12345),
+        (1000, 1000, True, True),
+    ],
+)
+def test_stop_service_process_rejects_malformed_identity_record_components(
+    monkeypatch,
+    tmp_path,
+    recorded_uid,
+    current_uid,
+    recorded_start,
+    current_start,
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "argv": cli._service_command("127.0.0.1", 8765),
+        "uid": recorded_uid,
+        "start_time": recorded_start,
+    }
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: current_uid)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: current_start)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0)
+
+    assert stopped is False
+    assert kills == []
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
 @pytest.mark.parametrize("invalid_port", [0, -1])


### PR DESCRIPTION
## Summary

- fall back to `ps -p <pid> -o lstart=` when `/proc/<pid>/stat` is unavailable for service daemon start identity
- keep daemon stop safety strict: empty/failed identity recovery remains unverifiable, and UID/start identity values must have exact safe types before signaling
- document the service-stop ownership behavior in AGENTS, CLI guide/reference, and the branch plan

## Verification

- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'process_start_identity or ps_start_identity'` failed with 2 expected failures before the fallback
- RED: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py::test_stop_service_process_rejects_malformed_identity_record_components -q` failed with 5 expected failures before identity type hardening
- GREEN: `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q -k 'process_start_identity or ps_start_identity or malformed_identity_record_components or unknown_recorded_identity_components or unknown_current_identity_components or stops_matching_owned_daemon'` passed with 15 passed
- `PYTHONPATH=$PWD/src pytest tests/test_cli_service_commands.py -q` passed with 206 passed
- `PYTHONPATH=$PWD/src pytest tests -q` passed with 856 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the existing Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` passed
- `git diff --check` passed

## Local Review

- local subagent review pass 1: no must-fix issues; suggested stricter identity type checks
- local subagent review pass 2: no must-fix issues after the stricter checks
