### PR TITLE
[gpu-info, mcp] fix: surface listing enumeration failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,8 @@ This file defines how coding agents should work in this repository.
 - Direct JSON-RPC and MCP tool `list_gpus` calls must classify expected
   `DeviceEnumerationUnavailableError` failures as startup-unavailable, matching
   REST `/api/gpus` `503` behavior; malformed GPU listing payloads remain
-  internal service contract errors.
+  internal service contract errors. CUDA/ROCm `torch.cuda.device_count()`
+  failures are enumeration-unavailable errors, not successful empty GPU lists.
 - CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes
   (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
@@ -263,7 +264,8 @@ This file defines how coding agents should work in this repository.
   handler exceptions drop the HTTP connection.
 - `GET /api/gpus` must report expected `DeviceEnumerationUnavailableError`
   failures as structured JSON `503` responses; arbitrary listing runtime
-  failures remain structured `500` errors.
+  failures remain structured `500` errors. CUDA/ROCm visible-device count
+  failures must not be flattened into successful empty listings.
 - The dashboard request wrapper must prefer structured REST `error.message`
   strings over raw JSON bodies so users see actionable start/refresh/release
   failures instead of protocol payloads.

--- a/docs/plans/list-gpus-enumeration-unavailable.md
+++ b/docs/plans/list-gpus-enumeration-unavailable.md
@@ -1,0 +1,56 @@
+# List GPUs Enumeration Unavailable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface CUDA/ROCm visible-device enumeration failures as startup-unavailable list-gpus errors instead of successful empty GPU lists.
+
+**Architecture:** Keep the root cause in `gpu_info`: after CUDA/ROCm is reported available, failed `torch.cuda.device_count()` or `torch.cuda.current_device()` means enumeration is unavailable, while a valid zero count remains an empty listing. `torch.cuda.is_available()` probe failures stay soft so non-CUDA fallbacks such as MPS can still work. Existing service, JSON-RPC, MCP, REST, and CLI layers already know how to classify `DeviceEnumerationUnavailableError`.
+
+**Tech Stack:** Python, pytest, KeepGPU utility/service layers, MkDocs.
+
+---
+
+## Task 1: Propagate Enumeration Failures from GPU Listing
+
+**Files:**
+- Modify: `src/keep_gpu/utilities/gpu_info.py`
+- Modify: `tests/utilities/test_gpu_info.py`
+- Modify: `tests/mcp/test_server.py`
+- Modify: `AGENTS.md`
+- Modify: `docs/reference/cli.md`
+- Create: `docs/plans/list-gpus-enumeration-unavailable.md`
+
+- [x] **Step 1: Write failing regressions**
+
+Flip the CUDA NVML count-failure test to expect `DeviceEnumerationUnavailableError`, add ROCm count-failure coverage, and add a service test that uses the real `gpu_info.get_gpu_info()` helper path through `KeepGPUServer.list_gpus()`.
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q -k 'count_fails or enumeration_unavailable'
+PYTHONPATH=src pytest tests/mcp/test_server.py -q -k 'list_gpus and enumeration'
+```
+
+Expected: fails because `get_gpu_info()` currently swallows count failures and returns an empty list.
+
+- [x] **Step 3: Implement root-cause fix**
+
+Raise `DeviceEnumerationUnavailableError` when post-availability CUDA/ROCm `torch.cuda.device_count()` or `torch.cuda.current_device()` fails in NVML, ROCm, or torch fallback listing paths. Re-raise that error through `get_gpu_info()` instead of falling back to other listing modes.
+
+- [x] **Step 4: Update docs and agent guidance**
+
+Document that list-gpus surfaces CUDA/ROCm enumeration failures as startup-unavailable instead of empty lists.
+
+- [x] **Step 5: Verify GREEN and PR**
+
+Run targeted utility/service tests, broader MCP/GPU-info tests, full tests, docs build, pre-commit, and local subagent review before opening the PR.
+
+Verification:
+- `PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q -k 'cuda_nvml_raises_when_torch_current_device_fails'`
+- `PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q -k 'availability_fails or current_device_fails or count_fails or enumeration_unavailable or mps_fallback'`
+- `PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q`
+- `PYTHONPATH=src pytest tests/mcp/test_server.py -q -k 'list_gpus or DeviceEnumerationUnavailableError or startup_unavailable'`
+- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -q -k 'api_gpus or list_gpus or startup_unavailable or enumeration_unavailable'`
+- `PYTHONPATH=src pytest tests -q`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,10 +114,12 @@ rather than advertised as
 usable `gpu_ids`. On ROCm, listed records are limited to visible ordinals that
 Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
-reported as `{"error": "..."}`. Malformed JSON-RPC service envelopes are
-reported as JSON error objects instead of empty success results; malformed GPU
-records are reported the same way. `utilization` is either `null` or a finite
-number from `0` to `100`; out-of-range telemetry is unavailable, not idle.
+reported as `{"error": "..."}`. CUDA/ROCm visible-device enumeration failures
+are reported as startup-unavailable errors instead of successful empty GPU
+lists. Malformed JSON-RPC service envelopes are reported as JSON error objects
+instead of empty success results; malformed GPU records are reported the same
+way. `utilization` is either `null` or a finite number from `0` to `100`;
+out-of-range telemetry is unavailable, not idle.
 Invalid endpoint values, including non-integer or out-of-range ports, are
 reported as JSON errors before RPC.
 

--- a/src/keep_gpu/utilities/gpu_info.py
+++ b/src/keep_gpu/utilities/gpu_info.py
@@ -11,6 +11,9 @@ from keep_gpu.utilities.cuda_visibility import (
     lookup_nvml_uuid_handle,
 )
 from keep_gpu.utilities.logger import setup_logger
+from keep_gpu.utilities.platform_manager import (
+    DeviceEnumerationUnavailableError,
+)
 from keep_gpu.utilities.rocm_visibility import (
     resolve_rocm_visible_rank_to_smi_index,
     rocm_monitor_device_count,
@@ -20,17 +23,36 @@ from keep_gpu.utilities.session_config import normalize_utilization_percent
 logger = setup_logger(__name__)
 
 
+def _visible_torch_device_count() -> int:
+    try:
+        return int(torch.cuda.device_count())
+    except Exception as exc:
+        raise DeviceEnumerationUnavailableError(
+            f"Unable to enumerate visible GPUs: {exc}"
+        ) from exc
+
+
+def _torch_cuda_current_device() -> int:
+    try:
+        return int(torch.cuda.current_device())
+    except Exception as exc:
+        raise DeviceEnumerationUnavailableError(
+            f"Unable to enumerate visible GPUs: {exc}"
+        ) from exc
+
+
 def _torch_cuda_visible_count() -> Optional[int]:
     cuda = getattr(torch, "cuda", None)
     if cuda is None:
         return None
     try:
-        if not cuda.is_available():
-            return 0
-        count = int(cuda.device_count())
+        available = bool(cuda.is_available())
     except Exception as exc:
-        logger.debug("Torch CUDA visible count failed: %s", exc)
+        logger.debug("Torch CUDA availability query failed: %s", exc)
         return None
+    if not available:
+        return 0
+    count = _visible_torch_device_count()
     if count < 0:
         return None
     return count
@@ -43,14 +65,12 @@ def _torch_cuda_visible_ordinals_startable(count: int) -> bool:
 
     current_device = None
     try:
-        try:
-            current_device = int(cuda.current_device())
-        except Exception as exc:
-            logger.debug("Torch CUDA current device query failed: %s", exc)
-
+        current_device = _torch_cuda_current_device()
         for idx in range(count):
             cuda.set_device(idx)
         return True
+    except DeviceEnumerationUnavailableError:
+        raise
     except Exception as exc:
         logger.debug("Torch CUDA visible ordinal probe failed: %s", exc)
         return False
@@ -221,10 +241,15 @@ def _query_rocm() -> List[Dict[str, Any]]:
     try:
         rocm_smi.rsmi_init()
         monitor_count = rocm_monitor_device_count(rocm_smi)
-        if torch.cuda.is_available():
-            current_device = torch.cuda.current_device()
+        try:
+            cuda_available = bool(torch.cuda.is_available())
+        except Exception as exc:
+            logger.debug("Torch ROCm availability query failed: %s", exc)
+            cuda_available = False
+        if cuda_available:
+            current_device = _torch_cuda_current_device()
         # Use torch to enumerate devices for names/memory
-        count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+        count = _visible_torch_device_count() if cuda_available else 0
         for idx in range(count):
             try:
                 torch.cuda.set_device(idx)
@@ -284,11 +309,15 @@ def _query_rocm() -> List[Dict[str, Any]]:
 
 def _query_torch() -> List[Dict[str, Any]]:
     infos: List[Dict[str, Any]] = []
-    if not torch.cuda.is_available():
-        return infos
-    current_device = torch.cuda.current_device()
     try:
-        count = torch.cuda.device_count()
+        if not torch.cuda.is_available():
+            return infos
+    except Exception as exc:
+        logger.debug("Torch CUDA availability query failed: %s", exc)
+        return infos
+    current_device = _torch_cuda_current_device()
+    try:
+        count = _visible_torch_device_count()
         for idx in range(count):
             torch.cuda.set_device(idx)
             try:
@@ -315,6 +344,8 @@ def _query_torch() -> List[Dict[str, Any]]:
                     "utilization": None,
                 }
             )
