### PR TITLE
[cli] fix: reject malformed rpc error messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,9 @@ This file defines how coding agents should work in this repository.
   (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
   concrete id, response IDs that compare equal but use an invalid JSON-RPC id
   type such as float or boolean, missing `result`, non-object direct-method
-  `result`, or non-object `error`) instead of treating them as successful empty
-  responses or leaking tracebacks.
+  `result`, non-object `error`, or missing/non-string `error.message`) instead
+  of treating them as successful empty responses, real service errors, or
+  leaking tracebacks.
 - CLI commands that consume service-specific JSON-RPC results must validate
   required result fields before rendering user-facing output; malformed
   method-specific payloads should become clean `ServiceResponseError` messages,
@@ -232,8 +233,8 @@ This file defines how coding agents should work in this repository.
 - If `keep-gpu start` auto-starts a service daemon and the following
   `start_keep` RPC returns expected startup-unavailable JSON-RPC code
   `-32000` before creating a session, the CLI must best-effort stop that
-  just-created daemon. Do not stop already-running daemons, malformed success
-  payloads, or unrelated RPC failures.
+  just-created daemon. Do not stop already-running daemons, malformed JSON-RPC
+  envelopes, malformed success payloads, or unrelated RPC failures.
 - If service auto-start itself times out before the health check succeeds, the
   CLI must best-effort stop the just-started managed daemon and preserve the
   auto-start timeout error.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -31,6 +31,9 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 If this invocation auto-starts the service but session creation fails with an
 expected startup-unavailable error before a session is created, `start`
 best-effort stops the just-created daemon so it does not remain idle.
+Malformed JSON-RPC service envelopes, including missing or non-string
+`error.message`, are reported as response errors and do not trigger this
+startup-unavailable rollback.
 If auto-start times out before the service becomes healthy, the CLI applies the
 same best-effort cleanup to the daemon it just started.
 
@@ -103,8 +106,9 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. `status`, `stop`, and `list-gpus` print JSON objects,
 including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
-Malformed JSON-RPC service envelopes and malformed method-specific result
-records are reported as JSON error objects instead of empty success results.
+Malformed JSON-RPC service envelopes, including missing or non-string
+`error.message`, and malformed method-specific result records are reported as
+JSON error objects instead of empty success results.
 Utilization values are either `null` or finite percentages from `0` to `100`;
 out-of-range vendor readings are displayed as unavailable telemetry.
 Response IDs must echo the request ID with a valid matching JSON-RPC ID type.

