### PR TITLE
[docs] fix: describe eco-safe overview backoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,11 @@ This file defines how coding agents should work in this repository.
   making KeepGPU sound CUDA-only or treating MCP as experimental. Mac M/MPS docs
   must also explain that utilization telemetry is unavailable, so users need
   `busy_threshold=-1` only when they intentionally want unconditional MPS
-  keepalive work.
+  keepalive work. Public overview docs must not imply unconditional allocation
+  under the default eco-safe backoff; describe allocation and keepalive compute
+  as running only when utilization backoff permits, with the loop backing off
+  when telemetry is unavailable unless users explicitly choose
+  `busy_threshold=-1`.
 - Keep the MCP server compatible with standard MCP lifecycle/tool methods
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,12 @@
 # KeepGPU
 
-> Keep a GPU busy so the scheduler, lab mate, or cluster watchdog does not take it away.
+> Hold a GPU reservation politely while the scheduler, lab mate, or cluster watchdog waits.
 
-KeepGPU is a tiny-but-focused toolkit that continuously allocates VRAM and launches
-low-cost platform-specific keep-alive work so that a GPU always looks “in use.”
-You can run it as a CLI while you prep data, or embed the controllers directly
-in Python to guard resources during longer CPU-bound sections of your workflow.
+KeepGPU is a tiny-but-focused toolkit that allocates memory and runs low-cost
+platform-specific keep-alive work when utilization backoff permits. When
+utilization telemetry is unavailable, the default loop backs off and sleeps
+instead of forcing compute; `--busy-threshold -1` is the explicit unconditional
+keepalive mode, especially on Mac M/MPS.
 
 ## Why it matters
 

--- a/docs/plans/docs-eco-safe-overview.md
+++ b/docs/plans/docs-eco-safe-overview.md
@@ -1,0 +1,33 @@
+# Docs Eco-Safe Overview Plan
+
+## Background
+
+The public overview claimed that KeepGPU continuously allocates VRAM and makes a
+GPU always look in use. That overstates the default behavior because unavailable
+telemetry makes the default loop back off when `busy_threshold >= 0`.
+
+## Goal
+
+Keep the overview concise while making the eco-safe contract clear: allocation
+and keepalive work happen only when utilization backoff permits, and
+`busy_threshold=-1` is the explicit unconditional mode.
+
+## Tasks
+
+- [x] Add a RED doc guard for unconditional overview claims.
+- [x] Update `docs/index.md` with the backoff caveat.
+- [x] Add an `AGENTS.md` contract note for future overview edits.
+- [x] Run the focused guard.
+- [x] Run the strict docs build.
+
+## Verification
+
+- RED:
+  `pytest tests/test_package_metadata.py::test_index_overview_describes_eco_safe_backoff_without_unconditional_claims -q`
+  failed because `docs/index.md` still said `continuously allocates`.
+- GREEN:
+  the same focused guard passed after the overview described unavailable
+  telemetry backoff and the explicit unconditional mode.
+- DOCS:
+  `PYTHONPATH=$PWD/src mkdocs build --strict` passed with the existing Material
+  for MkDocs warning.

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -202,6 +202,21 @@ def test_public_docs_do_not_regress_to_cuda_only_or_experimental_mcp():
     assert "--busy-threshold -1" in public_docs["getting_started"]
 
 
+def test_index_overview_describes_eco_safe_backoff_without_unconditional_claims():
+    index = (PROJECT_ROOT / "docs/index.md").read_text(encoding="utf-8")
+    normalized_index = re.sub(r"\s+", " ", index.lower())
+
+    assert "continuously allocates" not in normalized_index
+    assert "always looks" not in normalized_index
+    assert re.search(
+        r"(?:utilization )?telemetry is unavailable.*back(?:s)? off"
+        r"|back(?:s)? off.*(?:utilization )?telemetry is unavailable",
+        normalized_index,
+    )
+    assert "--busy-threshold -1" in normalized_index
+    assert "unconditional" in normalized_index
+
+
 def test_rest_session_docs_distinguish_empty_gpu_ids_from_empty_listing():
     public_docs = {
         "cli_reference": (PROJECT_ROOT / "docs/reference/cli.md").read_text(

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -209,8 +209,8 @@ def test_index_overview_describes_eco_safe_backoff_without_unconditional_claims(
     assert "continuously allocates" not in normalized_index
     assert "always looks" not in normalized_index
     assert re.search(
-        r"(?:utilization )?telemetry is unavailable.*back(?:s)? off"
-        r"|back(?:s)? off.*(?:utilization )?telemetry is unavailable",
+        r"(?:utilization )?telemetry is unavailable.*back(?:s|ing)?\s*-?\s*off"
+        r"|back(?:s|ing)?\s*-?\s*off.*(?:utilization )?telemetry is unavailable",
         normalized_index,
     )
     assert "--busy-threshold -1" in normalized_index


### PR DESCRIPTION
## Summary
- replace unconditional overview wording with the eco-safe backoff contract
- add a doc guard against `continuously allocates` / `always looks` regressions
- update AGENTS.md and add a focused plan doc

## Verification
- `PYTHONPATH=src pytest tests/test_package_metadata.py -q`
- `PYTHONPATH=src pytest tests -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

## Notes
- README is untouched and keeps the Zenodo DOI badge.