### PR TITLE
[mcp] fix: return structured head asset errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,12 @@ This file defines how coding agents should work in this repository.
   noncanonical spellings such as `/rpc/`, `/rpc;...`, `/rpc?...`, `/rp%63`, and
   `/%72pc` return structured JSON `404 Unknown endpoint` without JSON-RPC
   dispatch or dashboard/static fallback.
-- Missing dashboard asset URLs, including `/assets/*` and extension-bearing
-  static paths, must return structured JSON `404` errors instead of the
-  dashboard HTML shell.
+- Missing dashboard asset URLs, including `GET`/`HEAD` requests for `/assets/*`
+  and extension-bearing static paths, must return structured JSON `404` errors
+  instead of the dashboard HTML shell; `HEAD` responses must not include a body.
+- `HEAD` requests for GET-able dashboard/static paths such as `/` and concrete
+  static assets must return the same success headers as `GET` with no body,
+  while API/RPC `HEAD` requests keep the structured JSON 405/404 contract.
 - For stdio MCP, stdout must contain only JSON protocol messages; diagnostics
   and human logs belong on stderr.
 

--- a/docs/plans/head-static-assets.md
+++ b/docs/plans/head-static-assets.md
@@ -1,0 +1,19 @@
+# HEAD Static Assets Implementation Plan
+
+**Goal:** Make HEAD requests for missing dashboard asset paths return the same structured JSON 404 headers as GET, with no response body.
+
+**Background:** `_JSONRPCHandler.do_GET()` routes dashboard/static paths through `_serve_static()`, which already identifies missing `/assets/*` and extension-bearing paths as structured JSON 404 errors. Because `_JSONRPCHandler` does not implement `do_HEAD()`, those requests currently fall through to `BaseHTTPRequestHandler` HTML 501 responses.
+
+**Approach:** Add focused regression tests for missing assets, static success, noncanonical API/RPC routes, and runtime-error envelopes under `HEAD`, verify the original missing-asset case fails, then route HEAD static requests through existing static semantics using `write_body=False`. Keep GET behavior unchanged and update `AGENTS.md` only to clarify that dashboard/static HEAD responses are header-only while API/RPC HEAD keeps structured 405/404 handling.
+
+**Todo:**
+- [x] Add the minimal failing parametrized HEAD missing-asset test near the existing GET missing-asset test.
+- [x] Run the targeted new test and record the RED failure.
+- [x] Implement the smallest `_JSONRPCHandler` change needed for HEAD missing assets.
+- [x] Update `AGENTS.md` narrowly for the HEAD/GET missing dashboard asset contract.
+- [x] Address local review by preserving `HEAD /` static success, suppressing
+  HEAD runtime-error bodies, and covering HEAD noncanonical API/RPC routes.
+- [x] Address hosted review by avoiding full static file reads for HEAD
+  content length and removing unreachable `/rpc` handling from `do_HEAD()`.
+- [x] Run the requested targeted, full MCP HTTP API, docs, pre-commit, and diff checks.
+- [x] Commit with `fix(mcp): return structured head asset errors`.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1105,7 +1105,14 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             return
         super().send_error(code, message, explain)
 
-    def _json_runtime_error(self, method: str, path: str, exc: Exception) -> None:
+    def _json_runtime_error(
+        self,
+        method: str,
+        path: str,
+        exc: Exception,
+        *,
+        write_body: bool = True,
+    ) -> None:
         logger.exception("%s request failed for path %s", method, path)
         self._json_response(
             500,
@@ -1115,6 +1122,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                     "type": exc.__class__.__name__,
                 }
             },
+            write_body=write_body,
         )
 
     def _read_json_body(self) -> Any:
@@ -1132,7 +1140,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         body = self.rfile.read(length).decode("utf-8")
         return json.loads(body)
 
-    def _serve_static(self, request_path: str) -> None:
+    def _serve_static(self, request_path: str, write_body: bool = True) -> None:
         if request_path in ("/", ""):
             relative = "index.html"
         else:
@@ -1142,7 +1150,11 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         requested = (STATIC_DIR / decoded_relative).resolve()
         static_root = STATIC_DIR.resolve()
         if static_root not in requested.parents and requested != static_root:
