### PR TITLE
[cli] fix: normalize busy threshold parse errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,11 @@ This file defines how coding agents should work in this repository.
   before socket bind, matching the CLI service endpoint contract. The MCP
   argparse layer must pass raw `--port` values to the shared validator so
   non-integer ports use the shared error message instead of argparse type errors.
-- `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before auto-starting the service daemon or making RPC calls.
+- `keep-gpu start` must validate local inputs such as `--vram`, `--job-id`,
+  `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before
+  auto-starting the service daemon or making RPC calls. CLI numeric options that
+  use shared validators must pass raw command-line values to those validators so
+  parse failures use KeepGPU's clean project errors instead of Typer usage text.
 - If `keep-gpu start` auto-starts a service daemon and the following
   `start_keep` RPC returns expected startup-unavailable JSON-RPC code
   `-32000` before creating a session, the CLI must best-effort stop that

--- a/docs/plans/busy-threshold-cli-validation.md
+++ b/docs/plans/busy-threshold-cli-validation.md
@@ -1,0 +1,63 @@
+# Busy-Threshold CLI Validation Plan
+
+## Background
+
+`keep-gpu start --busy-threshold abc` currently fails in Typer's integer parser
+before KeepGPU can run its shared CLI validator. That produces generic usage
+text instead of the project error message:
+`busy_threshold must be -1 or an integer between 0 and 100`.
+
+`--interval` and `--port` already accept raw command-line strings at the Typer
+boundary and then normalize through KeepGPU validators before service startup or
+RPC side effects.
+
+## Goal
+
+Make non-integer busy-threshold CLI values fail through KeepGPU's shared
+validation path, with no service auto-start or RPC calls and no Typer usage
+text.
+
+## Solution
+
+- Add RED coverage for service-mode `start --busy-threshold abc`.
+- Add focused root-mode coverage for `keep-gpu --busy-threshold abc`.
+- Preserve the existing guard that rejects blocking-mode root options before
+  service subcommands, including malformed root busy-threshold values.
+- Change the Typer boundary to accept raw busy-threshold input and parse it in
+  `_validate_cli_busy_threshold()`.
+- Keep valid explicit values and defaults behavior unchanged.
+
+## Todo
+
+- [x] Add failing regression tests.
+- [x] Record the RED failure.
+- [x] Implement the minimal parser/annotation fix.
+- [x] Update `AGENTS.md` with the raw numeric option validation contract.
+- [x] Run targeted tests, docs build, pre-commit, and diff checks.
+- [x] Commit the focused change.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'non_integer_busy_threshold or invalid_root_busy_threshold'`
+  failed with 3 failures. Each case exited with Typer code `2` instead of the
+  expected project-handled code `1`.
+- GREEN focused:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'non_integer_busy_threshold or invalid_root_busy_threshold'`
+  passed with `3 passed, 206 deselected`.
+- GREEN CLI shard:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q` passed with
+  `209 passed`.
+- Final focused regression:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'non_integer_busy_threshold or invalid_root_busy_threshold'`
+  passed with `3 passed, 206 deselected`.
+- Final CLI service-command shard:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q` passed with
+  `209 passed`.
+- Final docs build:
+  `PYTHONPATH=src mkdocs build --strict` passed. It emitted the existing
+  Material for MkDocs warning about future MkDocs 2 compatibility.
+- Final pre-commit:
+  `pre-commit run --all-files --show-diff-on-failure` passed all hooks.
+- Final whitespace check:
+  `git diff --check` passed.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -233,8 +233,8 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _apply_legacy_threshold(
-    vram_value: str, legacy_threshold: Optional[str], busy_threshold: int
-) -> Tuple[str, int, Optional[str]]:
+    vram_value: str, legacy_threshold: Optional[str], busy_threshold: Union[int, str]
+) -> Tuple[str, Union[int, str], Optional[str]]:
     """
     Interpret the deprecated --threshold flag.
 
@@ -304,7 +304,19 @@ def _validate_cli_vram(vram: str) -> str:
     return vram
 
 
-def _validate_cli_busy_threshold(busy_threshold: int) -> int:
+def _validate_cli_busy_threshold(busy_threshold: Any) -> int:
+    if isinstance(busy_threshold, str):
+        normalized = busy_threshold.strip()
+        if not normalized:
+            raise typer.BadParameter(
+                "busy_threshold must be -1 or an integer between 0 and 100"
+            )
+        try:
+            busy_threshold = int(normalized)
+        except ValueError as exc:
+            raise typer.BadParameter(
+                "busy_threshold must be -1 or an integer between 0 and 100"
+            ) from exc
     try:
         return validate_busy_threshold(busy_threshold)
     except ValueError as exc:
@@ -884,7 +896,7 @@ def _run_blocking(
     gpu_ids: Optional[str],
     vram: str,
     legacy_threshold: Optional[str],
-    busy_threshold: int,
+    busy_threshold: Union[int, str],
 ) -> None:
     vram, busy_threshold, legacy_mode = _apply_legacy_threshold(
         vram, legacy_threshold, busy_threshold
@@ -958,10 +970,11 @@ def main(
         hidden=True,
         help="Deprecated alias: numeric maps to busy-threshold, string maps to vram.",
     ),
-    busy_threshold: int = typer.Option(
-        DEFAULT_BUSY_THRESHOLD,
+    busy_threshold: str = typer.Option(
+        str(DEFAULT_BUSY_THRESHOLD),
         "--busy-threshold",
         "--util-threshold",
+        metavar="INTEGER",
         help=(
             "Back off when utilization is above this 0..100 percent threshold "
             "or telemetry is unavailable; -1 disables utilization backoff "
@@ -975,6 +988,7 @@ def main(
             _reject_root_blocking_options_before_subcommand(ctx)
             return
         interval = _validate_cli_interval(interval)
+        busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         _parse_gpu_ids(gpu_ids)
         _run_blocking(interval, gpu_ids, vram, legacy_threshold, busy_threshold)
     except typer.BadParameter as exc:
@@ -1019,10 +1033,11 @@ def start(
     interval: str = typer.Option(
         "300", metavar="NUMBER", help="Interval in seconds between checks."
     ),
-    busy_threshold: int = typer.Option(
-        DEFAULT_BUSY_THRESHOLD,
+    busy_threshold: str = typer.Option(
+        str(DEFAULT_BUSY_THRESHOLD),
         "--busy-threshold",
         "--util-threshold",
+        metavar="INTEGER",
         help=(
             "Back off when utilization is above this 0..100 percent threshold "
             "or telemetry is unavailable; -1 disables utilization backoff."

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -318,6 +318,30 @@ def test_start_command_rejects_busy_threshold_above_percent_range(monkeypatch):
     assert "busy_threshold must be -1 or an integer between 0 and 100" in result.output
 
 
+def test_start_command_rejects_non_integer_busy_threshold_before_auto_start(
+    monkeypatch,
+):
+    called = {"ensure": False, "rpc": False}
+
+    def fake_ensure(*args, **kwargs):
+        called["ensure"] = True
+        raise AssertionError("service should not be started")
+
+    def fake_rpc(*args, **kwargs):
+        called["rpc"] = True
+        raise AssertionError("RPC should not be called")
+
+    monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["start", "--busy-threshold", "abc"])
+
+    assert result.exit_code == 1
+    assert "busy_threshold must be -1 or an integer between 0 and 100" in result.output
+    assert "Usage:" not in result.output
+    assert called == {"ensure": False, "rpc": False}
+
+
 @pytest.mark.parametrize(
     ("args", "message"),
     [
@@ -1705,6 +1729,22 @@ def test_blocking_mode_rejects_non_positive_interval(monkeypatch):
     assert "interval must be positive" in result.output
 
 
+def test_blocking_mode_rejects_non_integer_busy_threshold_without_usage(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_run_blocking",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("blocking runner should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["--busy-threshold", "abc"])
+
+    assert result.exit_code == 1
+    assert "busy_threshold must be -1 or an integer between 0 and 100" in result.output
+    assert "Usage:" not in result.output
+
+
 def test_invalid_root_interval_before_subcommand_is_rejected(monkeypatch):
     monkeypatch.setattr(
         cli,
@@ -1729,6 +1769,33 @@ def test_invalid_root_interval_before_subcommand_is_rejected(monkeypatch):
     assert "Omit blocking-mode root options before service subcommands" in (
         normalized_output
     )
+
+
+def test_invalid_root_busy_threshold_before_subcommand_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "_ensure_service_running",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be started")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("RPC should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["--busy-threshold", "abc", "start"])
+
+    normalized_output = " ".join(result.output.split())
+    assert result.exit_code == 1
+    assert "--busy-threshold" in normalized_output
+    assert "Omit blocking-mode root options before service subcommands" in (
+        normalized_output
+    )
+    assert "Usage:" not in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Parse CLI busy-threshold values through the shared KeepGPU validator instead of Typer integer parsing.
- Return clean project errors for malformed --busy-threshold in service and blocking modes before service, RPC, or blocking side effects.
- Add regression tests and update AGENTS plus the implementation plan.

## Verification
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k "non_integer_busy_threshold or invalid_root_busy_threshold" (3 passed, 206 deselected)
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q (209 passed)
- PYTHONPATH=src pytest tests -q (876 passed, 11 skipped)
- PYTHONPATH=src mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- git diff --check HEAD~1 HEAD

## Local review
- Local subagent review found no Critical or Important issues.
- Minor suggestions around explicit no-blocking side-effect coverage and tighter helper typing were addressed, then re-reviewed cleanly.