--- a/docs/plans/cli-rpc-error-message.md
+++ b/docs/plans/cli-rpc-error-message.md
@@ -1,0 +1,48 @@
+# CLI RPC Error Message Validation Plan
+
+> **For agentic workers:** Follow this plan task-by-task. Use test-first changes for code behavior.
+
+**Goal:** Reject malformed JSON-RPC error objects before they can be mistaken for real service failures.
+
+**Architecture:** Keep `_rpc_call()` responsible only for generic JSON-RPC envelope validation. A service error is a `ServiceRPCError` only when the error object has a usable integer code, if present, and a string `message`; malformed error envelopes remain `ServiceResponseError` and must not trigger daemon rollback.
+
+**Tech Stack:** Python, Typer CLI, pytest, MkDocs.
+
+---
+
+### Task 1: Reproduce the malformed error envelope
+
+**Files:**
+- Modify: `tests/test_cli_service_commands.py`
+
+- [ ] Add a test showing `_rpc_call()` raises `ServiceResponseError` when `error.message` is missing or not a string.
+- [ ] Add a test showing `keep-gpu start` does not stop a just-auto-started daemon when the `start_keep` response has `code=-32000` but a malformed `error.message`.
+- [ ] Run the focused tests and confirm they fail for the current behavior.
+
+### Task 2: Validate `error.message`
+
+**Files:**
+- Modify: `src/keep_gpu/cli.py`
+
+- [ ] Require JSON-RPC error objects to contain a string `message` before raising `ServiceRPCError`.
+- [ ] Leave method-specific result validation at CLI call sites.
+- [ ] Run the focused tests and confirm they pass.
+
+### Task 3: Keep docs aligned
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/guides/cli.md`
+- Modify: `docs/reference/cli.md`
+
+- [ ] Document that malformed JSON-RPC error objects include missing or non-string `error.message`.
+- [ ] Document that malformed service envelopes do not trigger startup-unavailable daemon rollback.
+
+### Task 4: Verify and publish
+
+- [ ] Run `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q`.
+- [ ] Run `PYTHONPATH=src pytest tests -q`.
+- [ ] Run `mkdocs build --strict`.
+- [ ] Run `pre-commit run --all-files --show-diff-on-failure`.
+- [ ] Run `git diff --check`.
+- [ ] Commit, push, open a PR, run local subagent review, resolve comments, wait for hosted checks, and squash merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,6 +48,8 @@ GPUs; explicit empty or whitespace-only values are invalid.
 If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
+Malformed JSON-RPC service envelopes, including missing or non-string
+`error.message`, are response errors and do not trigger this rollback.
 The same best-effort cleanup runs when auto-start times out before the service
 passes its health check. Auto-start refuses to overwrite an ownership-verified
 live daemon PID record when that daemon's health endpoint is unavailable; inspect
@@ -75,8 +77,8 @@ the service log at
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes and malformed status job records are reported as JSON error objects
-instead of empty success results.
+envelopes, including missing or non-string `error.message`, and malformed status
+job records are reported as JSON error objects instead of empty success results.
 Started sessions with terminal worker allocation/runtime failures remain listed
 as `state="runtime_failed"` with `last_error` and can still be stopped. Normal
 busy-GPU or unavailable-telemetry backoff keeps the session active; it is not a
@@ -104,8 +106,9 @@ later starts.
 in deterministic snapshot order with the same additive response fields.
 The output is a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes and malformed stop result records are reported as JSON error objects
-instead of empty success results.
+envelopes, including missing or non-string `error.message`, and malformed stop
+result records are reported as JSON error objects instead of empty success
+results.
 
 ### `keep-gpu list-gpus`
 
@@ -120,9 +123,10 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
 reported as `{"error": "..."}`. CUDA/ROCm visible-device enumeration failures
 are reported as startup-unavailable errors instead of successful empty GPU
-lists. Malformed JSON-RPC service envelopes are reported as JSON error objects
-instead of empty success results; malformed GPU records are reported the same
-way. `utilization` is either `null` or a finite number from `0` to `100`;
+lists. Malformed JSON-RPC service envelopes, including missing or non-string
+`error.message`, are reported as JSON error objects instead of empty success
+results; malformed GPU records are reported the same way. `utilization` is
+either `null` or a finite number from `0` to `100`;
 out-of-range telemetry is unavailable, not idle.
 Invalid endpoint values, including non-integer or out-of-range ports, are
 reported as JSON errors before RPC.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -665,7 +665,12 @@ def _rpc_call(
         code = error.get("code")
         if isinstance(code, bool) or not isinstance(code, int):
             code = None
-        raise ServiceRPCError(error.get("message", str(error)), code=code)
+        message = error.get("message")
+        if not isinstance(message, str):
+            raise ServiceResponseError(
+                "Malformed JSON-RPC response: error.message must be a string"
+            )
+        raise ServiceRPCError(message, code=code)
     if not _jsonrpc_response_id_matches(response.get("id"), payload["id"]):
         raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
     if "result" not in response:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1630,7 +1630,7 @@ def test_rpc_call_rejects_error_envelope_without_string_message(monkeypatch, err
     )
 
     with pytest.raises(
-        cli.ServiceResponseError, match="error.message must be a string"
+        cli.ServiceResponseError, match=re.escape("error.message must be a string")
     ):
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1613,6 +1613,28 @@ def test_rpc_call_rejects_error_envelope_with_non_object_error(monkeypatch):
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        {"code": -32603},
+        {"code": -32603, "message": None},
+        {"code": -32603, "message": []},
+    ],
+)
+def test_rpc_call_rejects_error_envelope_without_string_message(monkeypatch, error):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1000, "error": error},
+    )
+
+    with pytest.raises(
+        cli.ServiceResponseError, match="error.message must be a string"
+    ):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
 def test_rpc_call_rejects_error_envelope_with_null_id(monkeypatch):
     monkeypatch.setattr(cli.time, "time", lambda: 1.0)
     monkeypatch.setattr(
@@ -1993,6 +2015,33 @@ def test_start_does_not_stop_auto_started_service_for_malformed_success_payload(
 
     assert result.exit_code == 1
     assert "start_keep result must include job_id" in result.output
+    assert stopped == []
+
+
+def test_start_does_not_stop_auto_started_service_for_malformed_error_envelope(
+    monkeypatch,
+):
+    stopped = []
+
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {
+            "jsonrpc": "2.0",
+            "id": 1000,
+            "error": {"code": cli.JSONRPC_STARTUP_UNAVAILABLE, "message": []},
+        },
+    )
+    monkeypatch.setattr(
+        cli, "_stop_service_process", lambda host, port: stopped.append((host, port))
+    )
+
+    result = runner.invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "error.message must be a string" in result.output
     assert stopped == []
 
 


### PR DESCRIPTION
## Summary
- reject JSON-RPC error envelopes with missing or non-string `error.message` as malformed service responses
- prevent malformed `start_keep` error envelopes from triggering startup-unavailable daemon rollback
- update AGENTS.md and CLI docs to keep the protocol/rollback contract explicit

## Verification
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q`
- `PYTHONPATH=src pytest tests -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

## Notes
- README keeps the Zenodo DOI badge in the top badge block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CLI error handling so malformed JSON-RPC responses are treated as errors instead of being mistaken for successful results.
  * Ensured startup cleanup is skipped when the service error response is malformed, preventing unintended stop attempts.

* **Documentation**
  * Clarified CLI behavior for `start`, `status`, `stop`, and `list-gpus` when responses or records are malformed.
  * Added a new planning document outlining the expected error-validation and testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->