### PR TITLE
[mcp] fix: reject noncanonical api gpu routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,8 @@ This file defines how coding agents should work in this repository.
   is API-shaped (`/api`, `/api/...`, `/api;...`, `/api?...`, or `/api#...`)
   must return structured JSON `404 Unknown endpoint` responses instead of
   serving the dashboard/static fallback or `BaseHTTPRequestHandler` HTML errors.
+  Exact API endpoints such as `/api/gpus` must not accept params, query strings,
+  or fragments unless the handler explicitly documents those components.
   Canonical API paths may still validate encoded `job_id` path components
   normally.
 - Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)

--- a/docs/plans/api-gpus-noncanonical.md
+++ b/docs/plans/api-gpus-noncanonical.md
@@ -1,0 +1,117 @@
+# API GPUs Noncanonical Route Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure noncanonical `/api/gpus` HTTP routes with params or query components return structured `404 Unknown endpoint` responses without invoking GPU telemetry.
+
+**Architecture:** Keep the fix centralized in `_JSONRPCHandler._is_noncanonical_api_route()` so `/api/gpus` params/query requests are rejected before telemetry dispatch. Preserve exact canonical `/api/gpus` dispatch and existing session path component validation behavior.
+
+**Tech Stack:** Python `http.server` handler, `urllib.parse.urlparse`, pytest HTTP integration tests.
+
+---
+
+### Task 1: Regression Test
+
+**Files:**
+- Modify: `tests/mcp/test_http_api.py`
+
+- [x] **Step 1: Add a minimal parametrized test**
+
+Add a test near the existing API route 404 tests:
+
+```python
+@pytest.mark.parametrize("path", ["/api/gpus?bad=query", "/api/gpus;bad"])
+def test_http_get_api_gpus_noncanonical_route_returns_json_404_without_listing(path):
+    server = make_server()
+    list_calls = []
+
+    def fail_list_gpus():
+        list_calls.append(True)
+        raise AssertionError("list_gpus should not run for noncanonical route")
+
+    server.list_gpus = fail_list_gpus  # type: ignore[method-assign]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+    assert list_calls == []
+```
+
+- [x] **Step 2: Run RED**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_noncanonical_route_returns_json_404_without_listing -q
+```
+
+Expected: fail because current routing dispatches canonical-looking `/api/gpus` params/query requests to `list_gpus()`.
+
+### Task 2: Minimal Fix
+
+**Files:**
+- Modify: `src/keep_gpu/mcp/server.py`
+
+- [x] **Step 1: Fix API noncanonical detection**
+
+Update `_is_noncanonical_api_route()` so `/api/gpus` with `parsed.params`, `parsed.query`, or `parsed.fragment` is noncanonical, while exact canonical `/api/gpus` without those components continues normally.
+
+- [x] **Step 2: Run GREEN**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_noncanonical_route_returns_json_404_without_listing -q
+```
+
+Expected: pass.
+
+### Task 3: Verification and Commit
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/plans/api-gpus-noncanonical.md`
+- Modify: `tests/mcp/test_http_api.py`
+- Modify: `src/keep_gpu/mcp/server.py`
+
+- [x] **Step 1: Run focused HTTP API tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/mcp/test_http_api.py -q
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run whitespace diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: pass with no output.
+
+- [x] **Step 3: Update agent contract**
+
+Document that exact API endpoints such as `/api/gpus` do not accept params,
+query strings, or fragments unless explicitly documented by the handler.
+
+- [x] **Step 4: Commit**
+
+Run:
+
+```bash
+git add docs/plans/api-gpus-noncanonical.md tests/mcp/test_http_api.py src/keep_gpu/mcp/server.py
+git commit -m "fix(mcp): reject noncanonical api gpu routes"
+```

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1019,6 +1019,10 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
 
     @classmethod
     def _is_noncanonical_api_route(cls, parsed) -> bool:
+        if parsed.path == "/api/gpus" and bool(
+            parsed.params or parsed.query or parsed.fragment
+        ):
+            return True
         if cls._is_api_path(parsed.path):
             return False
         route_paths = (parsed.path, unquote(parsed.path))

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -1445,6 +1445,31 @@ def test_http_unknown_api_route_returns_json_404(path):
         thread.join(timeout=2)
 
 
+@pytest.mark.parametrize("path", ["/api/gpus?bad=query", "/api/gpus;bad"])
+def test_http_get_api_gpus_noncanonical_route_returns_json_404_without_listing(path):
+    server = make_server()
+    list_calls = []
+
+    def fail_list_gpus():
+        list_calls.append(True)
+        raise AssertionError("list_gpus should not run for noncanonical route")
+
+    server.list_gpus = fail_list_gpus  # type: ignore[method-assign]
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json("GET", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+    assert list_calls == []
+
+
 @pytest.mark.parametrize("data", [None, b"{bad json"])
 def test_http_post_unknown_api_route_returns_json_404_before_body_parse(data):
     server = make_server()


### PR DESCRIPTION
## Summary
- Reject noncanonical /api/gpus routes with params or query components as structured JSON 404s.
- Prevent those malformed routes from invoking list_gpus telemetry.
- Add focused regression coverage plus AGENTS/docs plan notes.

## Verification
- PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_get_api_gpus_noncanonical_route_returns_json_404_without_listing -q
- PYTHONPATH=src pytest tests/mcp/test_http_api.py -q
- PYTHONPATH=src pytest tests -q (864 passed, 11 skipped)
- PYTHONPATH=src mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- git diff --check HEAD~1 HEAD

## Local review
- Local subagent review found no Critical, Important, or Minor issues after inspection.
