### PR TITLE
[cli, service] fix: guard live daemon pid records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,9 @@ This file defines how coding agents should work in this repository.
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.
 - Keep service daemon ownership safe: no stop, force-stop, or fallback path may signal a PID unless the auto-start ownership record verifies the running process. PID records must store exact plain JSON integer `pid`, `port`, and `uid` values plus a non-empty string `start_time`; lossy numeric coercions such as floats or booleans are not ownership-verified. Non-`/proc` process metadata fallbacks are allowed only when they recover known UID and start-identity values. If auto-start spawns a daemon but cannot write a trustworthy ownership record, it must best-effort terminate that just-spawned process and fail instead of leaving an unmanaged daemon behind.
+- Auto-start must not overwrite the PID record for an ownership-verified live
+  KeepGPU daemon whose health endpoint is unavailable; fail with an actionable
+  message so the user can inspect logs or explicitly force-stop it.
 - Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -82,8 +82,12 @@ stops only an ownership-verified daemon that KeepGPU auto-started. Malformed PID
 records, including float or boolean numeric identity values, are ignored instead
 of being coerced into a process signal target. Auto-start also cleans up and
 fails if it cannot create a trustworthy ownership record for the daemon it just
-spawned. On systems without `/proc`, KeepGPU may recover daemon identity from
-platform process metadata, but unknown identity still refuses to signal.
+spawned. If auto-start finds an ownership-verified live daemon record but the
+health check is unavailable, it refuses to overwrite that record; inspect the
+service log at `~/.keepgpu/service-<host-with-dots-as-underscores>-<port>.log`
+or use `keep-gpu service-stop --force` before trying again. On systems without
+`/proc`, KeepGPU may recover daemon identity from platform process metadata, but
+unknown identity still refuses to signal.
 
 ### List telemetry
 

