### PR TITLE
[mcp] fix: reject leading slash route aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,22 +138,22 @@ This file defines how coding agents should work in this repository.
   responses. `/api/sessions/{job_id}` accepts exactly one raw path component;
   raw extra segments such as `/api/sessions/foo/bar` are unknown routes.
 - Encoded or otherwise noncanonical route spellings whose raw or decoded target
-  is API-shaped (`/api`, `/api/...`, `/api;...`, `/api?...`, or `/api#...`)
-  must return structured JSON `404 Unknown endpoint` responses instead of
-  serving the dashboard/static fallback or `BaseHTTPRequestHandler` HTML errors.
-  Exact API endpoints such as `/api/gpus` must not accept params, query strings,
-  or fragments unless the handler explicitly documents those components.
-  Canonical API paths may still validate encoded `job_id` path components
-  normally.
+  is API-shaped (`//api/...`, `/api`, `/api/...`, `/api;...`, `/api?...`, or
+  `/api#...`) must return structured JSON `404 Unknown endpoint` responses
+  instead of serving the dashboard/static fallback or `BaseHTTPRequestHandler`
+  HTML errors. Exact API endpoints such as `/api/gpus` must not accept params,
+  query strings, or fragments unless the handler explicitly documents those
+  components. Canonical API paths may still validate encoded `job_id` path
+  components normally.
 - Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)
   must call the shared unsupported-method helper before local unknown-endpoint
   404 branches, so known paths never regress to 404 or body-parse errors solely
   because the wrong implemented verb was used.
 - `/rpc` is an exact POST-only JSON-RPC endpoint; `GET /rpc` must return
   structured JSON `405 Method Not Allowed` with `Allow: POST`, while
-  noncanonical spellings such as `/rpc/`, `/rpc;...`, `/rpc?...`, `/rp%63`, and
-  `/%72pc` return structured JSON `404 Unknown endpoint` without JSON-RPC
-  dispatch or dashboard/static fallback.
+  noncanonical spellings such as `//rpc`, `/rpc/`, `/rpc;...`, `/rpc?...`,
+  `/rp%63`, and `/%72pc` return structured JSON `404 Unknown endpoint` without
+  JSON-RPC dispatch or dashboard/static fallback.
 - Missing dashboard asset URLs, including `GET`/`HEAD` requests for `/assets/*`
   and extension-bearing static paths, must return structured JSON `404` errors
   instead of the dashboard HTML shell; `HEAD` responses must not include a body.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -10,7 +10,8 @@ KeepGPU ships a local service that powers four local surfaces:
 This is the same backend used by `keep-gpu start/status/stop/list-gpus`.
 Exact `/api` and unknown `/api/*` paths return structured JSON `404` errors
 instead of dashboard HTML. `/api/sessions/{job_id}` uses one raw path component;
-extra raw path segments are unknown endpoints.
+extra raw path segments are unknown endpoints. Noncanonical raw aliases such as
+`//api/sessions` are also unknown endpoints and do not start or stop sessions.
 Missing packaged asset URLs also return JSON `404` responses instead of the
 dashboard shell.
 
@@ -63,8 +64,8 @@ envelopes.
 HTTP mode is KeepGPU's local JSON-RPC/REST/dashboard service. It accepts the
 same JSON-RPC message shapes at the exact `/rpc` endpoint, but it is not a
 Streamable HTTP MCP endpoint. Noncanonical `/rpc` URLs, including trailing
-slashes, query strings, or encoded aliases such as `/rp%63`, return structured
-`404 Unknown endpoint` errors.
+slashes, query strings, leading double slashes such as `//rpc`, or encoded
+aliases such as `/rp%63`, return structured `404 Unknown endpoint` errors.
 
 Malformed HTTP JSON-RPC bodies return a JSON-RPC `-32700 Parse error` envelope
 with `id: null`; REST routes keep REST-shaped JSON errors.

--- a/docs/plans/rpc-leading-slash-routes.md
+++ b/docs/plans/rpc-leading-slash-routes.md
@@ -1,0 +1,24 @@
+# RPC Leading Slash Routes Plan
+
+## Background
+
+Python's `BaseHTTPRequestHandler` collapses request targets that begin with
+`//` before KeepGPU route checks read `self.path`. That can make raw targets such
+as `//api/sessions` and `//rpc` behave like canonical API/RPC routes.
+
+## Goal
+
+Reject raw leading-double-slash API/RPC aliases as structured JSON
+`404 Unknown endpoint` responses before body parsing, JSON-RPC dispatch, or REST
+session side effects.
+
+## Tasks
+
+- [x] Add raw-socket regression tests for `POST //api/sessions`,
+  `DELETE //api/sessions/{job_id}`, and `POST //rpc`.
+- [x] Capture or derive the raw request target before relying on normalized
+  `self.path`.
+- [x] Reuse the existing noncanonical API/RPC structured 404 helpers.
+- [x] Update API/RPC docs and `AGENTS.md` to call out leading `//` aliases.
+- [x] Run targeted MCP HTTP tests, full tests, docs build, pre-commit, and
+  `git diff --check`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -160,7 +160,8 @@ creation returns `503`, and unexpected service/runtime failures return `500`
 instead of dropping the connection. Encoded noncanonical spellings such as
 `/api%2Fsessions`, `/api%3Bdebug`, or `/api%3Fsessions` are treated as
 unknown API routes and return JSON `404` responses rather than the dashboard
