### PR TITLE
[controller] fix: propagate startup allocation failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,9 +315,11 @@ This file defines how coding agents should work in this repository.
   Non-OOM allocation or steady-state `RuntimeError` failures after startup must
   be retained as runtime failures.
 - Single-GPU `keep()` must not report success until fatal backend startup setup
-  has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors
-  and MPS first-allocation setup failures must propagate synchronously so
-  services cannot register false active sessions.
+  has succeeded. CUDA/ROCm worker startup failures such as `set_device` errors,
+  first permitted non-OOM allocation failures, and MPS first-allocation setup
+  failures must propagate synchronously so services cannot register false active
+  sessions. Eco-safe busy/unknown-telemetry deferral and recoverable OOM retries
+  may still complete startup without allocating.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,8 @@ This file defines how coding agents should work in this repository.
   first permitted non-OOM allocation failures, and MPS first-allocation setup
   failures must propagate synchronously so services cannot register false active
   sessions. Eco-safe busy/unknown-telemetry deferral and recoverable OOM retries
-  may still complete startup without allocating.
+  may still complete startup without allocating; recoverable OOM retries must
+  clear the backend cache before sleeping and retrying.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,9 @@ This file defines how coding agents should work in this repository.
   sessions. Eco-safe busy/unknown-telemetry deferral and recoverable OOM retries
   may still complete startup without allocating; recoverable OOM retries must
   clear the backend cache before sleeping and retrying.
+- Internal single-GPU startup paths that receive a `startup_evt` must always
+  signal it before returning, and paths without a `startup_errors` list must
+  retain the failure detail in `allocation_status()`.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -50,7 +50,10 @@ CLI args ──▶ GlobalGPUController ──▶ [backend controller rank=0]
      device count before `torch.device`, `set_device`, telemetry, or allocation
      can target an invalid ordinal.
    - Starts a daemon thread and confirms fatal backend startup setup before
-     `keep()` reports success.
+     `keep()` reports success. When backoff permits an initial allocation, a
+     fatal non-OOM allocation failure is still a startup failure; busy/unknown
+     telemetry deferral and recoverable OOM retries remain normal startup
+     progress.
    - Performs intervalled lightweight elementwise batches after startup.
    - Calls `_monitor_utilization` (by way of NVML) to detect real activity
      before allocating the keep tensor.
@@ -116,9 +119,10 @@ Elementwise keep-alive batches:
   visible and can still be stopped. Busy-GPU or unavailable-telemetry deferral is
   normal backoff behavior and does not change an active session to
   `runtime_failed`.
-- Fatal backend startup errors are reported before `keep()` returns. Recoverable
-  later runtime errors are logged, and recoverable allocation failures retry
-  after clearing the device cache.
+- Fatal backend startup errors are reported before `keep()` returns, including a
+  first permitted non-OOM allocation failure. Recoverable later runtime errors
+  are logged, and recoverable allocation failures retry after clearing the device
+  cache.
 
 ## Platform detection
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -123,7 +123,9 @@ Elementwise keep-alive batches:
 - Fatal backend startup errors are reported before `keep()` returns, including a
   first permitted non-OOM allocation failure. Recoverable later runtime errors
   are logged, and recoverable startup or runtime allocation failures retry after
-  clearing the device cache.
+  clearing the device cache. Internal startup waiters are always signaled before
+  the worker returns, and no-error-list internal paths retain failure details in
+  `allocation_status()`.
 
 ## Platform detection
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -53,7 +53,8 @@ CLI args ──▶ GlobalGPUController ──▶ [backend controller rank=0]
      `keep()` reports success. When backoff permits an initial allocation, a
      fatal non-OOM allocation failure is still a startup failure; busy/unknown
      telemetry deferral and recoverable OOM retries remain normal startup
-     progress.
+     progress. Recoverable OOM retries clear the device cache before the next
+     attempt.
    - Performs intervalled lightweight elementwise batches after startup.
    - Calls `_monitor_utilization` (by way of NVML) to detect real activity
      before allocating the keep tensor.
@@ -121,8 +122,8 @@ Elementwise keep-alive batches:
   `runtime_failed`.
 - Fatal backend startup errors are reported before `keep()` returns, including a
   first permitted non-OOM allocation failure. Recoverable later runtime errors
