### PR TITLE
[mcp] fix: reject ambiguous content length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,10 @@ This file defines how coding agents should work in this repository.
 - HTTP JSON-RPC endpoints (`/` and `/rpc`) must return JSON-RPC envelopes for
   protocol parse errors, including `jsonrpc`, `id`, and numeric `error.code`;
   REST routes keep REST-shaped structured JSON errors.
-- HTTP body readers must validate `Content-Length` as a non-negative integer
-  before reading; invalid values must fail quickly with REST JSON 400 errors or
-  JSON-RPC `-32700` parse-error envelopes.
+- HTTP body readers must validate parser-normalized `Content-Length` as exactly
+  one plain ASCII decimal non-negative integer before reading. Duplicate values,
+  signs, underscores, and other non-digit forms must fail quickly with REST JSON
+  400 errors or JSON-RPC `-32700` parse-error envelopes.
 - API/RPC unsupported HTTP methods must not fall back to
   `BaseHTTPRequestHandler` HTML errors; known API/RPC routes return structured
   JSON `405 Method Not Allowed` responses with `Allow`, and exact `/api` plus

--- a/docs/plans/http-content-length-validation.md
+++ b/docs/plans/http-content-length-validation.md
@@ -1,0 +1,35 @@
+# HTTP Content-Length Validation Plan
+
+## Background
+
+The HTTP JSON body reader uses `Content-Length` to decide how many bytes to read
+before REST or JSON-RPC request handling. It already rejects negative and
+non-integer values, but Python's `int()` accepts loose forms such as `+2` and
+`0_2`, and `headers.get()` hides duplicate `Content-Length` fields.
+
+## Goal
+
+Reject ambiguous or loose `Content-Length` values before any body read or
+session side effect. REST endpoints keep structured JSON `400` errors, while
+JSON-RPC endpoints keep parse-error envelopes.
+
+## Design
+
+- Use `headers.get_all("content-length")` to detect duplicate headers.
+- Accept only one present value, or preserve the existing missing-header
+  behavior as length zero.
+- Accept only parser-normalized plain ASCII decimal digits before converting to
+  `int`; leading zeroes remain valid digits, while signs, underscores, and
+  Unicode decimal digits do not.
+- Keep the change local to the shared HTTP JSON body reader and MCP HTTP tests.
+
+## Todo
+
+- [x] Add failing REST and JSON-RPC tests for duplicate `Content-Length`.
+- [x] Add failing REST and JSON-RPC tests for `int()`-accepted loose syntax.
+- [x] Tighten the shared HTTP body reader before `rfile.read()`.
+- [x] Update `AGENTS.md` with the stricter HTTP body-reader contract.
+- [x] Run focused MCP HTTP tests, full tests, docs build, and pre-commit
+      locally.
+- [ ] Run local review, hosted PR checks, and merge only after all review
+      comments are resolved.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1169,13 +1169,16 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
         )
 
     def _read_json_body(self) -> Any:
-        raw_length = self.headers.get("content-length", "0")
-        try:
-            length = int(raw_length)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Content-Length must be a non-negative integer") from exc
-        if length < 0:
+        raw_lengths = self.headers.get_all("content-length")
+        if raw_lengths is None:
+            raw_length = "0"
+        elif len(raw_lengths) == 1:
+            raw_length = raw_lengths[0]
+        else:
+            raise ValueError("Content-Length must appear exactly once")
+        if not (raw_length.isdecimal() and raw_length.isascii()):
             raise ValueError("Content-Length must be a non-negative integer")