-HTML shell.
+HTML shell. Raw leading-double-slash API aliases such as `//api/sessions` are
+also unknown routes and do not start or stop sessions.
 The dashboard consumes those JSON objects and displays `error.message` when it is
 present, falling back to the plain response body or HTTP status only when needed.
 Direct JSON-RPC service calls report the same expected hardware/platform
@@ -177,7 +178,7 @@ enumeration, with error code `-32000`; arbitrary runtime failures remain
 | `/api/sessions` | POST | Start session with a JSON object body (`gpu_ids`, `vram`, finite positive bounded `interval`, `busy_threshold`, `job_id`); `vram` accepts human sizes or bytes up to 1 PiB byte-equivalent, omitted `gpu_ids` means all GPUs visible to the service process, omitted `busy_threshold` uses `25`, and duplicate or out-of-range selections are invalid. Explicit `gpu_ids` are checked against a validated `list_gpus()` response; an explicit empty `gpu_ids` list is invalid, an empty validated GPU listing is `503`, and malformed listing payloads are structured `500` errors before any session starts. |
 | `/api/sessions` | DELETE | Stop all sessions; returns `stopped`, `timed_out`, `failed`, and `errors`. |
 | `/api/sessions/{job_id}` | DELETE | Stop one session; returns `stopped`, `timed_out`, `failed`, and `errors`. |
-| `/rpc` | POST | Exact JSON-RPC compatibility endpoint; noncanonical `/rpc` URLs, including encoded exact aliases, return structured `404` errors. |
+| `/rpc` | POST | Exact JSON-RPC compatibility endpoint; noncanonical `/rpc` URLs, including leading `//rpc` and encoded exact aliases, return structured `404` errors. |
 | `/` | GET | Dashboard UI. |
 
 ## Environment variables

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1024,8 +1024,36 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
     def _is_api_path(path: str) -> bool:
         return path == "/api" or path.startswith("/api/")
 
+    @staticmethod
+    def _request_target_from_raw_requestline(raw_requestline: bytes) -> Optional[str]:
+        request_line = raw_requestline.decode("iso-8859-1").rstrip("\r\n")
+        parts = request_line.split()
+        if len(parts) < 2:
+            return None
+        return parts[1]
+
+    def _raw_request_target(self) -> Optional[str]:
+        raw_requestline = getattr(self, "raw_requestline", b"")
+        if not isinstance(raw_requestline, bytes):
+            return None
+        return self._request_target_from_raw_requestline(raw_requestline)
+
+    @staticmethod
+    def _collapse_leading_slash_target(raw_target: Optional[str]) -> Optional[str]:
+        if raw_target is None or not raw_target.startswith("//"):
+            return None
+        return "/" + raw_target.lstrip("/")
+
     @classmethod
-    def _is_noncanonical_api_route(cls, parsed) -> bool:
+    def _is_noncanonical_api_route(
+        cls, parsed, raw_target: Optional[str] = None
+    ) -> bool:
+        collapsed_raw = cls._collapse_leading_slash_target(raw_target)
+        if collapsed_raw is not None:
+            raw_parsed = urlparse(collapsed_raw)
+            route_paths = (raw_parsed.path, unquote(raw_parsed.path))
+            if any(cls._is_api_path(path) for path in route_paths):
+                return True
         if parsed.path == "/api/gpus" and bool(
             parsed.params or parsed.query or parsed.fragment
         ):
@@ -1038,8 +1066,16 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             for path in route_paths
         ) or any(path == "/api" for path in route_paths)
 
