### PR TITLE
[mcp] fix: reject encoded rpc aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,9 +145,9 @@ This file defines how coding agents should work in this repository.
   because the wrong implemented verb was used.
 - `/rpc` is an exact POST-only JSON-RPC endpoint; `GET /rpc` must return
   structured JSON `405 Method Not Allowed` with `Allow: POST`, while
-  noncanonical spellings such as `/rpc/`, `/rpc;...`, and `/rpc?...` return
-  structured JSON `404 Unknown endpoint` without JSON-RPC dispatch or
-  dashboard/static fallback.
+  noncanonical spellings such as `/rpc/`, `/rpc;...`, `/rpc?...`, `/rp%63`, and
+  `/%72pc` return structured JSON `404 Unknown endpoint` without JSON-RPC
+  dispatch or dashboard/static fallback.
 - Missing dashboard asset URLs, including `/assets/*` and extension-bearing
   static paths, must return structured JSON `404` errors instead of the
   dashboard HTML shell.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -63,7 +63,8 @@ envelopes.
 HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
 same JSON-RPC message shapes at the exact `/rpc` endpoint, but it is not a
 Streamable HTTP MCP endpoint. Noncanonical `/rpc` URLs, including trailing
-slashes or query strings, return structured `404 Unknown endpoint` errors.
+slashes, query strings, or encoded aliases such as `/rp%63`, return structured
+`404 Unknown endpoint` errors.
 
 Malformed HTTP JSON-RPC bodies return a JSON-RPC `-32700 Parse error` envelope
 with `id: null`; REST routes keep REST-shaped JSON errors.

