### PR TITLE
[cli] fix: guard service-stop against late sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,7 +331,10 @@ This file defines how coding agents should work in this repository.
 - Auto-start must not overwrite the PID record for an ownership-verified live
   KeepGPU daemon whose health endpoint is unavailable; fail with an actionable
   message so the user can inspect logs or explicitly force-stop it.
-- Non-force `keep-gpu service-stop` must require a reachable service, successful status/RPC checks, and a clean `stop_keep` result with no timed-out or failed sessions before signaling; use `--force` for unresponsive auto-started daemons.
+- Non-force `keep-gpu service-stop` must require a reachable service,
+  successful status/RPC checks, a clean `stop_keep` result with no stopped,
+  timed-out, or failed sessions, and a final no-active-session status check
+  before signaling; use `--force` for unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
 - MCP tool schemas that expose `job_id` must reuse the shared

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -79,13 +79,15 @@ Explicit `--job-id` values use the same non-empty URL-path-safe validation as
 keep-gpu service-stop
 ```
 
-If sessions are still active, timed out, or failed to stop cleanly, resolve them
-first or use `--force`. Force mode skips the session RPC checks, but it still
-stops only an ownership-verified daemon that KeepGPU auto-started. Malformed PID
-records, including float or boolean numeric identity values, are ignored instead
-of being coerced into a process signal target. Auto-start also cleans up and
-fails if it cannot create a trustworthy ownership record for the daemon it just
-spawned. If auto-start finds an ownership-verified live daemon record but the
+If sessions are active, newly stopped by shutdown checks, timed out, or failed
+to stop cleanly, resolve them first or use `--force`. Non-force shutdown also
+performs a final status check before signaling the daemon. Force mode skips the
+session RPC checks, but it still stops only an ownership-verified daemon that
+KeepGPU auto-started. Malformed PID records, including float or boolean numeric
+identity values, are ignored instead of being coerced into a process signal
+target. Auto-start also cleans up and fails if it cannot create a trustworthy
+ownership record for the daemon it just spawned. If auto-start finds an
+ownership-verified live daemon record but the
 health check is unavailable, it refuses to overwrite that record; inspect the
 service log at `~/.keepgpu/service-<host-with-dots-as-underscores>-<port>.log`
 or use `keep-gpu service-stop --force` before trying again. On systems without

--- a/docs/plans/service-stop-active-session-guard.md
+++ b/docs/plans/service-stop-active-session-guard.md
@@ -1,0 +1,36 @@
+# Service Stop Active Session Guard Plan
+
+## Background
+
+Non-force `keep-gpu service-stop` checks `status`, calls `stop_keep`, then
+signals the ownership-verified daemon process. A session can appear after the
+first status snapshot. If `stop_keep` reports it stopped that session, or if a
+new session appears after `stop_keep` returns a clean empty result, the CLI must
+not stop the daemon as if it had proven the service idle.
+
+## Goal
+
+Keep non-force daemon shutdown conservative: signal the daemon only after the
+service is reachable, `stop_keep` reports no session work, and a final status
+check still shows no active sessions.
+
+## Design
+
+- Keep `service-stop --force` unchanged: it skips session RPC checks but still
+  requires ownership-verified daemon identity.
+- Treat any non-empty `stopped`, `timed_out`, or `failed` `stop_keep` field as
+  not clean for non-force daemon shutdown.
+- Recheck all-session `status` after a clean `stop_keep` result and before
+  `_stop_service_process()`.
+- Keep the change local to CLI service-stop validation and tests.
+
+## Todo
+
+- [x] Add a failing regression for a late session stopped by `stop_keep`.
+- [x] Add a failing regression for a late session visible only on the final
+      status recheck.
+- [x] Tighten `service-stop` guards before daemon signaling.
+- [x] Update `AGENTS.md` and CLI docs with the stricter non-force contract.
+- [x] Run targeted CLI tests, full tests, docs build, and pre-commit locally.
+- [ ] Run local review, hosted PR checks, and merge only after all review
+      comments are resolved.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -135,14 +135,15 @@ reported as JSON errors before RPC.
 
 Stops the ownership-verified local daemon process created by auto-start logic.
 Invalid endpoint values are rejected locally before service checks or
-ownership-verified stop operations. Non-force shutdown requires session checks
-to finish cleanly with no timed-out or failed stops. Malformed PID records with
-float or boolean numeric identity values are ignored rather than coerced before
-signaling. Auto-start cleans up and fails if it cannot create a trustworthy
-ownership record for the daemon it just spawned. On systems without `/proc`,
-KeepGPU may recover daemon identity from platform process metadata, but it still
-signals only when recovered identity is known and exactly matches the stored
-ownership record.
+ownership-verified stop operations. Non-force shutdown requires the service to
+be reachable, `stop_keep` to report no stopped, timed-out, or failed sessions,
+and a final status check to show no active sessions before the daemon process is
+signaled. Malformed PID records with float or boolean numeric identity values
+are ignored rather than coerced before signaling. Auto-start cleans up and fails
+if it cannot create a trustworthy ownership record for the daemon it just
+spawned. On systems without `/proc`, KeepGPU may recover daemon identity from
+platform process metadata, but it still signals only when recovered identity is
+known and exactly matches the stored ownership record.
 
 | Option | Description |
 | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -854,6 +854,8 @@ def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
 
 def _require_clean_stop_keep_for_service_stop(result: Dict[str, Any]) -> None:
     incomplete = []
+    if result["stopped"]:
+        incomplete.append(f"stopped: {', '.join(result['stopped'])}")
     if result["timed_out"]:
         incomplete.append(f"timed out: {', '.join(result['timed_out'])}")
     if result["failed"]:
@@ -864,6 +866,20 @@ def _require_clean_stop_keep_for_service_stop(result: Dict[str, Any]) -> None:
             f"({'; '.join(incomplete)}). Resolve those sessions first, or use "
             "`keep-gpu service-stop --force` for an unresponsive auto-started daemon."
         )
+
+
+def _require_no_active_jobs_for_service_stop(status: Dict[str, Any]) -> None:
+    active_jobs = status.get("active_jobs", [])
+    if not active_jobs:
+        return
+    job_ids = ", ".join(
+        job["job_id"] for job in active_jobs if isinstance(job.get("job_id"), str)
+    )
+    detail = f" Active jobs: {job_ids}." if job_ids else ""
+    raise RuntimeError(
+        "Tracked keep sessions detected."
+        f"{detail} Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
+    )
 
 
 def _validate_list_gpus_result(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -1316,14 +1332,13 @@ def service_stop(
                 "For an unresponsive auto-started daemon, run `keep-gpu service-stop --force`."
             ) from exc
 
-        active_jobs = status.get("active_jobs", [])
-        if active_jobs:
-            raise RuntimeError(
-                "Tracked keep sessions detected. Stop sessions first (`keep-gpu stop --all`) or re-run with --force."
-            )
+        _require_no_active_jobs_for_service_stop(status)
         stop_result = _rpc_call("stop_keep", {}, host, port, timeout=45.0)
         stop_result = _validate_stop_keep_result(stop_result)
         _require_clean_stop_keep_for_service_stop(stop_result)
+        status = _rpc_call("status", {}, host, port)
+        status = _validate_status_result(status, single_job=False)
+        _require_no_active_jobs_for_service_stop(status)
 
         stopped = _stop_service_process(host, port)
         if not stopped:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2199,6 +2199,119 @@ def test_service_stop_rejects_incomplete_stop_keep_before_stopping_daemon(
     assert "Traceback" not in result.output
 
 
+def test_service_stop_rejects_newly_stopped_session_before_stopping_daemon(
+    monkeypatch,
+):
+    calls = {"stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        if method == "stop_keep":
+            return {
+                "stopped": ["late-job"],
+                "timed_out": [],
+                "failed": [],
+                "errors": {},
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert "late-job" in result.output
+    assert "service-stop --force" in result.output
+    assert calls["stop_process"] == 0
+    assert "Traceback" not in result.output
+
+
+def test_service_stop_rechecks_status_after_clean_stop_keep_before_stopping_daemon(
+    monkeypatch,
+):
+    calls = {"status": 0, "stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            calls["status"] += 1
+            if calls["status"] == 1:
+                return {"active_jobs": []}
+            return {
+                "active_jobs": [
+                    {
+                        "job_id": "late-job",
+                        "params": {},
+                        "state": "active",
+                        "last_error": None,
+                    }
+                ]
+            }
+        if method == "stop_keep":
+            return {
+                "stopped": [],
+                "timed_out": [],
+                "failed": [],
+                "errors": {},
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert calls == {"status": 2, "stop_process": 0}
+    assert "Tracked keep sessions detected" in result.output
+    assert "late-job" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_service_stop_rejects_malformed_final_status_before_stopping_daemon(
+    monkeypatch,
+):
+    calls = {"status": 0, "stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            calls["status"] += 1
+            if calls["status"] == 1:
+                return {"active_jobs": []}
+            return {"active_jobs": {}}
+        if method == "stop_keep":
+            return {
+                "stopped": [],
+                "timed_out": [],
+                "failed": [],
+                "errors": {},
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert calls == {"status": 2, "stop_process": 0}
+    assert "active_jobs must be a list" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_service_stop_requires_live_status_without_force(monkeypatch):
     called = {"stop_process": False}
 


### PR DESCRIPTION
## Summary
- tighten non-force `keep-gpu service-stop` so a non-empty `stopped`, `timed_out`, or `failed` `stop_keep` result blocks daemon signaling
- add a final all-session `status` recheck before `_stop_service_process()` to catch sessions that appear after `stop_keep` returns cleanly
- document the stricter non-force daemon shutdown contract in AGENTS and CLI docs

## Verification
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_stop_rejects_newly_stopped_session_before_stopping_daemon -q` (RED before fix, then pass)
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_stop_rechecks_status_after_clean_stop_keep_before_stopping_daemon -q` (RED before fix, then pass)
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q` -> `226 passed`
- `PYTHONPATH=src pytest tests -q` -> `921 passed, 11 skipped`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- local subagent review: no critical/important/minor issues after adding malformed-final-status coverage

README/Zenodo badge untouched.