+    except DeviceEnumerationUnavailableError:
+        raise
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Torch GPU info failed: %s", exc)
     finally:
@@ -379,12 +410,16 @@ def get_gpu_info() -> List[Dict[str, Any]]:
             infos = _query_rocm()
             if infos:
                 return infos
+        except DeviceEnumerationUnavailableError:
+            raise
         except Exception as exc:
             logger.debug("ROCm info failed: %s", exc)
         try:
             infos = _query_torch()
             if infos:
                 return infos
+        except DeviceEnumerationUnavailableError:
+            raise
         except Exception as exc:
             logger.debug("Torch GPU info failed: %s", exc)
         return _query_mps()
@@ -395,6 +430,8 @@ def get_gpu_info() -> List[Dict[str, Any]]:
         infos, nvml_allows_torch_fallback = _query_nvml()
         if infos:
             return infos
+    except DeviceEnumerationUnavailableError:
+        raise
     except Exception as exc:
         logger.debug("NVML info failed: %s", exc)
 
@@ -403,6 +440,8 @@ def get_gpu_info() -> List[Dict[str, Any]]:
             infos = _query_torch()
             if infos:
                 return infos
+        except DeviceEnumerationUnavailableError:
+            raise
         except Exception as exc:
             logger.debug("Torch GPU info failed: %s", exc)
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -20,7 +20,7 @@ from keep_gpu.mcp.server import (
     SessionStartupUnavailable,
     _handle_request,
 )