--- a/docs/plans/rpc-encoded-aliases.md
+++ b/docs/plans/rpc-encoded-aliases.md
@@ -1,0 +1,62 @@
+# Encoded RPC Alias Rejection Plan
+
+## Background
+
+KeepGPU's HTTP server reserves exact `/rpc` for JSON-RPC POST requests. Recent
+routing hardening rejects trailing slash, parameter, query, and encoded
+separator variants so they do not fall through to dashboard/static handling or
+JSON-RPC body parsing.
+
+One alias class remains: paths such as `/rp%63` and `/%72pc` decode to exact
+`/rpc` but are not the canonical raw endpoint. `GET /rp%63` can reach dashboard
+fallback, and unsupported methods can fall through to `BaseHTTPRequestHandler`
+HTML responses instead of structured JSON.
+
+## Goal
+
+Reject percent-encoded exact `/rpc` aliases as structured JSON `404 Unknown
+endpoint` responses before static fallback, JSON-RPC parsing, or stdlib HTML
+errors. Preserve exact raw `/rpc` behavior: POST remains JSON-RPC, and unsupported
+methods return structured JSON `405`.
+
+## Solution
+
+- Add RED tests for encoded exact `/rpc` aliases across GET, POST, and
+  unsupported methods.
+- Treat decoded `/rpc` with raw `parsed.path != "/rpc"` as noncanonical.
+- Keep existing `/rpc` and `/` JSON-RPC compatibility behavior unchanged.
+- Update agent/docs wording for the encoded alias contract.
+
+## Tasks
+
+- [x] Create an isolated `.worktrees/codex/rpc-encoded-aliases` branch from
+  latest `origin/main`.
+- [x] Add RED tests for encoded exact `/rpc` aliases.
+- [x] Implement the minimal route predicate fix.
+- [x] Update `AGENTS.md` and CLI/API docs.
+- [x] Run targeted/full verification and local subagent review.
+- [ ] Open a PR, resolve hosted comments/checks, squash merge, and clean up.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'http_rpc_noncanonical_get_returns_json_404_without_static_fallback or http_rpc_encoded_exact_alias'`
+  failed with 4 failures: encoded exact GET aliases returned dashboard `200`,
+  and encoded exact unsupported methods returned stdlib `501`.
+- GREEN:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'http_rpc_noncanonical_get_returns_json_404_without_static_fallback or http_rpc_encoded_exact_alias or http_rpc_get_rejects_with_json_405 or http_jsonrpc_parse_error_returns_jsonrpc_envelope'`
+  passed with 13 passed.
+- HTTP API:
+  `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with 121
+  passed.
+- Full suite:
+  `PYTHONPATH=$PWD/src pytest tests -q` passed with 862 passed, 11 skipped.
+- Docs:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the existing
+  Material for MkDocs warning.
+- Hooks:
+  `pre-commit run --all-files --show-diff-on-failure` and `git diff --check`
+  passed after Black reformatted `src/keep_gpu/mcp/server.py`.
+- Local review:
+  a local subagent review found no must-fix issues and reran the focused
+  regression slice with 13 passed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -165,7 +165,7 @@ enumeration, with error code `-32000`; arbitrary runtime failures remain
 | `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and empty, duplicate, or out-of-range selections are invalid. Explicit `gpu_ids` are checked against a validated `list_gpus()` response; a valid empty list is `503`, while malformed listing payloads are structured `500` errors before any session starts. |
 | `/api/sessions` | DELETE | Stop all sessions; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/api/sessions/{job_id}` | DELETE | Stop one session; returns `stopped`, `timed_out`, `failed`, and `errors`. |
-| `/rpc` | POST | Exact JSON-RPC compatibility endpoint; noncanonical `/rpc` URLs return structured `404` errors. |
+| `/rpc` | POST | Exact JSON-RPC compatibility endpoint; noncanonical `/rpc` URLs, including encoded exact aliases, return structured `404` errors. |
 | `/` | GET | Dashboard UI. |
 
 ## Environment variables

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1030,12 +1030,16 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
     @staticmethod
     def _is_noncanonical_rpc_route(parsed) -> bool:
         route_paths = (parsed.path, unquote(parsed.path))
-        return any(
-            path.startswith(("/rpc/", "/rpc;", "/rpc?", "/rpc#"))
-            for path in route_paths
-        ) or (
-            any(path == "/rpc" for path in route_paths)
-            and bool(parsed.params or parsed.query or parsed.fragment)
+        return (
+            any(
+                path.startswith(("/rpc/", "/rpc;", "/rpc?", "/rpc#"))
+                for path in route_paths
+            )
+            or (parsed.path != "/rpc" and unquote(parsed.path) == "/rpc")
+            or (
+                any(path == "/rpc" for path in route_paths)
+                and bool(parsed.params or parsed.query or parsed.fragment)
+            )
         )
 
     def _reject_noncanonical_rpc_route(self, parsed, write_body: bool = True) -> bool:

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -306,7 +306,7 @@ def test_http_rpc_head_rejects_with_json_405_and_empty_body():
 
 @pytest.mark.parametrize(
     "rpc_path",
-    ["/rpc/", "/rpc%2F", "/rpc%3Bdebug", "/rpc%3Fdebug=1"],
+    ["/rpc/", "/rpc%2F", "/rpc%3Bdebug", "/rpc%3Fdebug=1", "/rp%63", "/%72pc"],
 )
 def test_http_rpc_noncanonical_get_returns_json_404_without_static_fallback(
     rpc_path,
@@ -345,6 +345,45 @@ def test_http_rpc_noncanonical_path_rejects_before_jsonrpc_parse(rpc_path):
 
     assert status == 404
     assert payload["error"]["message"] == "Unknown endpoint"
+
+
+@pytest.mark.parametrize("rpc_path", ["/rp%63", "/%72pc"])
+def test_http_rpc_encoded_exact_alias_rejects_before_jsonrpc_parse(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, payload = _request_raw("POST", f"{base}{rpc_path}", b"{bad json")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload["error"]["message"] == "Unknown endpoint"
+
+
+@pytest.mark.parametrize("rpc_path", ["/rp%63", "/%72pc"])
+def test_http_rpc_encoded_exact_alias_unsupported_method_returns_json_404(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("OPTIONS", f"{base}{rpc_path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Unknown endpoint"}
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- reject percent-encoded exact `/rpc` aliases such as `/rp%63` and `/%72pc` as structured JSON `404 Unknown endpoint`
- preserve exact raw `/rpc` behavior as the canonical POST-only JSON-RPC endpoint with structured `405` for unsupported methods
- document the route contract in AGENTS, MCP guide/reference, and the branch plan

## Verification

- RED: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'http_rpc_noncanonical_get_returns_json_404_without_static_fallback or http_rpc_encoded_exact_alias'` failed with 4 expected failures before the fix
- GREEN: `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q -k 'http_rpc_noncanonical_get_returns_json_404_without_static_fallback or http_rpc_encoded_exact_alias or http_rpc_get_rejects_with_json_405 or http_jsonrpc_parse_error_returns_jsonrpc_envelope'` passed with 13 passed
- `PYTHONPATH=$PWD/src pytest tests/mcp/test_http_api.py -q` passed with 121 passed
- `PYTHONPATH=$PWD/src pytest tests -q` passed with 862 passed, 11 skipped
- `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the existing Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` passed
- `git diff --check` passed

## Local Review

- local subagent review: no must-fix issues; reviewer reran the focused regression slice with 13 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to encoded or noncanonical `/rpc` URLs now return a structured `404 Unknown endpoint` response.
  * These paths no longer fall through to other handlers or static content, and unsupported methods are handled consistently.

* **Documentation**
  * Updated API and CLI guides to clarify which `/rpc` URL forms are treated as invalid.
  * Added a planning note describing the expected behavior for encoded endpoint variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->