-            self._json_response(403, {"error": {"message": "Forbidden"}})
+            self._json_response(
+                403,
+                {"error": {"message": "Forbidden"}},
+                write_body=write_body,
+            )
             return
 
         is_asset_request = (
@@ -1155,22 +1167,34 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         if not requested.exists() or requested.is_dir():
             if is_asset_request:
                 self._json_response(
-                    404, {"error": {"message": "Static asset not found"}}
+                    404,
+                    {"error": {"message": "Static asset not found"}},
+                    write_body=write_body,
                 )
                 return
             # SPA fallback for client-side routes.
             requested = static_root / "index.html"
             if not requested.exists():
-                self._json_response(404, {"error": {"message": "UI not built"}})
+                self._json_response(
+                    404,
+                    {"error": {"message": "UI not built"}},
+                    write_body=write_body,
+                )
                 return
 
-        content = requested.read_bytes()
         content_type, _ = mimetypes.guess_type(str(requested))
         self.send_response(200)
         self.send_header("content-type", content_type or "application/octet-stream")
-        self.send_header("content-length", str(len(content)))
+        if write_body:
+            content = requested.read_bytes()
+            content_length = len(content)
+        else:
+            content = b""
+            content_length = requested.stat().st_size
+        self.send_header("content-length", str(content_length))
         self.end_headers()
-        self.wfile.write(content)
+        if write_body:
+            self.wfile.write(content)
 
     def _job_id_from_session_path(self, path: str) -> str:
         prefix = "/api/sessions/"
@@ -1243,6 +1267,31 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             self._serve_static(path)
         except Exception as exc:  # noqa: BLE001  # pragma: no cover - defensive
             self._json_runtime_error("GET", path, exc)
+
+    def do_HEAD(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        path = parsed.path
+        try:
+            if self._reject_noncanonical_rpc_route(parsed, write_body=False):
+                return
+            if self._reject_noncanonical_api_route(parsed, write_body=False):
+                return
+            if path == "/":
+                self._serve_static(path, write_body=False)
+                return
+            if self._send_known_route_unsupported_method_response(path):
+                return
+            if self._is_api_path(path):
+                self._json_response(
+                    404,
+                    {"error": {"message": "Unknown endpoint"}},
+                    write_body=False,
+                )
+                return
+
+            self._serve_static(path, write_body=False)
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - defensive
+            self._json_runtime_error("HEAD", path, exc, write_body=False)
 
     def do_POST(self):  # noqa: N802
         """

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -304,6 +304,25 @@ def test_http_rpc_head_rejects_with_json_405_and_empty_body():
     assert body == b""
 
 
+@pytest.mark.parametrize("rpc_path", ["/rpc/", "/rp%63"])
+def test_http_rpc_noncanonical_head_returns_json_404_without_body(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}{rpc_path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert body == b""
+
+
 @pytest.mark.parametrize(
     "rpc_path",
     ["/rpc/", "/rpc%2F", "/rpc%3Bdebug", "/rpc%3Fdebug=1", "/rp%63", "/%72pc"],
@@ -584,6 +603,24 @@ def test_http_head_api_sessions_rejects_with_json_405_headers_and_empty_body():
     assert body == b""
 
 
+def test_http_api_encoded_noncanonical_head_returns_json_404_without_body():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}/api%2Fsessions")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get("content-type") == "application/json"
+    assert "allow" not in {name.lower() for name in headers.keys()}
+    assert body == b""
+
+
 def test_http_unsupported_method_helper_ignores_uninitialized_handler():
     handler = _JSONRPCHandler.__new__(_JSONRPCHandler)
 
@@ -727,6 +764,68 @@ def test_http_missing_static_asset_returns_404_not_dashboard_index(path):
     assert json.loads(body.decode("utf-8")) == {
         "error": {"message": "Static asset not found"}
     }
+
+
+@pytest.mark.parametrize("path", ["/assets/missing.js", "/missing.keepgpu-test.js"])
+def test_http_head_missing_static_asset_returns_json_404_without_body(path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers.get_content_type() == "application/json"
+    assert body == b""
+
+
+@pytest.mark.parametrize(
+    ("path", "content_type"),
+    [("/", "text/html"), ("/assets/index.css", "text/css")],
+)
+def test_http_head_static_success_returns_headers_without_body(path, content_type):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}{path}")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 200
+    assert headers.get_content_type() == content_type
+    assert int(headers["content-length"]) > 0
+    assert body == b""
+
+
+def test_http_head_static_runtime_error_returns_json_500_without_body(monkeypatch):
+    server = make_server()
+
+    def fail_guess_type(_path):
+        raise RuntimeError("static exploded")
+
+    monkeypatch.setattr(server_module.mimetypes, "guess_type", fail_guess_type)
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status, headers, body = _request_http_response("HEAD", f"{base}/")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 500
+    assert headers.get_content_type() == "application/json"
+    assert body == b""
 
 
 def test_http_missing_dashboard_shell_reports_ui_not_built(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Route dashboard/static HEAD requests through structured static handling with no response body.
- Preserve API/RPC HEAD 405/404 behavior and suppress HEAD runtime-error bodies.
- Add regression coverage for missing assets, static success, noncanonical routes, and runtime errors.

## Verification
- PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_head_missing_static_asset_returns_json_404_without_body tests/mcp/test_http_api.py::test_http_head_static_success_returns_headers_without_body tests/mcp/test_http_api.py::test_http_head_static_runtime_error_returns_json_500_without_body tests/mcp/test_http_api.py::test_http_rpc_noncanonical_head_returns_json_404_without_body tests/mcp/test_http_api.py::test_http_api_encoded_noncanonical_head_returns_json_404_without_body -q
- PYTHONPATH=src pytest tests/mcp/test_http_api.py -q (131 passed)
- PYTHONPATH=src pytest tests -q (873 passed, 11 skipped)
- PYTHONPATH=src mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- git diff --check HEAD~1 HEAD

## Local review
- Local subagent review initially found two Important HEAD semantics issues: HEAD / returned 405, and HEAD runtime-error envelopes could write a body.
- Both issues were fixed and re-reviewed; reviewer reported no remaining Critical, Important, or Minor issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `HEAD` requests now return the same status and headers as `GET` for dashboard pages and static assets, but with no response body.
  * Missing asset URLs now return structured JSON `404` responses instead of falling back to the dashboard HTML shell.
  * API and RPC `HEAD` requests continue to use the expected structured JSON error responses.

* **Documentation**
  * Updated guidance to clarify expected behavior for dashboard, static asset, and API/RPC `HEAD` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->