-from keep_gpu.utilities import platform_manager as pm
+from keep_gpu.utilities import gpu_info, platform_manager as pm
 from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
 
 
@@ -944,6 +944,64 @@ def test_list_gpus():
     server = make_server()
     info = server.list_gpus()
     assert "gpus" in info
+
+
+def test_list_gpus_propagates_real_helper_enumeration_unavailable(
+    monkeypatch,
+):
+    class DummyNVML:
+        shutdown_calls = 0
+
+        @staticmethod
+        def nvmlInit():
+            return None
+
+        @staticmethod
+        def nvmlDeviceGetCount():
+            return 1
+
+        @classmethod
+        def nvmlShutdown(cls):
+            cls.shutdown_calls += 1
+
+    class DummyCuda:
+        @staticmethod
+        def is_available():
+            return True
+
+        @staticmethod
+        def device_count():
+            raise RuntimeError("cuda runtime unavailable")
+
+    dummy_torch = type(
+        "T",
+        (),
+        {
+            "cuda": DummyCuda(),
+            "version": type("V", (), {"hip": None}),
+            "backends": type(
+                "Backends",
+                (),
+                {
+                    "mps": type(
+                        "MPSBackend", (), {"is_available": staticmethod(lambda: False)}
+                    )
+                },
+            ),
+        },
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", DummyNVML)
+    monkeypatch.setitem(sys.modules, "rocm_smi", None)
+    monkeypatch.setattr(gpu_info, "torch", dummy_torch)
+
+    server = make_server()
+
+    with pytest.raises(
+        pm.DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: cuda runtime unavailable",
+    ):
+        server.list_gpus()
+    assert DummyNVML.shutdown_calls == 1
 
 
 def test_list_gpus_accepts_nullable_memory_and_utilization(monkeypatch):

--- a/tests/utilities/test_gpu_info.py
+++ b/tests/utilities/test_gpu_info.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 from keep_gpu.utilities import gpu_info
+from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 
 OVERSIZED_NUMERIC_TOKEN = "9" * 100
 
@@ -77,22 +78,33 @@ class DummyTorchCudaROCm:
         self,
         count: int = 2,
         *,
+        available_error: Exception | None = None,
+        current_device_error: Exception | None = None,
+        device_count_error: Exception | None = None,
         set_device_errors: "dict[int, Exception] | None" = None,
     ):
         self.count = count