+        length = int(raw_length)
         if length > MAX_JSON_BODY_BYTES:
             raise ValueError(
                 f"Request body too large: {length} bytes (max {MAX_JSON_BODY_BYTES})"

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -182,6 +182,24 @@ def _raw_post_with_content_length(httpd, path: str, content_length: str):
     return _send_raw_http_json_request(httpd, request)
 
 
+def _raw_post_with_content_length_headers(
+    httpd, path: str, content_lengths: list[str], body: bytes = b"{}"
+):
+    host, port = httpd.server_address
+    headers = "".join(
+        f"Content-Length: {content_length}\r\n" for content_length in content_lengths
+    )
+    request = (
+        f"POST {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Content-Type: application/json\r\n"
+        f"{headers}"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("ascii") + body
+    return _send_raw_http_json_request(httpd, request)
+
+
 def _raw_http_json_request(httpd, method: str, target: str, payload=None):
     host, port = httpd.server_address
     if payload is None:
@@ -815,10 +833,97 @@ def test_http_post_rejects_non_integer_content_length(path, expected_status):
     assert "Content-Length must be a non-negative integer" in (
         payload["error"]["message"]
     )
-    if path == "/rpc":
+    if path in ("/", "/rpc"):
         assert payload["jsonrpc"] == "2.0"
         assert payload["id"] is None
         assert payload["error"]["code"] == -32700
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_status"),
+    [
+        ("/api/sessions", 400),
+        ("/", 200),
+        ("/rpc", 200),
+    ],
+)
+def test_http_post_rejects_duplicate_content_length(path, expected_status):
+    server = make_server()
+    httpd, thread, _ = _start_threaded_http_server(server)
+
+    try:
+        status, payload = _raw_post_with_content_length_headers(
+            httpd, path, ["2", "2"], body=b"{}"
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == expected_status
+    assert "Content-Length must appear exactly once" in (payload["error"]["message"])
+    assert server.status()["active_jobs"] == []
+    if path in ("/", "/rpc"):
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] is None
+        assert payload["error"]["code"] == -32700
+
+
+@pytest.mark.parametrize(
+    ("path", "content_length", "expected_status"),
+    [
+        ("/api/sessions", "+2", 400),
+        ("/api/sessions", "0_2", 400),
+        ("/", "+2", 200),
+        ("/", "0_2", 200),
+        ("/rpc", "+2", 200),
+        ("/rpc", "0_2", 200),
+    ],
+)
+def test_http_post_rejects_loose_content_length_syntax(
+    path, content_length, expected_status
+):
+    server = make_server()
+    httpd, thread, _ = _start_threaded_http_server(server)
+
+    try:
+        status, payload = _raw_post_with_content_length_headers(
+            httpd, path, [content_length], body=b"{}"
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == expected_status
+    assert "Content-Length must be a non-negative integer" in (
+        payload["error"]["message"]
+    )
+    assert server.status()["active_jobs"] == []
+    if path in ("/", "/rpc"):
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] is None
+        assert payload["error"]["code"] == -32700
+
+
+def test_http_json_body_rejects_unicode_decimal_content_length_before_read():
+    class FakeHeaders:
+        def get_all(self, name):
+            assert name == "content-length"
+            return ["٢"]
+
+    class ReadForbidden:
+        def read(self, _length):
+            raise AssertionError("body must not be read")
+
+    handler = cast(Any, object.__new__(_JSONRPCHandler))
+    handler.headers = FakeHeaders()
+    handler.rfile = ReadForbidden()
+
+    with pytest.raises(ValueError, match="Content-Length must be a non-negative"):
+        _JSONRPCHandler._read_json_body(handler)
 
 
 def test_http_health_and_static_index():


### PR DESCRIPTION
## Summary
- validate parser-normalized `Content-Length` with `headers.get_all()` before reading request bodies
- reject duplicate headers, signed values, underscores, and other non-digit forms with existing REST/JSON-RPC error shapes
- add REST plus `/` and `/rpc` regression coverage proving invalid lengths do not create sessions or dispatch JSON-RPC methods

## Verification
- baseline `PYTHONPATH=src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py -q` -> `270 passed`
- RED duplicate/loose Content-Length tests failed before implementation
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_post_rejects_duplicate_content_length tests/mcp/test_http_api.py::test_http_post_rejects_loose_content_length_syntax -q` -> `9 passed`
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py tests/mcp/test_server.py -q` -> `279 passed`
- `PYTHONPATH=src pytest tests -q` -> `931 passed, 11 skipped`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- local subagent review: no critical/important findings; coverage nits resolved

README/Zenodo badge untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened HTTP request validation so `Content-Length` must be a single, plain non-negative decimal value.
  * Requests with duplicate, signed, underscored, or otherwise malformed `Content-Length` values now fail immediately with the appropriate error response.
  * Improved JSON-RPC and REST error handling for invalid request bodies.

* **Documentation**
  * Added guidance describing the accepted `Content-Length` format and expected rejection behavior for invalid headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->