### PR TITLE
[cli] fix: keep service JSON ANSI-free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,12 @@ This file defines how coding agents should work in this repository.
   REST `/api/gpus` `503` behavior; malformed GPU listing payloads remain
   internal service contract errors. CUDA/ROCm `torch.cuda.device_count()`
   failures are enumeration-unavailable errors, not successful empty GPU lists.
-- CLI service JSON commands (`status`, `stop`, `list-gpus`) must print structured JSON objects that downstream tools can parse with one decode, including `{"error": "..."}` objects for service/runtime errors after CLI parsing succeeds.
+- CLI service JSON commands (`status`, `stop`, `list-gpus`) must print
+  structured JSON objects that downstream tools can parse with one decode,
+  including `{"error": "..."}` objects for service/runtime errors after CLI
+  parsing succeeds. These machine JSON paths must bypass Rich color/highlight
+  rendering so pseudo-TTY or forced-color environments cannot inject ANSI escapes
+  into the JSON stream.
 - CLI service RPC clients must reject malformed JSON-RPC service envelopes
   (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
   concrete id, response IDs that compare equal but use an invalid JSON-RPC id

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -108,6 +108,8 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. `status`, `stop`, and `list-gpus` print JSON objects,
 including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
+The machine JSON stream is plain JSON without Rich color or highlighting, even
+when the command runs under a pseudo-TTY or forced-color terminal.
 Malformed JSON-RPC service envelopes, including missing or non-string
 `error.message`, and malformed method-specific result records are reported as
 JSON error objects instead of empty success results.

--- a/docs/plans/fix-cli-json-output.md
+++ b/docs/plans/fix-cli-json-output.md
@@ -7,6 +7,11 @@
 that string as data and emits a top-level JSON string, so callers must decode
 twice and tools such as `jq` cannot index the output directly.
 
+A later audit found that `console.print_json(data=result)` still routes machine
+JSON through Rich rendering. In pseudo-TTY or forced-color environments, Rich can
+inject ANSI styling into otherwise structured JSON, breaking a single
+`json.loads()` call again.
+
 ## Goal
 
 Emit structured JSON objects from service CLI commands so one `json.loads()` or
@@ -18,7 +23,9 @@ one shell JSON tool invocation sees the expected object.
   `list-gpus` that require a single JSON decode to return a dict.
 - Update the existing stop-all fallback test to single-decode the command
   output.
-- Print decoded result objects with `console.print_json(data=result)`.
+- Print decoded result objects with a small `_print_machine_json()` helper that
+  serializes with stdlib `json.dumps()` and writes directly to the console stream
+  without Rich color/highlight rendering.
 - After CodeRabbit review, print `{"error": "..."}` JSON objects for
   `RuntimeError` paths in the same CLI commands.
 - Document in `AGENTS.md`, README, and CLI docs that these CLI commands emit
@@ -29,11 +36,12 @@ one shell JSON tool invocation sees the expected object.
 - [x] Add RED tests for single-decode structured JSON output.
 - [x] Implement minimal CLI output changes.
 - [x] Add RED tests and implementation for single-decode JSON error objects.
+- [x] Add RED tests and implementation for ANSI-free machine JSON output under
+      forced-color consoles.
 - [x] Update `AGENTS.md`, README, CLI docs, and this plan.
 - [x] Run targeted tests, full tests, docs build, pre-commit, and local
       subagent review before PR.
-- [ ] Open PR, resolve review comments, wait for clean checks, squash merge, and
-      clean the worktree.
+- [x] Original PR was opened, reviewed, merged, and the worktree was cleaned.
 
 ## Verification
 
@@ -57,3 +65,14 @@ one shell JSON tool invocation sees the expected object.
   and the plan had the previous full-suite count. Wording now limits JSON error
   objects to service/runtime errors after CLI parsing succeeds, and verification
   records the final 249-test full-suite run.
+- Follow-up ANSI RED:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_json_commands_stay_plain_json_when_console_color_is_enabled tests/test_cli_service_commands.py::test_service_json_errors_stay_plain_json_when_console_color_is_enabled -q`
+  failed with all four cases containing ANSI escape sequences from Rich
+  rendering under a forced-color console.
+- Follow-up ANSI GREEN:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_json_commands_stay_plain_json_when_console_color_is_enabled tests/test_cli_service_commands.py::test_service_json_errors_stay_plain_json_when_console_color_is_enabled -q`
+  passed with 4 tests after `_print_machine_json()` wrote stdlib JSON directly
+  to the console stream.
+- CLI service command slice:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q` passed with 230
+  tests.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,6 +79,8 @@ Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
 envelopes, including missing or non-string `error.message`, and malformed status
 job records are reported as JSON error objects instead of empty success results.
+The machine JSON stream is plain JSON without Rich color or highlighting, even
+when the command runs under a pseudo-TTY or forced-color terminal.
 Started sessions with terminal worker allocation/runtime failures remain listed
 as `state="runtime_failed"` with `last_error` and can still be stopped. Normal
 busy-GPU or unavailable-telemetry backoff keeps the session active; it is not a
@@ -109,6 +111,8 @@ service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
 envelopes, including missing or non-string `error.message`, and malformed stop
 result records are reported as JSON error objects instead of empty success
 results.
+The machine JSON stream is plain JSON without Rich color or highlighting, even
+when the command runs under a pseudo-TTY or forced-color terminal.
 
 ### `keep-gpu list-gpus`
 
@@ -128,6 +132,8 @@ lists. Malformed JSON-RPC service envelopes, including missing or non-string
 results; malformed GPU records are reported the same way. `utilization` is
 either `null` or a finite number from `0` to `100`;
 out-of-range telemetry is unavailable, not idle.
+The machine JSON stream is plain JSON without Rich color or highlighting, even
+when the command runs under a pseudo-TTY or forced-color terminal.
 Invalid endpoint values, including non-integer or out-of-range ports, are
 reported as JSON errors before RPC.
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -97,6 +97,11 @@ def _service_command(host: str, port: int) -> List[str]:
     ]
 
 
+def _print_machine_json(data: Dict[str, Any]) -> None:
+    console.file.write(f"{json.dumps(data, indent=2, allow_nan=False)}\n")
+    console.file.flush()
+
+
 def _process_start_identity(pid: int) -> Optional[str]:
     try:
         stat_path = Path(f"/proc/{pid}/stat")
@@ -1230,9 +1235,9 @@ def status(
             port,
         )
         result = _validate_status_result(result, single_job=job_id is not None)
-        console.print_json(data=result)
+        _print_machine_json(result)
     except (RuntimeError, typer.BadParameter) as exc:
-        console.print_json(data={"error": str(exc)})
+        _print_machine_json({"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 
@@ -1273,9 +1278,9 @@ def stop(
                 timeout=45.0,
             )
             result = _validate_stop_keep_result(result)
-        console.print_json(data=result)
+        _print_machine_json(result)
     except (RuntimeError, typer.BadParameter) as exc:
-        console.print_json(data={"error": str(exc)})
+        _print_machine_json({"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 
@@ -1293,9 +1298,9 @@ def list_gpus(
         host, port = _validate_cli_service_endpoint(host, port)
         result = _rpc_call("list_gpus", {}, host, port)
         result = _validate_list_gpus_result(result)
-        console.print_json(data=result)
+        _print_machine_json(result)
     except (RuntimeError, typer.BadParameter) as exc:
-        console.print_json(data={"error": str(exc)})
+        _print_machine_json({"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1,8 +1,10 @@
 import builtins
 import json
 import re
+from io import StringIO
 
 import pytest
+from rich.console import Console
 from typer.testing import CliRunner
 
 from keep_gpu import cli
@@ -15,6 +17,16 @@ def _single_decoded_json_object(output):
     payload = json.loads(output)
     assert isinstance(payload, dict)
     return payload
+
+
+def _force_color_console(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(
+        cli,
+        "console",
+        Console(file=output, force_terminal=True, color_system="truecolor"),
+    )
+    return output
 
 
 def test_interval_help_uses_number_metavar():
@@ -810,6 +822,63 @@ def test_status_outputs_single_decoded_json_object(monkeypatch):
     payload = _single_decoded_json_object(result.output)
     assert payload["active"] is True
     assert payload["active_jobs"][0]["job_id"] == "job-1"
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_payload"),
+    [
+        (["status"], {"active_jobs": []}),
+        (
+            ["stop", "--job-id", "job-1"],
+            {"stopped": ["job-1"], "timed_out": [], "failed": [], "errors": {}},
+        ),
+        (["list-gpus"], {"gpus": []}),
+    ],
+)
+def test_service_json_commands_stay_plain_json_when_console_color_is_enabled(
+    monkeypatch, command, expected_payload
+):
+    output = _force_color_console(monkeypatch)
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        if method == "stop_keep":
+            return {"stopped": ["job-1"], "timed_out": [], "failed": [], "errors": {}}
+        if method == "list_gpus":
+            return {"gpus": []}
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, command)
+
+    rendered = output.getvalue()
+    assert result.exit_code == 0
+    assert "\x1b[" not in rendered
+    assert _single_decoded_json_object(rendered) == expected_payload
+
+
+def test_service_json_errors_stay_plain_json_when_console_color_is_enabled(
+    monkeypatch,
+):
+    output = _force_color_console(monkeypatch)
+    monkeypatch.setattr(
+        cli,
+        "_rpc_call",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("telemetry service unavailable")
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["list-gpus"])
+
+    rendered = output.getvalue()
+    assert result.exit_code == 1
+    assert "\x1b[" not in rendered
+    assert _single_decoded_json_object(rendered) == {
+        "error": "telemetry service unavailable"
+    }
 
 
 def test_status_job_outputs_single_decoded_json_object(monkeypatch):


### PR DESCRIPTION
## Summary
- route status/stop/list-gpus machine JSON through a plain stdlib JSON writer instead of Rich rendering
- add forced-color regression coverage for success and error JSON paths
- document that service JSON output is ANSI-free under pseudo-TTY/forced-color consoles

## Verification
- RED: forced-color CLI JSON tests failed with ANSI escapes before the helper change
- PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_json_commands_stay_plain_json_when_console_color_is_enabled tests/test_cli_service_commands.py::test_service_json_errors_stay_plain_json_when_console_color_is_enabled -q -> 4 passed
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q -> 230 passed
- PYTHONPATH=src pytest tests -q -> 936 passed, 11 skipped
- mkdocs build --strict -> passed with known Material warning
- pre-commit run --all-files --show-diff-on-failure -> passed
- local subagent code review -> clean, ready to PR