-  are logged, and recoverable allocation failures retry after clearing the device
-  cache.
+  are logged, and recoverable startup or runtime allocation failures retry after
+  clearing the device cache.
 
 ## Platform detection
 

--- a/docs/plans/controller-startup-allocation-handshake.md
+++ b/docs/plans/controller-startup-allocation-handshake.md
@@ -30,6 +30,8 @@ real progress safely or intentionally deferred work for eco-safe backoff.
       failure.
 - [x] Add public `keep()` coverage for eco-safe deferral, recoverable OOM retry,
       and bounded ROCm OOM exhaustion.
+- [x] Resolve review feedback so failure paths always signal any startup event,
+      including internal calls without a `startup_errors` list.
 - [x] Update CUDA and ROCm startup handshakes.
 - [x] Update `AGENTS.md` and architecture docs with the explicit first-allocation
       startup contract.

--- a/docs/plans/controller-startup-allocation-handshake.md
+++ b/docs/plans/controller-startup-allocation-handshake.md
@@ -32,6 +32,8 @@ real progress safely or intentionally deferred work for eco-safe backoff.
       and bounded ROCm OOM exhaustion.
 - [x] Resolve review feedback so failure paths always signal any startup event,
       including internal calls without a `startup_errors` list.
+- [x] Resolve review feedback so recoverable CUDA and ROCm startup OOM retries
+      clear the backend cache before sleeping and retrying.
 - [x] Update CUDA and ROCm startup handshakes.
 - [x] Update `AGENTS.md` and architecture docs with the explicit first-allocation
       startup contract.

--- a/docs/plans/controller-startup-allocation-handshake.md
+++ b/docs/plans/controller-startup-allocation-handshake.md
@@ -1,0 +1,37 @@
+# Controller Startup Allocation Handshake Plan
+
+## Background
+
+CUDA and ROCm workers currently signal `keep()` startup success after device setup
+but before the first permitted keep tensor allocation. If that first allocation
+fails with a fatal non-OOM error, service mode can briefly register a false
+active session and only later learn about `runtime_failed`.
+
+## Goal
+
+Make CUDA and ROCm `keep()` return success only after startup has either made
+real progress safely or intentionally deferred work for eco-safe backoff.
+
+## Design
+
+- Preserve eco-safe behavior: busy or unavailable telemetry with
+  `busy_threshold >= 0` may still signal startup because no allocation should run.
+- Preserve recoverable OOM behavior: an initial OOM retry is not a fatal startup
+  error.
+- Treat a first permitted non-OOM allocation failure as startup failure and
+  propagate it synchronously, matching the existing MPS controller contract.
+- Keep the implementation local to the CUDA/ROCm controller loops; no API change.
+
+## Todo
+
+- [x] Add CUDA `keep()` regression test for first permitted non-OOM allocation
+      failure.
+- [x] Add ROCm `keep()` regression test for first permitted non-OOM allocation
+      failure.
+- [x] Add public `keep()` coverage for eco-safe deferral, recoverable OOM retry,
+      and bounded ROCm OOM exhaustion.
+- [x] Update CUDA and ROCm startup handshakes.
+- [x] Update `AGENTS.md` and architecture docs with the explicit first-allocation
+      startup contract.
+- [x] Run targeted controller tests, full tests, docs build, pre-commit, local
+      review, and PR checks before merge.

--- a/docs/plans/controller-startup-allocation-handshake.md
+++ b/docs/plans/controller-startup-allocation-handshake.md
@@ -34,6 +34,8 @@ real progress safely or intentionally deferred work for eco-safe backoff.
       including internal calls without a `startup_errors` list.
 - [x] Resolve review feedback so recoverable CUDA and ROCm startup OOM retries
       clear the backend cache before sleeping and retrying.
+- [x] Resolve local review feedback so pre-stopped startup paths still signal
+      waiters and ROCm no-error-list setup failures retain failure details.
 - [x] Update CUDA and ROCm startup handshakes.
 - [x] Update `AGENTS.md` and architecture docs with the explicit first-allocation
       startup contract.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -211,6 +211,27 @@ class CudaGPUController(BaseGPUController):
         startup_errors: Optional[list[Exception]] = None,
     ) -> None:
         """Internal: run workloads until stop event is set."""
