### PR TITLE
[controller] fix: retain MPS startup stop failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,10 @@ This file defines how coding agents should work in this repository.
 - Internal single-GPU startup paths that receive a `startup_evt` must always
   signal it before returning, and paths without a `startup_errors` list must
   retain the failure detail in `allocation_status()`.
+- MPS startup paths stopped before first allocation must follow the same
+  contract as CUDA/ROCm: signal startup completion and retain
+  `stopped before MPS startup allocation` so service status does not degrade to a
+  generic timeout or lose the lifecycle cause.
 - Single-GPU `keep()` must reject a restart while a previous worker thread is
   still alive with its stop event already set; returning success in that state
   hides a stopping keeper as if a fresh keep succeeded.

--- a/docs/plans/macm-startup-stop-failure-retention.md
+++ b/docs/plans/macm-startup-stop-failure-retention.md
@@ -1,0 +1,45 @@
+# Mac M Startup Stop Failure Retention Plan
+
+## Background
+
+`MacMGPUController._keep_loop()` could reach its `tensor is None` exit when the
+stop event was already set before the first allocation. That path logged a
+generic allocation message and returned without signaling `startup_evt` or
+retaining a failure in `allocation_status()`. CUDA and ROCm already report this
+as a concrete `stopped before ... startup allocation` lifecycle cause.
+
+## Goal
+
+Keep MPS startup lifecycle state truthful when a startup is stopped before first
+allocation: signal startup completion and preserve the specific failure cause so
+service status does not degrade to a timeout or lose the reason.
+
+## Solution
+
+- Add a Mac M regression test mirroring the CUDA/ROCm startup-stop contract.
+- When MPS exits before first allocation and startup has not been signaled,
+  record `rank N: stopped before MPS startup allocation` in `startup_errors` or
+  `_failure_exc`, then set `startup_evt`.
+- Leave post-confirmation exits as quiet debug exits so eco-safe deferred or
+  recoverable paths keep their current behavior.
+- Document the MPS-specific lifecycle invariant in `AGENTS.md`.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_preserves_failure_when_stopped_before_startup_allocation -q`
+  failed because `startup_evt` was not set.
+- GREEN:
+  `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_preserves_failure_when_stopped_before_startup_allocation -q`
+  passed.
+- Mac M slice:
+  `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py -q` passed
+  with 21 tests.
+
+## Remaining Checks
+
+- [x] Run the targeted controller suite.
+- [x] Run the full test suite.
+- [x] Run `mkdocs build --strict`.
+- [x] Run `pre-commit run --all-files --show-diff-on-failure`.
+- [x] Run local subagent code review before PR.

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -239,7 +239,21 @@ class MacMGPUController(BaseGPUController):
                 return
 
         if tensor is None:
-            logger.error("rank %s: failed to allocate tensor, exiting loop", self.rank)
+            if startup_evt is not None and not startup_evt.is_set():
+                exc = RuntimeError(
+                    f"rank {self.rank}: stopped before MPS startup allocation"
+                )
+                logger.error("%s", exc)
+                if startup_errors is not None:
+                    startup_errors.append(exc)
+                else:
+                    self._failure_exc = exc
+                startup_evt.set()
+            else:
+                logger.debug(
+                    "rank %s: exiting before MPS allocation after startup confirmation",
+                    self.rank,
+                )
             return
 
         while not stop_evt.is_set():

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -43,6 +43,14 @@ class _StopWaitForbidden:
         raise AssertionError("fatal worker failures should stop immediately")
 
 
+class _StopAlreadySet:
+    def is_set(self):
+        return True
+
+    def wait(self, _timeout):
+        raise AssertionError("pre-stopped workers should not wait")
+
+
 class _AliveThread:
     def is_alive(self):
         return True
@@ -343,6 +351,26 @@ def test_macm_records_invalid_post_start_num_elements_as_failure():
     error = ctrl.allocation_status()
     assert isinstance(error, RuntimeError)
     assert str(error) == "rank 0: invalid vram_to_keep=0"
+
+
+def test_macm_preserves_failure_when_stopped_before_startup_allocation():
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 0
+    ctrl.device = "mps"
+    ctrl.interval = 0.01
+    ctrl.busy_threshold = -1
+    ctrl.iterations = 1
+    ctrl._num_elements = 4
+    ctrl._failure_exc = None
+    ctrl._stop_evt = _StopAlreadySet()
+    startup_evt = threading.Event()
+
+    ctrl._keep_loop(startup_evt=startup_evt, startup_errors=None)
+
+    assert startup_evt.is_set()
+    error = ctrl.allocation_status()
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "rank 0: stopped before MPS startup allocation"
 
 
 def test_macm_retries_post_start_allocation_oom_without_failure(monkeypatch):


### PR DESCRIPTION
## Summary
- retain a concrete MPS startup-stop failure when the worker exits before first allocation
- signal startup completion on that path so service status does not degrade to a generic timeout
- add a Mac M regression mirroring the CUDA/ROCm startup-stop allocation contract
- document the MPS lifecycle invariant in AGENTS and a focused plan note

## Verification
- RED: PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_preserves_failure_when_stopped_before_startup_allocation -q failed because startup_evt remained unset
- PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_preserves_failure_when_stopped_before_startup_allocation -q -> 1 passed
- PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py -q -> 21 passed
- PYTHONPATH=src pytest tests/macm_controller tests/cuda_controller/test_throttle.py tests/rocm_controller/test_rocm_backoff.py -q -> 73 passed, 5 skipped
- PYTHONPATH=src pytest tests -q -> 937 passed, 11 skipped
- mkdocs build --strict -> passed with known Material warning
- pre-commit run --all-files --show-diff-on-failure -> passed
- local subagent code review -> clean, ready to PR