+        self.available_error = available_error
+        self.current_device_error = current_device_error
+        self.device_count_error = device_count_error
         self.current = 0
         self.set_device_attempts: list[int] = []
         self.set_devices: list[int] = []
         self.set_device_errors = set_device_errors or {}
 
-    @staticmethod
-    def is_available():
+    def is_available(self):
+        if self.available_error is not None:
+            raise self.available_error
         return True
 
     def current_device(self):
+        if self.current_device_error is not None:
+            raise self.current_device_error
         return self.current
 
     def device_count(self):
+        if self.device_count_error is not None:
+            raise self.device_count_error
         return self.count
 
     def set_device(self, idx):
@@ -117,20 +129,28 @@ class DummyTorchCudaCUDA:
         count: int = 1,
         *,
         available: bool = True,
+        available_error: Exception | None = None,
+        current_device_error: Exception | None = None,
         device_count_error: Exception | None = None,
         set_device_error: Exception | None = None,
     ):
         self.count = count
         self.available = available
+        self.available_error = available_error
+        self.current_device_error = current_device_error
         self.device_count_error = device_count_error
         self.set_device_error = set_device_error
         self.current = 0
         self.set_devices: list[int] = []
 
     def is_available(self):
+        if self.available_error is not None:
+            raise self.available_error
         return self.available
 
     def current_device(self):
+        if self.current_device_error is not None:
+            raise self.current_device_error
         return self.current
 
     def device_count(self):