+        startup_confirmed = startup_evt is None
+
+        def confirm_startup() -> None:
+            nonlocal startup_confirmed
+            if startup_confirmed:
+                return
+            startup_confirmed = True
+            assert startup_evt is not None
+            startup_evt.set()
+
+        def record_worker_failure(exc: Exception) -> None:
+            failure = RuntimeError(
+                f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
+            )
+            if startup_confirmed or startup_errors is None:
+                self._failure_exc = failure
+            else:
+                startup_errors.append(failure)
+                confirm_startup()
+            logger.exception("%s", failure)
+
         stop_evt = self._stop_evt
         if stop_evt is None:
             exc = RuntimeError(f"rank {self.rank}: stop event not initialized")
@@ -248,13 +269,12 @@ class CudaGPUController(BaseGPUController):
             if startup_evt is not None:
                 startup_evt.set()
             return
-        if startup_evt is not None:
-            startup_evt.set()
         matrix = None
         while not stop_evt.is_set():
             try:
                 gpu_utilization = self._monitor_utilization(self.rank)
                 if not self._should_run_batch(gpu_utilization, self.busy_threshold):
+                    confirm_startup()
                     logger.debug(
                         "rank %s: GPU utilization unavailable or busy (%s), deferring allocation",
                         self.rank,
@@ -269,23 +289,19 @@ class CudaGPUController(BaseGPUController):
                     dtype=torch.float32,
                     requires_grad=False,
                 )
+                confirm_startup()
                 break
             except RuntimeError as e:
                 logger.error("rank %s: failed to allocate matrix: %s", self.rank, e)
                 if "out of memory" in str(e).lower():
+                    confirm_startup()
                     if stop_evt.wait(self.interval):
                         return
                     continue
-                self._failure_exc = RuntimeError(
-                    f"rank {self.rank}: unexpected CUDA keep worker failure: {e}"
-                )
-                logger.exception("%s", self._failure_exc)
+                record_worker_failure(e)
                 return
             except Exception as exc:
-                self._failure_exc = RuntimeError(
-                    f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
-                )
-                logger.exception("%s", self._failure_exc)
+                record_worker_failure(exc)
                 return
         if matrix is None:
             logger.error("rank %s: failed to allocate matrix, exiting loop", self.rank)

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -225,11 +225,11 @@ class CudaGPUController(BaseGPUController):
             failure = RuntimeError(
                 f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
             )
-            if startup_confirmed or startup_errors is None:
-                self._failure_exc = failure
-            else:
+            if not startup_confirmed and startup_errors is not None:
                 startup_errors.append(failure)
-                confirm_startup()
+            else:
+                self._failure_exc = failure
+            confirm_startup()
             logger.exception("%s", failure)
 
         stop_evt = self._stop_evt

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -301,7 +301,7 @@ class CudaGPUController(BaseGPUController):
                     continue
                 record_worker_failure(e)
                 return
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - surface backend startup failure
                 record_worker_failure(exc)
                 return
         if matrix is None:

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -294,6 +294,7 @@ class CudaGPUController(BaseGPUController):
             except RuntimeError as e:
                 logger.error("rank %s: failed to allocate matrix: %s", self.rank, e)
                 if "out of memory" in str(e).lower():
+                    torch.cuda.empty_cache()
                     confirm_startup()
                     if stop_evt.wait(self.interval):
                         return

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -221,27 +221,25 @@ class CudaGPUController(BaseGPUController):
             assert startup_evt is not None
             startup_evt.set()
 
+        def record_startup_failure(exc: Exception) -> None:
+            if not startup_confirmed and startup_errors is not None:
+                startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
+            confirm_startup()
+
         def record_worker_failure(exc: Exception) -> None:
             failure = RuntimeError(
                 f"rank {self.rank}: unexpected CUDA keep worker failure: {exc}"
             )