-    @staticmethod
-    def _is_noncanonical_rpc_route(parsed) -> bool:
+    @classmethod
+    def _is_noncanonical_rpc_route(
+        cls, parsed, raw_target: Optional[str] = None
+    ) -> bool:
+        collapsed_raw = cls._collapse_leading_slash_target(raw_target)
+        if collapsed_raw is not None:
+            raw_parsed = urlparse(collapsed_raw)
+            route_paths = (raw_parsed.path, unquote(raw_parsed.path))
+            if any(path == "/rpc" for path in route_paths):
+                return True
         route_paths = (parsed.path, unquote(parsed.path))
         return (
             any(
@@ -1054,7 +1090,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         )
 
     def _reject_noncanonical_rpc_route(self, parsed, write_body: bool = True) -> bool:
-        if not self._is_noncanonical_rpc_route(parsed):
+        if not self._is_noncanonical_rpc_route(parsed, self._raw_request_target()):
             return False
         self._json_response(
             404,
@@ -1064,7 +1100,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         return True
 
     def _reject_noncanonical_api_route(self, parsed, write_body: bool = True) -> bool:
-        if not self._is_noncanonical_api_route(parsed):
+        if not self._is_noncanonical_api_route(parsed, self._raw_request_target()):
             return False
         self._json_response(
             404,

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -142,18 +142,8 @@ def _allow_methods(headers):
     }
 
 
-def _raw_post_with_content_length(httpd, path: str, content_length: str):
+def _send_raw_http_json_request(httpd, request: bytes):
     host, port = httpd.server_address
-    request = (
-        f"POST {path} HTTP/1.1\r\n"
-        f"Host: {host}:{port}\r\n"
-        "Content-Type: application/json\r\n"
-        f"Content-Length: {content_length}\r\n"
-        "Connection: close\r\n"
-        "\r\n"
-        "{}"
-    ).encode("ascii")
-
     with socket.create_connection((host, port), timeout=2.0) as sock:
         sock.settimeout(2.0)
         sock.sendall(request)
@@ -176,6 +166,39 @@ def _raw_post_with_content_length(httpd, path: str, content_length: str):
     status_line = header_bytes.splitlines()[0].decode("iso-8859-1")
     status_code = int(status_line.split()[1])
     return status_code, json.loads(body.decode("utf-8")) if body else {}
+
+
+def _raw_post_with_content_length(httpd, path: str, content_length: str):
+    host, port = httpd.server_address
+    request = (
+        f"POST {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {content_length}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+        "{}"
+    ).encode("ascii")
+    return _send_raw_http_json_request(httpd, request)
+
+
+def _raw_http_json_request(httpd, method: str, target: str, payload=None):
+    host, port = httpd.server_address
+    if payload is None:
+        body = b""
+    elif isinstance(payload, bytes):
+        body = payload
+    else:
+        body = json.dumps(payload).encode("utf-8")
+    request = (
+        f"{method} {target} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("ascii") + body
+    return _send_raw_http_json_request(httpd, request)
 
 
 @pytest.mark.parametrize(
@@ -383,6 +406,27 @@ def test_http_rpc_encoded_exact_alias_rejects_before_jsonrpc_parse(rpc_path):
     assert payload["error"]["message"] == "Unknown endpoint"
 
 
+def test_http_rpc_raw_double_slash_rejects_before_jsonrpc_parse():
+    server = make_server()
+    httpd, thread, _ = _start_http_server(server)
+
+    try:
+        status, payload = _raw_http_json_request(
+            httpd,
+            "POST",
+            "//rpc",
+            b"{bad json",
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+
+
 @pytest.mark.parametrize("rpc_path", ["/rp%63", "/%72pc"])
 def test_http_rpc_encoded_exact_alias_unsupported_method_returns_json_404(rpc_path):
     server = make_server()
@@ -462,6 +506,67 @@ def test_http_encoded_api_routes_return_json_404_without_static_fallback(path):
     assert json.loads(body.decode("utf-8")) == {
         "error": {"message": "Unknown endpoint"}
     }
+
+
+def test_http_raw_double_slash_api_sessions_post_returns_404_without_start():
+    server = make_server()
+    httpd, thread, _ = _start_http_server(server)
+
+    try:
+        status, payload = _raw_http_json_request(
+            httpd,
+            "POST",
+            "//api/sessions",
+            {
+                "job_id": "double-slash-start",
+                "gpu_ids": [0],
+                "vram": "64MB",
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+    assert server.status()["active_jobs"] == []
+
+
+def test_http_raw_double_slash_api_session_delete_returns_404_without_stop():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        _, start_payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {
+                "job_id": "double-slash-stop",
+                "gpu_ids": [0],
+                "vram": "64MB",
+                "interval": 20,
+                "busy_threshold": 5,
+            },
+        )
+        job_id = start_payload["job_id"]
+
+        status, payload = _raw_http_json_request(
+            httpd, "DELETE", f"//api/sessions/{job_id}"
+        )
+        _, status_payload = _request_json("GET", f"{base}/api/sessions")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert payload == {"error": {"message": "Unknown endpoint"}}
+    assert [job["job_id"] for job in status_payload["active_jobs"]] == [job_id]
 
 
 def test_http_encoded_api_route_unsupported_method_returns_json_404():


### PR DESCRIPTION
## Summary
- reject raw leading-double-slash API/RPC aliases before REST side effects or JSON-RPC parsing
- add raw-socket regressions for `//api/sessions`, `//api/sessions/{job_id}`, and `//rpc`
- document the noncanonical route contract in AGENTS.md and API docs

## Verification
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -q -k 'raw_double_slash or content_length'`
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -q`
- `PYTHONPATH=src pytest tests -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

## Notes
- README is untouched and keeps the Zenodo DOI badge.