### PR TITLE
[macm] fix: surface startup allocation failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,8 @@ This file defines how coding agents should work in this repository.
   be retained as runtime failures.
 - Single-GPU `keep()` must not report success until fatal backend startup setup
   has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
-  must propagate synchronously so services cannot register false active sessions.
+  and MPS first-allocation setup failures must propagate synchronously so
+  services cannot register false active sessions.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.

--- a/docs/plans/macm-startup-handshake.md
+++ b/docs/plans/macm-startup-handshake.md
@@ -1,0 +1,21 @@
+# Mac M Startup Handshake Implementation Plan
+
+**Goal:** Make `MacMGPUController.keep()` fail synchronously when the worker hits a fatal first-allocation startup error, matching the single-GPU startup contract already used by CUDA and ROCm.
+
+**Background:** The Mac M controller currently starts `_keep_loop()` in a daemon thread and immediately logs success. The first MPS allocation happens later in the worker, so an immediate non-OOM allocation failure can be reported only through `allocation_status()` after `keep()` has already returned.
+
+**Approach:** Add a small startup event/error handshake to the Mac M worker path. The worker will signal startup only after it has either completed the first successful allocation, decided to defer allocation because telemetry backoff is active, or captured a fatal startup setup/allocation error. `keep()` will wait for that signal, clean up thread state on fatal startup errors, and raise the captured exception.
+
+**Files:**
+- Modify `tests/macm_controller/test_macm_backoff.py` with one regression test for a first `torch.rand` `RuntimeError("mps startup allocation failed")`.
+- Modify `src/keep_gpu/single_gpu_controller/macm_gpu_controller.py` to add the startup event/error plumbing.
+- Modify `AGENTS.md` to name MPS first-allocation setup failures in the existing synchronous startup-failure contract.
+
+**Todo:**
+- [x] Add the failing regression test first.
+- [x] Run the new test and record the expected RED failure.
+- [x] Implement the minimal Mac M startup handshake.
+- [x] Strengthen the regression test to assert startup-failure state cleanup.
+- [x] Update `AGENTS.md` with the MPS-specific startup failure contract.
+- [x] Run the new test, full Mac M backoff tests, analogous CUDA/ROCm startup tests, and `git diff --check`.
+- [x] Commit with `fix(macm): surface startup allocation failures`.

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -63,12 +63,36 @@ class MacMGPUController(BaseGPUController):
             raise ValueError("vram_to_keep must be positive")
 
         self._stop_evt = threading.Event()
+        startup_evt = threading.Event()
+        startup_errors: list[Exception] = []
         self._thread = threading.Thread(
             target=self._keep_loop,
+            args=(startup_evt, startup_errors),
             name=f"gpu-keeper-macm-{self.rank}",
             daemon=True,
         )
         self._thread.start()
+        startup_timeout = 5.0
+        if not startup_evt.wait(startup_timeout):
+            stop_evt = self._stop_evt
+            if stop_evt is not None:
+                stop_evt.set()
+            self._thread.join(timeout=1.0)
+            if self._thread.is_alive():
+                raise RuntimeError(
+                    f"rank {self.rank}: MPS keep thread did not complete startup "
+                    f"within {startup_timeout:.1f}s"
+                )
+            self._thread = None
+            self._stop_evt = None
+            raise RuntimeError(
+                f"rank {self.rank}: MPS keep thread exited before startup completed"
+            )
+        if startup_errors:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+            self._stop_evt = None
+            raise startup_errors[0]
         logger.info("rank %s: MPS keep thread started", self.rank)
 
     def release(self) -> None:
@@ -122,21 +146,35 @@ class MacMGPUController(BaseGPUController):
     def __exit__(self, exc_type, exc, tb):
         self.release()
 
-    def _keep_loop(self) -> None:
+    def _keep_loop(
+        self,
+        startup_evt: Optional[threading.Event] = None,
+        startup_errors: Optional[list[Exception]] = None,
+    ) -> None:
         stop_evt = self._stop_evt
         if stop_evt is None:
-            self._failure_exc = RuntimeError(
-                f"rank {self.rank}: stop event not initialized"
-            )
-            logger.error("%s", self._failure_exc)
+            exc = RuntimeError(f"rank {self.rank}: stop event not initialized")
+            logger.error("%s", exc)
+            if startup_errors is not None:
+                startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
+            if startup_evt is not None:
+                startup_evt.set()
             return
 
         num_elements = self._num_elements if self._num_elements is not None else 0
         if num_elements <= 0:
-            self._failure_exc = RuntimeError(
+            exc = RuntimeError(
                 f"rank {self.rank}: invalid vram_to_keep={self.vram_to_keep}"
             )
-            logger.error("%s", self._failure_exc)
+            logger.error("%s", exc)
+            if startup_errors is not None:
+                startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
+            if startup_evt is not None:
+                startup_evt.set()
             return
 
         tensor = None
@@ -148,6 +186,8 @@ class MacMGPUController(BaseGPUController):
                         self.rank,
                         self.busy_threshold,
                     )
+                    if startup_evt is not None:
+                        startup_evt.set()
                     if stop_evt.wait(self.interval):
                         return
                     continue
@@ -157,25 +197,45 @@ class MacMGPUController(BaseGPUController):
                     dtype=torch.float32,
                     requires_grad=False,
                 )
+                if startup_evt is not None:
+                    startup_evt.set()
                 break
             except RuntimeError as exc:
                 logger.error("rank %s: failed to allocate tensor: %s", self.rank, exc)
                 if "out of memory" in str(exc).lower():
                     torch.mps.empty_cache()
                     gc.collect()
+                    if startup_evt is not None:
+                        startup_evt.set()
                     if stop_evt.wait(self.interval):
                         return
                     continue
-                self._failure_exc = RuntimeError(
+                failure = RuntimeError(
                     f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
                 )
-                logger.exception("%s", self._failure_exc)
+                if startup_evt is not None and not startup_evt.is_set():
+                    if startup_errors is not None:
+                        startup_errors.append(failure)
+                    else:
+                        self._failure_exc = failure
+                    startup_evt.set()
+                else:
+                    self._failure_exc = failure
+                logger.exception("%s", failure)
                 return
             except Exception as exc:
-                self._failure_exc = RuntimeError(
+                failure = RuntimeError(
                     f"rank {self.rank}: unexpected MPS keep worker failure: {exc}"
                 )
-                logger.exception("%s", self._failure_exc)
+                if startup_evt is not None and not startup_evt.is_set():
+                    if startup_errors is not None:
+                        startup_errors.append(failure)
+                    else:
+                        self._failure_exc = failure
+                    startup_evt.set()
+                else:
+                    self._failure_exc = failure
+                logger.exception("%s", failure)
                 return
 
         if tensor is None:

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -121,6 +121,35 @@ def test_macm_keep_rejects_restart_while_previous_thread_is_stopping():
         ctrl.keep()
 
 
+def test_macm_keep_raises_when_startup_allocation_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: True,
+    )
+
+    ctrl = MacMGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        iterations=1,
+    )
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("mps startup allocation failed")
+
+    monkeypatch.setattr(macm_module.torch, "rand", fail_allocation)
+
+    with pytest.raises(RuntimeError, match="mps startup allocation failed"):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
 def test_macm_unknown_utilization_backs_off_when_threshold_enabled():
     assert MacMGPUController._should_run_batch(None, 10) is False
 


### PR DESCRIPTION
## Summary
- Add a Mac M worker startup handshake so keep() cannot report success after fatal first-allocation setup failures.
- Preserve eco-safe deferred allocation and OOM retry behavior as non-fatal startup states.
- Add regression coverage, cleanup assertions, and AGENTS/docs plan notes.

## Verification
- PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_keep_raises_when_startup_allocation_fails -q
- PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py -q
- PYTHONPATH=src pytest tests/cuda_controller/test_keep_and_release.py tests/rocm_controller/test_rocm_backoff.py -q
- PYTHONPATH=src pytest tests -q (863 passed, 11 skipped)
- PYTHONPATH=src mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- git diff --check HEAD~1 HEAD

## Local review
- Local subagent review found no Critical or Important issues.
- One Minor suggestion to assert full startup-failure cleanup was addressed before PR.