-            if not startup_confirmed and startup_errors is not None:
-                startup_errors.append(failure)
-            else:
-                self._failure_exc = failure
-            confirm_startup()
+            record_startup_failure(failure)
             logger.exception("%s", failure)
 
         stop_evt = self._stop_evt
         if stop_evt is None:
             exc = RuntimeError(f"rank {self.rank}: stop event not initialized")
             logger.error("%s", exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            else:
-                self._failure_exc = exc
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         assert stop_evt is not None
 
@@ -249,12 +247,7 @@ class CudaGPUController(BaseGPUController):
             torch.cuda.set_device(self.rank)
         except Exception as exc:  # noqa: BLE001 - surface backend startup failure
             logger.error("rank %s: CUDA startup failed: %s", self.rank, exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            else:
-                self._failure_exc = exc
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         num_elements = self._num_elements if self._num_elements is not None else 0
         if num_elements <= 0:
@@ -262,12 +255,7 @@ class CudaGPUController(BaseGPUController):
                 f"rank {self.rank}: invalid vram_to_keep={self.vram_to_keep}"
             )
             logger.error("%s", exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            else:
-                self._failure_exc = exc
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         matrix = None
         while not stop_evt.is_set():
@@ -305,7 +293,17 @@ class CudaGPUController(BaseGPUController):
                 record_worker_failure(exc)
                 return
         if matrix is None:
-            logger.error("rank %s: failed to allocate matrix, exiting loop", self.rank)
+            if not startup_confirmed:
+                exc = RuntimeError(
+                    f"rank {self.rank}: stopped before CUDA startup allocation"
+                )
+                logger.error("%s", exc)
+                record_startup_failure(exc)
+            else:
+                logger.debug(
+                    "rank %s: exiting before CUDA allocation after startup confirmation",
+                    self.rank,
+                )
             return
         while not stop_evt.is_set():
             try:

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -323,6 +323,7 @@ class RocmGPUController(BaseGPUController):
                     confirm_startup()
                     logger.error("%s", failure)
                     return
+                torch.cuda.empty_cache()
                 confirm_startup()
                 if stop_evt.wait(self.interval):
                     return

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -228,25 +228,25 @@ class RocmGPUController(BaseGPUController):
             assert startup_evt is not None
             startup_evt.set()
 
+        def record_startup_failure(exc: Exception) -> None:
+            if not startup_confirmed and startup_errors is not None:
+                startup_errors.append(exc)
+            else:
+                self._failure_exc = exc
+            confirm_startup()
+
         def record_worker_failure(exc: Exception) -> None:
             failure = RuntimeError(
                 f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
             )
-            if not startup_confirmed and startup_errors is not None:
-                startup_errors.append(failure)
-            else:
-                self._failure_exc = failure
-            confirm_startup()
+            record_startup_failure(failure)
             logger.exception("%s", failure)
 
         stop_evt = self._stop_evt
         if stop_evt is None:
             exc = RuntimeError(f"rank {self.rank}: stop event not initialized")
             logger.error("%s", exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         assert stop_evt is not None
 
@@ -254,10 +254,7 @@ class RocmGPUController(BaseGPUController):
             torch.cuda.set_device(self.rank)
         except Exception as exc:  # noqa: BLE001 - surface backend startup failure
             logger.error("rank %s: ROCm startup failed: %s", self.rank, exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         tensor = None
         attempts = 0
@@ -267,10 +264,7 @@ class RocmGPUController(BaseGPUController):
                 f"rank {self.rank}: invalid vram_to_keep={self.vram_to_keep}"
             )
             logger.error("%s", exc)
-            if startup_errors is not None:
-                startup_errors.append(exc)
-            if startup_evt is not None:
-                startup_evt.set()
+            record_startup_failure(exc)
             return
         while not stop_evt.is_set():
             try:
@@ -316,11 +310,7 @@ class RocmGPUController(BaseGPUController):
                     failure = RuntimeError(
                         f"rank {self.rank}: failed to allocate tensor after {attempts} attempts"
                     )
-                    if not startup_confirmed and startup_errors is not None:
-                        startup_errors.append(failure)
-                    else:
-                        self._failure_exc = failure
-                    confirm_startup()
+                    record_startup_failure(failure)
                     logger.error("%s", failure)
                     return
                 torch.cuda.empty_cache()
@@ -332,7 +322,17 @@ class RocmGPUController(BaseGPUController):
                 return
 
         if tensor is None:
-            logger.error("rank %s: failed to allocate tensor, exiting loop", self.rank)
+            if not startup_confirmed:
+                exc = RuntimeError(
+                    f"rank {self.rank}: stopped before ROCm startup allocation"
+                )
+                logger.error("%s", exc)
+                record_startup_failure(exc)
+            else:
+                logger.debug(
+                    "rank %s: exiting before ROCm allocation after startup confirmation",
+                    self.rank,
+                )
             return
         assert tensor is not None
 

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -218,6 +218,27 @@ class RocmGPUController(BaseGPUController):
         startup_evt: Optional[threading.Event] = None,
         startup_errors: Optional[list[Exception]] = None,
     ) -> None:
+        startup_confirmed = startup_evt is None
+
+        def confirm_startup() -> None:
+            nonlocal startup_confirmed
+            if startup_confirmed:
+                return
+            startup_confirmed = True
+            assert startup_evt is not None
+            startup_evt.set()
+
+        def record_worker_failure(exc: Exception) -> None:
+            failure = RuntimeError(
+                f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
+            )
+            if startup_confirmed or startup_errors is None:
+                self._failure_exc = failure
+            else:
+                startup_errors.append(failure)
+                confirm_startup()
+            logger.exception("%s", failure)
+
         stop_evt = self._stop_evt
         if stop_evt is None:
             exc = RuntimeError(f"rank {self.rank}: stop event not initialized")
@@ -251,12 +272,11 @@ class RocmGPUController(BaseGPUController):
             if startup_evt is not None:
                 startup_evt.set()
             return
-        if startup_evt is not None:
-            startup_evt.set()
         while not stop_evt.is_set():
             try:
                 util = self._query_utilization()
                 if not self._should_run_batch(util, self.busy_threshold):
+                    confirm_startup()
                     logger.debug(
                         "rank %s: GPU utilization unavailable or busy (%s), deferring allocation",
                         self.rank,
@@ -271,6 +291,7 @@ class RocmGPUController(BaseGPUController):
                     dtype=torch.float32,
                     requires_grad=False,
                 )
+                confirm_startup()
                 break
             except RuntimeError as exc:
                 attempts += 1
@@ -286,27 +307,27 @@ class RocmGPUController(BaseGPUController):
                     exc,
                 )
                 if "out of memory" not in str(exc).lower():
-                    self._failure_exc = RuntimeError(
-                        f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
-                    )
-                    logger.exception("%s", self._failure_exc)
+                    record_worker_failure(exc)
                     return
                 if (
                     self.max_allocation_retries is not None
                     and attempts >= self.max_allocation_retries
                 ):
-                    self._failure_exc = RuntimeError(
+                    failure = RuntimeError(
                         f"rank {self.rank}: failed to allocate tensor after {attempts} attempts"
                     )
-                    logger.error("%s", self._failure_exc)
+                    if startup_confirmed or startup_errors is None:
+                        self._failure_exc = failure
+                    else:
+                        startup_errors.append(failure)
+                        confirm_startup()
+                    logger.error("%s", failure)
                     return
+                confirm_startup()
                 if stop_evt.wait(self.interval):
                     return
             except Exception as exc:
-                self._failure_exc = RuntimeError(
-                    f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
-                )
-                logger.exception("%s", self._failure_exc)
+                record_worker_failure(exc)
                 return
 
         if tensor is None:

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -232,11 +232,11 @@ class RocmGPUController(BaseGPUController):
             failure = RuntimeError(
                 f"rank {self.rank}: unexpected ROCm keep worker failure: {exc}"
             )
-            if startup_confirmed or startup_errors is None:
-                self._failure_exc = failure
-            else:
+            if not startup_confirmed and startup_errors is not None:
                 startup_errors.append(failure)
-                confirm_startup()
+            else:
+                self._failure_exc = failure
+            confirm_startup()
             logger.exception("%s", failure)
 
         stop_evt = self._stop_evt
@@ -316,11 +316,11 @@ class RocmGPUController(BaseGPUController):
                     failure = RuntimeError(
                         f"rank {self.rank}: failed to allocate tensor after {attempts} attempts"
                     )
-                    if startup_confirmed or startup_errors is None:
-                        self._failure_exc = failure
-                    else:
+                    if not startup_confirmed and startup_errors is not None:
                         startup_errors.append(failure)
-                        confirm_startup()
+                    else:
+                        self._failure_exc = failure
+                    confirm_startup()
                     logger.error("%s", failure)
                     return
                 confirm_startup()

--- a/tests/cuda_controller/test_keep_and_release.py
+++ b/tests/cuda_controller/test_keep_and_release.py
@@ -31,6 +31,93 @@ def test_cuda_keep_raises_when_worker_startup_fails(monkeypatch):
     assert not (ctrl._thread and ctrl._thread.is_alive())
 
 
+def test_cuda_keep_raises_when_startup_allocation_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "device_count", lambda: 1)
+
+    ctrl = CudaGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        relu_iterations=1,
+    )
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("cuda startup allocation failed")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    with pytest.raises(RuntimeError, match="cuda startup allocation failed"):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
+def test_cuda_keep_returns_when_startup_defers_for_unknown_utilization(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(cuda_module.torch.cuda, "empty_cache", lambda: None)
+
+    ctrl = CudaGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=25,
+        relu_iterations=1,
+    )
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: None)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise AssertionError("allocation should be deferred while telemetry is unknown")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl.keep()
+
+    assert ctrl._thread is not None
+    assert ctrl._thread.is_alive()
+    assert ctrl.allocation_status() is None
+    ctrl.release()
+    assert ctrl._thread is None
+
+
+def test_cuda_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(cuda_module.torch.cuda, "empty_cache", lambda: None)
+
+    ctrl = CudaGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        relu_iterations=1,
+    )
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("CUDA out of memory")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl.keep()
+
+    assert ctrl._thread is not None
+    assert ctrl._thread.is_alive()
+    assert ctrl.allocation_status() is None
+    ctrl.release()
+    assert ctrl._thread is None
+
+
 def test_cuda_keep_rejects_retry_while_startup_thread_is_stopping(monkeypatch):
     import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
 