--- a/docs/plans/service-live-pid-guard.md
+++ b/docs/plans/service-live-pid-guard.md
@@ -1,0 +1,66 @@
+# Service Live PID Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent service auto-start from overwriting the PID record of an already-running KeepGPU daemon whose health endpoint is unavailable.
+
+**Architecture:** Keep daemon ownership decisions centralized in `src/keep_gpu/cli.py`. `_ensure_service_running()` should distinguish dead stale PID records from live ownership-verified records before spawning another daemon; only dead records are cleared for auto-start.
+
+**Tech Stack:** Python, Typer CLI helpers, pytest, MkDocs.
+
+---
+
+## Task 1: Refuse Auto-Start Over a Live Managed Daemon
+
+**Files:**
+- Modify: `src/keep_gpu/cli.py`
+- Modify: `tests/test_cli_service_commands.py`
+- Modify: `AGENTS.md`
+- Modify: `docs/guides/cli.md`
+- Modify: `docs/reference/cli.md`
+- Create: `docs/plans/service-live-pid-guard.md`
+
+- [x] **Step 1: Reproduce the overwrite risk with a failing regression**
+
+Add a focused test where `_service_available()` is false, the PID file describes
+an ownership-verified live KeepGPU daemon, and auto-start would otherwise spawn
+over the record.
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'live_managed_pid'
+```
+
+Expected before the fix: the test fails because `_ensure_service_running()`
+calls `_start_service_process()` instead of refusing to overwrite the live
+record.
+
+- [x] **Step 2: Guard live managed daemon records before auto-start**
+
+In `_ensure_service_running()`, read the full PID record after health fails. If
+the recorded PID is dead, clear the stale record and continue. If the recorded
+PID is alive and `_record_matches_running_process()` verifies it as the KeepGPU
+daemon for the requested host/port, raise a clear `RuntimeError` instructing the
+user to inspect the exact service log path or use `keep-gpu service-stop
+--force`.
+
+- [x] **Step 3: Update docs and agent contract**
+
+Document that auto-start does not overwrite a live managed daemon record when
+health is unavailable.
+
+- [x] **Step 4: Verify**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'live_managed_pid'
+PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'clears_dead_pid_record'
+PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'service_process or service_stop or pid_record or ownership or ensure_service_running'
+PYTHONPATH=src pytest tests/test_cli_service_commands.py -q
+PYTHONPATH=src pytest tests -q
+PYTHONPATH=src mkdocs build --strict
+pre-commit run --all-files --show-diff-on-failure
+git diff --check
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,11 @@ If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
 The same best-effort cleanup runs when auto-start times out before the service
-passes its health check.
+passes its health check. Auto-start refuses to overwrite an ownership-verified
+live daemon PID record when that daemon's health endpoint is unavailable; inspect
+the service log at
+`~/.keepgpu/service-<host-with-dots-as-underscores>-<port>.log` or run
+`keep-gpu service-stop --force` before retrying.
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -503,9 +503,19 @@ def _ensure_service_running(host: str, port: int, auto_start: bool = True) -> bo
     if _service_available(host, port):
         return False
 
-    stale_pid = _read_service_pid(host, port)
-    if stale_pid and not _pid_alive(stale_pid):
-        _clear_service_pid(host, port)
+    pid_record = _read_service_pid_record(host, port)
+    if pid_record is not None:
+        pid = pid_record["pid"]
+        if not _pid_alive(pid):
+            _clear_service_pid(host, port)
+        elif _record_matches_running_process(pid_record, host, port):
+            log_path = _service_log_path(host, port)
+            raise RuntimeError(
+                f"KeepGPU service daemon pid={pid} is already running at "
+                f"{host}:{port}, but its health check failed. Inspect the service "
+                f"log at {log_path} or run `keep-gpu service-stop --force` before "
+                "auto-starting another daemon."
+            )
 
     if not auto_start:
         raise RuntimeError(

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -706,12 +706,12 @@ def test_http_json_request_reports_invalid_utf8_as_service_response_error(monkey
 
 
 def test_ensure_service_running_stops_auto_started_process_on_health_timeout(
-    monkeypatch,
+    monkeypatch, tmp_path
 ):
     stopped = []
 
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
     monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
-    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: None)
     monkeypatch.setattr(cli, "_start_service_process", lambda host, port: 4321)
     monkeypatch.setattr(cli.time, "sleep", lambda seconds: None)
 
@@ -724,6 +724,66 @@ def test_ensure_service_running_stops_auto_started_process_on_health_timeout(
         cli._ensure_service_running("127.0.0.1", 8765)
 
     assert stopped == [("127.0.0.1", 8765, 1.0)]
+
+
+def test_ensure_service_running_clears_dead_pid_record_before_auto_start(
+    monkeypatch, tmp_path
+):
+    starts = []
+
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_service_available", lambda host, port: len(starts) > 0)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        cli, "_start_service_process", lambda host, port: starts.append((host, port))
+    )
+
+    auto_started = cli._ensure_service_running("127.0.0.1", 8765)
+
+    assert auto_started is True
+    assert starts == [("127.0.0.1", 8765)]
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
+def test_ensure_service_running_refuses_to_spawn_over_live_managed_pid(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli, "_service_available", lambda host, port: False)
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+    cli._write_service_pid("127.0.0.1", 8765, 4321)
+    pid_path = cli._service_pid_path("127.0.0.1", 8765)
+    original_record = pid_path.read_text(encoding="utf-8")
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: pid == 4321)
+    monkeypatch.setattr(
+        cli,
+        "_process_cmdline",
+        lambda pid: cli._service_command("127.0.0.1", 8765),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_start_service_process",
+        lambda host, port: (_ for _ in ()).throw(
+            AssertionError("auto-start must not overwrite a live PID record")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_stop_service_process",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("timeout cleanup should not run without auto-start")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="health check failed") as exc_info:
+        cli._ensure_service_running("127.0.0.1", 8765)
+
+    assert str(cli._service_log_path("127.0.0.1", 8765)) in str(exc_info.value)
+    assert pid_path.read_text(encoding="utf-8") == original_record
 
 
 def test_status_outputs_single_decoded_json_object(monkeypatch):


### PR DESCRIPTION
## Summary
- refuse service auto-start over an ownership-verified live daemon whose health check is unavailable
- preserve the existing PID record and avoid running timeout cleanup when no new daemon was started
- document the recovery path in CLI docs and AGENTS.md

## Verification
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'live_managed_pid'\n- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -k 'service_process or service_stop or pid_record or ownership or ensure_service_running'\n- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q\n- PYTHONPATH=src pytest tests -q\n- PYTHONPATH=src mkdocs build --strict\n- pre-commit run --all-files --show-diff-on-failure\n- git diff --check