@@ -179,6 +199,9 @@ def _install_rocm_gpu_info_mocks(
     monkeypatch,
     *,
     count: int = 2,
+    available_error: Exception | None = None,
+    current_device_error: Exception | None = None,
+    device_count_error: Exception | None = None,
     util_by_index: dict[int, int] | None = None,
     smi_count: int = 8,
     set_device_errors: "dict[int, Exception] | None" = None,
@@ -189,6 +212,9 @@ def _install_rocm_gpu_info_mocks(
 
     dummy_cuda = DummyTorchCudaROCm(
         count=count,
+        available_error=available_error,
+        current_device_error=current_device_error,
+        device_count_error=device_count_error,
         set_device_errors=set_device_errors,
     )
     dummy_torch = type(
@@ -217,6 +243,8 @@ def _install_cuda_gpu_info_mocks(
     *,
     count: int = 1,
     available: bool = True,
+    available_error: Exception | None = None,
+    current_device_error: Exception | None = None,
     device_count_error: Exception | None = None,
     set_device_error: Exception | None = None,
     has_version: bool = True,
@@ -225,6 +253,8 @@ def _install_cuda_gpu_info_mocks(
     dummy_cuda = DummyTorchCudaCUDA(
         count=count,
         available=available,
+        available_error=available_error,
+        current_device_error=current_device_error,
         device_count_error=device_count_error,
         set_device_error=set_device_error,
     )
@@ -765,7 +795,7 @@ def test_get_gpu_info_cuda_nvml_hides_devices_when_torch_count_is_zero(monkeypat
     assert dummy_nvml.shutdown_calls == 1
 
 
-def test_get_gpu_info_cuda_nvml_hides_devices_when_torch_count_fails(monkeypatch):
+def test_get_gpu_info_cuda_nvml_raises_when_torch_count_fails(monkeypatch):
     dummy_nvml = MultiGPUDummyNVML(count=1)
     monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
     _install_cuda_gpu_info_mocks(
@@ -773,9 +803,99 @@ def test_get_gpu_info_cuda_nvml_hides_devices_when_torch_count_fails(monkeypatch
         device_count_error=RuntimeError("cuda runtime unavailable"),
     )
 
-    assert gpu_info.get_gpu_info() == []
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: cuda runtime unavailable",
+    ):
+        gpu_info.get_gpu_info()
     assert dummy_nvml.queried_indexes == []
     assert dummy_nvml.shutdown_calls == 1
+
+
+def test_get_gpu_info_cuda_nvml_raises_when_torch_current_device_fails(monkeypatch):
+    dummy_nvml = MultiGPUDummyNVML(count=1)
+    monkeypatch.setitem(sys.modules, "pynvml", dummy_nvml)
+    _install_cuda_gpu_info_mocks(
+        monkeypatch,
+        current_device_error=RuntimeError("cuda current device unavailable"),
+    )
+
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: cuda current device unavailable",
+    ):
+        gpu_info.get_gpu_info()
+    assert dummy_nvml.queried_indexes == []
+    assert dummy_nvml.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_raises_when_torch_count_fails(monkeypatch):
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        device_count_error=RuntimeError("rocm runtime unavailable"),
+    )
+
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: rocm runtime unavailable",
+    ):
+        gpu_info.get_gpu_info()
+    assert dummy_rocm.queried_indexes == []
+    assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_returns_empty_when_torch_availability_fails(monkeypatch):
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        available_error=RuntimeError("rocm availability unavailable"),
+    )
+
+    assert gpu_info.get_gpu_info() == []
+    assert dummy_rocm.queried_indexes == []
+    assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_rocm_raises_when_torch_current_device_fails(monkeypatch):
+    dummy_rocm, _ = _install_rocm_gpu_info_mocks(
+        monkeypatch,
+        current_device_error=RuntimeError("rocm current device unavailable"),
+    )
+
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: rocm current device unavailable",
+    ):
+        gpu_info.get_gpu_info()
+    assert dummy_rocm.queried_indexes == []
+    assert dummy_rocm.shutdown_calls == 1
+
+
+def test_get_gpu_info_torch_fallback_raises_when_current_device_fails(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    _install_cuda_gpu_info_mocks(
+        monkeypatch,
+        current_device_error=RuntimeError("cuda current device unavailable"),
+    )
+
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: cuda current device unavailable",
+    ):
+        gpu_info.get_gpu_info()
+
+
+def test_get_gpu_info_torch_fallback_raises_when_count_fails(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    _install_cuda_gpu_info_mocks(
+        monkeypatch,
+        device_count_error=RuntimeError("cuda fallback count unavailable"),
+    )
+
+    with pytest.raises(
+        DeviceEnumerationUnavailableError,
+        match="Unable to enumerate visible GPUs: cuda fallback count unavailable",
+    ):
+        gpu_info.get_gpu_info()
 
 
 def test_get_gpu_info_cuda_nvml_hides_devices_when_torch_set_device_fails(


### PR DESCRIPTION
## Summary
- raise `DeviceEnumerationUnavailableError` when CUDA/ROCm visible device counts fail during GPU listing
- keep `list_gpus`/`/api/gpus` aligned with startup-unavailable classification instead of returning successful empty lists
- add CUDA, ROCm, and service-level regression coverage plus docs/AGENTS guidance

## Test Plan
- [x] `PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q -k 'count_fails or enumeration_unavailable'` (RED before fix, green after)
- [x] `PYTHONPATH=src pytest tests/mcp/test_server.py -q -k 'list_gpus and enumeration'` (RED before fix, green after)
- [x] `PYTHONPATH=src pytest tests/utilities/test_gpu_info.py -q`
- [x] `PYTHONPATH=src pytest tests/mcp/test_server.py -q -k 'list_gpus or DeviceEnumerationUnavailableError or startup_unavailable'`
- [x] `PYTHONPATH=src pytest tests/mcp/test_http_api.py -q -k 'api_gpus or list_gpus or startup_unavailable or enumeration_unavailable'`
- [x] `PYTHONPATH=src pytest tests -q`
- [x] `PYTHONPATH=src mkdocs build --strict`
- [x] `pre-commit run --all-files --show-diff-on-failure`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU enumeration failures are now surfaced as unavailable errors instead of being treated like empty GPU lists.
  * CLI docs now clearly describe the updated GPU listing error behavior and telemetry handling.

* **Bug Fixes**
  * Improved GPU detection so failed CUDA/ROCm device checks propagate correctly through the app.
  * Added coverage to ensure GPU shutdown cleanup still runs when enumeration fails.

* **Documentation**
  * Updated guidance and reference docs to match the new GPU listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->