--- a/tests/cuda_controller/test_keep_and_release.py
+++ b/tests/cuda_controller/test_keep_and_release.py
@@ -91,13 +91,16 @@ def test_cuda_keep_returns_when_startup_defers_for_unknown_utilization(monkeypat
 def test_cuda_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
     import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
 
+    calls = []
     monkeypatch.setattr(cuda_module.torch.cuda, "device_count", lambda: 1)
     monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
-    monkeypatch.setattr(cuda_module.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        cuda_module.torch.cuda, "empty_cache", lambda: calls.append("empty_cache")
+    )
 
     ctrl = CudaGPUController(
         rank=0,
-        interval=0.01,
+        interval=60,
         vram_to_keep=4,
         busy_threshold=-1,
         relu_iterations=1,
@@ -111,10 +114,13 @@ def test_cuda_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
 
     ctrl.keep()
 
-    assert ctrl._thread is not None
-    assert ctrl._thread.is_alive()
-    assert ctrl.allocation_status() is None
-    ctrl.release()
+    try:
+        assert ctrl._thread is not None
+        assert ctrl._thread.is_alive()
+        assert ctrl.allocation_status() is None
+        assert calls == ["empty_cache"]
+    finally:
+        ctrl.release()
     assert ctrl._thread is None
 
 

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -45,6 +45,14 @@ class _StopWaitForbidden:
         raise AssertionError("fatal worker failures should stop immediately")
 
 
+class _StopAlreadySet:
+    def is_set(self):
+        return True
+
+    def wait(self, _timeout):
+        raise AssertionError("pre-stopped workers should not wait")
+
+
 def test_negative_busy_threshold_disables_backoff_without_gpu():
     assert CudaGPUController._should_run_batch(0, -1) is True
     assert CudaGPUController._should_run_batch(100, -1) is True
@@ -323,6 +331,30 @@ def test_cuda_sets_startup_event_when_recording_failure_without_error_list(monke
         str(error)
         == "rank 0: unexpected CUDA keep worker failure: illegal memory access"
     )
+
+
+def test_cuda_preserves_failure_when_stopped_before_startup_allocation(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAlreadySet()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: stopped before CUDA startup allocation"
 
 
 def test_cuda_retries_post_start_allocation_oom_without_failure(monkeypatch):

--- a/tests/cuda_controller/test_throttle.py
+++ b/tests/cuda_controller/test_throttle.py
@@ -1,3 +1,4 @@
+import threading
 import time
 
 import pytest
@@ -283,6 +284,39 @@ def test_cuda_records_post_start_allocation_runtime_error_as_failure(monkeypatch
 
     ctrl._keep_loop()
 
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected CUDA keep worker failure: illegal memory access"
+    )
+
+
+def test_cuda_sets_startup_event_when_recording_failure_without_error_list(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.relu_iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_monitor_utilization", lambda _rank: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("illegal memory access")
+
+    monkeypatch.setattr(cuda_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
     error = ctrl.allocation_status()
     assert isinstance(error, RuntimeError)
     assert (

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -515,6 +515,73 @@ def test_rocm_records_post_start_allocation_runtime_error_as_failure(monkeypatch
     )
 
 
+def test_rocm_sets_startup_event_when_recording_failure_without_error_list(
+    monkeypatch,
+):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("rocm allocation exploded")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert (
+        str(error)
+        == "rank 0: unexpected ROCm keep worker failure: rocm allocation exploded"
+    )
+
+
+def test_rocm_sets_startup_event_when_retry_exhausts_without_error_list(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*args, **kwargs):
+        raise RuntimeError("ROCm out of memory")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: failed to allocate tensor after 1 attempts"
+
+
 def test_rocm_records_unexpected_post_start_allocation_failure(monkeypatch):
     import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
 

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -27,6 +27,124 @@ def test_rocm_keep_raises_when_worker_startup_fails(monkeypatch):
     assert not (ctrl._thread and ctrl._thread.is_alive())
 
 
+def test_rocm_keep_raises_when_startup_allocation_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+    ctrl = RocmGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        iterations=1,
+    )
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("rocm startup allocation failed")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    with pytest.raises(RuntimeError, match="rocm startup allocation failed"):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
+def test_rocm_keep_raises_when_startup_oom_exhausts_retry_budget(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(rocm_module.torch.cuda, "empty_cache", lambda: None)
+
+    ctrl = RocmGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        iterations=1,
+        max_allocation_retries=1,
+    )
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("ROCm out of memory")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    with pytest.raises(
+        RuntimeError, match="failed to allocate tensor after 1 attempts"
+    ):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
+def test_rocm_keep_returns_when_startup_defers_for_unknown_utilization(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(rocm_module.torch.cuda, "empty_cache", lambda: None)
+
+    ctrl = RocmGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=25,
+        iterations=1,
+    )
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: None)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise AssertionError("allocation should be deferred while telemetry is unknown")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl.keep()
+
+    assert ctrl._thread is not None
+    assert ctrl._thread.is_alive()
+    assert ctrl.allocation_status() is None
+    ctrl.release()
+    assert ctrl._thread is None
+
+
+def test_rocm_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+    monkeypatch.setattr(rocm_module.torch.cuda, "empty_cache", lambda: None)
+
+    ctrl = RocmGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        iterations=1,
+        max_allocation_retries=None,
+    )
+    monkeypatch.setattr(ctrl, "_query_utilization", lambda: 0)
+
+    def fail_allocation(*_args, **_kwargs):
+        raise RuntimeError("ROCm out of memory")
+
+    monkeypatch.setattr(rocm_module.torch, "rand", fail_allocation)
+
+    ctrl.keep()
+
+    assert ctrl._thread is not None
+    assert ctrl._thread.is_alive()
+    assert ctrl.allocation_status() is None
+    ctrl.release()
+    assert ctrl._thread is None
+
+
 def test_rocm_keep_shuts_down_smi_when_worker_startup_fails(monkeypatch):
     import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
 

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -117,13 +117,16 @@ def test_rocm_keep_returns_when_startup_defers_for_unknown_utilization(monkeypat
 def test_rocm_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
     import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
 
+    calls = []
     monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
     monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
-    monkeypatch.setattr(rocm_module.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        rocm_module.torch.cuda, "empty_cache", lambda: calls.append("empty_cache")
+    )
 
     ctrl = RocmGPUController(
         rank=0,
-        interval=0.01,
+        interval=60,
         vram_to_keep=4,
         busy_threshold=-1,
         iterations=1,
@@ -138,10 +141,13 @@ def test_rocm_keep_returns_for_recoverable_startup_oom_retry(monkeypatch):
 
     ctrl.keep()
 
-    assert ctrl._thread is not None
-    assert ctrl._thread.is_alive()
-    assert ctrl.allocation_status() is None
-    ctrl.release()
+    try:
+        assert ctrl._thread is not None
+        assert ctrl._thread.is_alive()
+        assert ctrl.allocation_status() is None
+        assert calls == ["empty_cache"]
+    finally:
+        ctrl.release()
     assert ctrl._thread is None
 
 

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -284,6 +284,14 @@ class _StopWaitForbidden:
         raise AssertionError("fatal worker failures should stop immediately")
 
 
+class _StopAlreadySet:
+    def is_set(self):
+        return True
+
+    def wait(self, _timeout):
+        raise AssertionError("pre-stopped workers should not wait")
+
+
 def test_rocm_unknown_utilization_backs_off_when_threshold_enabled():
     assert RocmGPUController._should_run_batch(None, 10) is False
 
@@ -586,6 +594,89 @@ def test_rocm_sets_startup_event_when_retry_exhausts_without_error_list(monkeypa
     error = ctrl.allocation_status()
     assert isinstance(error, RuntimeError)
     assert str(error) == "rank 0: failed to allocate tensor after 1 attempts"
+
+
+def test_rocm_preserves_failure_when_stop_event_is_missing_without_error_list():
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl._failure_exc = None
+    ctrl._stop_evt = None
+    startup_evt = threading.Event()
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: stop event not initialized"
+
+
+def test_rocm_preserves_failure_when_set_device_fails_without_error_list(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+    startup_evt = threading.Event()
+
+    def fail_set_device(_rank):
+        raise RuntimeError("rocm startup exploded")
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", fail_set_device)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rocm startup exploded"
+
+
+def test_rocm_preserves_failure_when_vram_is_invalid_without_error_list(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.vram_to_keep = 0
+    ctrl._num_elements = 0
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopWaitForbidden()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: invalid vram_to_keep=0"
+
+
+def test_rocm_preserves_failure_when_stopped_before_startup_allocation(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 0
+    ctrl.device = "cuda:0"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl.max_allocation_retries = None
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAlreadySet()
+    startup_evt = threading.Event()
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "set_device", lambda _rank: None)
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: stopped before ROCm startup allocation"
 
 
 def test_rocm_records_unexpected_post_start_allocation_failure(monkeypatch):


### PR DESCRIPTION
## Summary
- Delay CUDA/ROCm startup success until first allocation succeeds, eco-safe telemetry deferral occurs, or a recoverable OOM retry begins.
- Propagate first permitted non-OOM allocation failures synchronously from keep(), so service mode cannot register false active sessions.
- Preserve eco-safe unknown/busy telemetry deferral and recoverable OOM retry behavior with public keep() regression coverage.
- Update AGENTS.md, architecture docs, and the implementation plan.

## Verification
- PYTHONPATH=src pytest tests/cuda_controller/test_keep_and_release.py tests/cuda_controller/test_throttle.py tests/rocm_controller/test_rocm_backoff.py -q -> 49 passed, 3 skipped
- PYTHONPATH=src pytest tests/cuda_controller tests/rocm_controller tests/macm_controller tests/global_controller tests/single_gpu_controller/test_release_contract.py tests/mcp/test_server.py -q -> 300 passed, 10 skipped
- PYTHONPATH=src pytest tests -q -> 911 passed, 11 skipped
- mkdocs build --strict -> passed with existing Material for MkDocs warning
- pre-commit run --all-files --show-diff-on-failure -> passed
- Local subagent code review and re-review completed; blocking findings resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU worker startup so allocation failures are reported at the right time, avoiding false “active” startup success.
  * Kept recoverable out-of-memory cases and unknown telemetry behavior working as expected during startup, with proper cleanup and retry handling.

* **Documentation**
  * Clarified GPU worker lifecycle behavior and startup/error handling guidance.
  * Added a design note describing the controller startup allocation handshake.

* **Tests**
  * Added coverage for startup failures, retry behavior, deferred allocation, and cleanup across CUDA and ROCm controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->