### PR TITLE
[mcp] fix: advertise job id schema contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,9 @@ This file defines how coding agents should work in this repository.
 - Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
+- MCP tool schemas that expose `job_id` must reuse the shared
+  `JOB_ID_PATTERN_TEXT` contract from `session_config.py`, so generated clients
+  see the same non-empty URL-path-safe shape enforced at runtime.
 - Stop requests must not miss starting sessions. Targeted stops wait for the
   matching startup before returning `not found`; stop-all records its initial
   active/starting boundary first, waits only for starts in that boundary, and

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -151,7 +151,8 @@ the duplicate is rejected before another controller begins keep-alive work.
 Only `null`/omitted means "generate an ID" for `start_keep` or "all sessions"
 for `status` and `stop_keep`. Custom IDs must be non-empty strings containing
 only letters, digits, `.`, `_`, `-`, or `~`; invalid IDs return an error before
-session state changes.
+session state changes. The MCP tool schemas advertise the same `job_id`
+pattern, so clients can reject invalid custom IDs before making a tool call.
 
 Status calls show reserved jobs as `state="starting"` while controller startup
 is still in progress. That includes both `status(job_id)` and the all-session

--- a/docs/plans/mcp-job-id-schema.md
+++ b/docs/plans/mcp-job-id-schema.md
@@ -1,0 +1,66 @@
+# MCP Job ID Schema Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep MCP tool schemas aligned with the shared public `job_id` validation contract.
+
+**Architecture:** `session_config.py` remains the single source for public session input validation. The MCP server imports a public job-id pattern string from that utility module and applies it to every `job_id` tool schema, so clients see the same non-empty URL-path-safe contract that runtime calls enforce.
+
+**Tech Stack:** Python, MCP JSON-RPC handlers, pytest, MkDocs.
+
+---
+
+## Task 1: Advertise the Shared Job ID Contract in MCP Schemas
+
+**Files:**
+- Modify: `src/keep_gpu/utilities/session_config.py`
+- Modify: `src/keep_gpu/mcp/server.py`
+- Modify: `tests/mcp/test_server.py`
+- Modify: `docs/guides/mcp.md`
+- Modify: `AGENTS.md`
+- Create: `docs/plans/mcp-job-id-schema.md`
+
+- [x] **Step 1: Write a failing schema regression**
+
+Extend `test_mcp_tools_list_exposes_keepgpu_actions` so `start_keep`, `stop_keep`, and `status` all require:
+
+```python
+{
+    "type": ["string", "null"],
+    "minLength": 1,
+    "pattern": JOB_ID_PATTERN_TEXT,
+}
+```
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/mcp/test_server.py -q -k tools_list_exposes_keepgpu_actions
+```
+
+Expected before the fix: the test fails because MCP schemas expose only `type`.
+
+- [x] **Step 2: Expose the runtime pattern text**
+
+Add `JOB_ID_PATTERN_TEXT = r"^[A-Za-z0-9._~-]+$"` in `session_config.py` and compile `_JOB_ID_PATTERN` from it.
+
+- [x] **Step 3: Reuse the pattern in MCP schemas**
+
+Import `JOB_ID_PATTERN_TEXT` in `mcp/server.py` and add `minLength` plus `pattern` to every MCP `job_id` schema.
+
+- [x] **Step 4: Update docs and agent contract**
+
+Mention that MCP schemas advertise the same URL-path-safe custom ID contract that runtime validation enforces.
+
+- [x] **Step 5: Verify**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/mcp/test_server.py -q -k tools_list_exposes_keepgpu_actions
+PYTHONPATH=src pytest tests/mcp/test_server.py tests/utilities/test_session_config.py -q
+PYTHONPATH=src pytest tests -q
+PYTHONPATH=src mkdocs build --strict
+pre-commit run --all-files --show-diff-on-failure
+git diff --check
+```

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -58,6 +58,7 @@ from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
+    JOB_ID_PATTERN_TEXT,
     PUBLIC_INTERVAL_MAX_SECONDS,
     is_utilization_percent_or_none,
     validate_busy_threshold,
@@ -116,6 +117,8 @@ MCP_TOOLS: List[Dict[str, Any]] = [
                 },
                 "job_id": {
                     "type": ["string", "null"],
+                    "minLength": 1,
+                    "pattern": JOB_ID_PATTERN_TEXT,
                     "description": "Optional URL-path-safe session identifier.",
                 },
             },
@@ -131,6 +134,8 @@ MCP_TOOLS: List[Dict[str, Any]] = [
             "properties": {
                 "job_id": {
                     "type": ["string", "null"],
+                    "minLength": 1,
+                    "pattern": JOB_ID_PATTERN_TEXT,
                     "description": "Session identifier; null or omitted stops all.",
                 }
             },
@@ -146,6 +151,8 @@ MCP_TOOLS: List[Dict[str, Any]] = [
             "properties": {
                 "job_id": {
                     "type": ["string", "null"],
+                    "minLength": 1,
+                    "pattern": JOB_ID_PATTERN_TEXT,
                     "description": "Session identifier; null or omitted lists all.",
                 }
             },

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -3,7 +3,8 @@ import re
 import threading
 from typing import Any, List, Optional, Union
 
-_JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9._~-]+$")
+JOB_ID_PATTERN_TEXT = r"^[A-Za-z0-9._~-]+$"
+_JOB_ID_PATTERN = re.compile(JOB_ID_PATTERN_TEXT)
 DEFAULT_BUSY_THRESHOLD = 25
 PUBLIC_INTERVAL_MAX_SECONDS = int(threading.TIMEOUT_MAX)
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -22,6 +22,7 @@ from keep_gpu.mcp.server import (
 )
 from keep_gpu.utilities import gpu_info, platform_manager as pm
 from keep_gpu.utilities.humanized_input import PUBLIC_VRAM_MAX_BYTES
+from keep_gpu.utilities.session_config import JOB_ID_PATTERN_TEXT
 
 
 class DummyController:
@@ -1267,10 +1268,11 @@ def test_mcp_tools_list_exposes_keepgpu_actions():
     assert start_schema["properties"]["interval"]["type"] == "number"
     assert start_schema["properties"]["interval"]["exclusiveMinimum"] == 0
     assert start_schema["properties"]["busy_threshold"]["default"] == 25
-    assert tools["status"]["inputSchema"]["properties"]["job_id"]["type"] == [
-        "string",
-        "null",
-    ]
+    for tool_name in ("start_keep", "stop_keep", "status"):
+        job_id_schema = tools[tool_name]["inputSchema"]["properties"]["job_id"]
+        assert job_id_schema["type"] == ["string", "null"]
+        assert job_id_schema["minLength"] == 1
+        assert job_id_schema["pattern"] == JOB_ID_PATTERN_TEXT
 
 
 def test_jsonrpc_rejects_explicit_invalid_request_version():


### PR DESCRIPTION
## Summary
- expose the shared public job_id pattern text from session_config
- advertise non-empty URL-path-safe job_id schemas for MCP start/status/stop tools
- document the MCP schema/runtime parity rule in docs and AGENTS.md

## Verification
- PYTHONPATH=src pytest tests/mcp/test_server.py -q -k tools_list_exposes_keepgpu_actions
- PYTHONPATH=src pytest tests/mcp/test_server.py tests/utilities/test_session_config.py -q
- PYTHONPATH=src pytest tests -q
- PYTHONPATH=src mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- git diff --check