### PR TITLE
[cli] fix: send jsonrpc version in service requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,9 @@ This file defines how coding agents should work in this repository.
   `result`, non-object `error`, or missing/non-string `error.message`) instead
   of treating them as successful empty responses, real service errors, or
   leaking tracebacks.
+- CLI service RPC clients must send explicit JSON-RPC 2.0 request envelopes
+  (`jsonrpc: "2.0"`) instead of relying on the server's omitted-version legacy
+  direct-call compatibility path.
 - CLI commands that consume service-specific JSON-RPC results must validate
   required result fields before rendering user-facing output; malformed
   method-specific payloads should become clean `ServiceResponseError` messages,

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -113,6 +113,9 @@ when the command runs under a pseudo-TTY or forced-color terminal.
 Malformed JSON-RPC service envelopes, including missing or non-string
 `error.message`, and malformed method-specific result records are reported as
 JSON error objects instead of empty success results.
+CLI service commands send explicit JSON-RPC 2.0 request envelopes to the local
+`/rpc` endpoint; omitted-version direct calls remain only a compatibility path
+for legacy local scripts.
 Utilization values are either `null` or finite percentages from `0` to `100`;
 out-of-range vendor readings are displayed as unavailable telemetry.
 Response IDs must echo the request ID with a valid matching JSON-RPC ID type.

--- a/docs/plans/cli-jsonrpc-request-version.md
+++ b/docs/plans/cli-jsonrpc-request-version.md
@@ -1,0 +1,49 @@
+# CLI JSON-RPC Request Version Plan
+
+## Background
+
+`keep-gpu status`, `keep-gpu stop`, and `keep-gpu list-gpus` call the local
+service through `_rpc_call()`. The client already rejects malformed JSON-RPC
+responses whose `jsonrpc` member is not `"2.0"`, but outgoing requests omitted
+the version and therefore used the server's legacy direct-call compatibility
+path.
+
+## Goal
+
+Make the CLI service client use standard JSON-RPC 2.0 request envelopes while
+preserving legacy omitted-version handling for direct local scripts.
+
+## Solution
+
+- Add a regression test that captures `_rpc_call()`'s outgoing payload.
+- Include `jsonrpc: "2.0"` in the request payload.
+- Document the client/server split in AGENTS and CLI docs.
+
+## Todo
+
+- [x] Verify the focused CLI/MCP baseline.
+- [x] Add the failing request-version regression test.
+- [x] Add the minimal `_rpc_call()` payload change.
+- [x] Run targeted verification.
+- [x] Run broader verification.
+- [x] Request local subagent review before PR.
+
+## Verification
+
+- RED:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_rpc_call_sends_explicit_jsonrpc_request_version -q`
+  failed because the captured request payload did not include `jsonrpc`.
+- GREEN:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_rpc_call_sends_explicit_jsonrpc_request_version -q`,
+  `1 passed`.
+- Targeted CLI/MCP contract suite:
+  `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py::test_jsonrpc_rejects_explicit_invalid_request_version tests/mcp/test_server.py::test_jsonrpc_accepts_explicit_valid_request_version tests/mcp/test_server.py::test_jsonrpc_omitted_version_legacy_direct_call_still_works -q`,
+  `234 passed`.
+- Full test suite:
+  `PYTHONPATH=src pytest tests -q`, `944 passed, 11 skipped`.
+- Docs and formatting:
+  `mkdocs build --strict` passed with the known Material for MkDocs warning;
+  `pre-commit run --all-files --show-diff-on-failure` passed.
+- Local subagent review:
+  reviewer found no functional issues and flagged that this plan file must be
+  tracked before PR.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -174,7 +174,9 @@ present, falling back to the plain response body or HTTP status only when needed
 Direct JSON-RPC service calls report the same expected hardware/platform
 startup-unavailable conditions, including failed CUDA/ROCm visible-device
 enumeration, with error code `-32000`; arbitrary runtime failures remain
-`-32603 Internal error`.
+`-32603 Internal error`. CLI service commands send explicit JSON-RPC 2.0
+request envelopes to `/rpc`; omitted-version direct calls are retained only for
+legacy local scripts.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -640,6 +640,7 @@ def _rpc_call(
     timeout: float = 8.0,
 ) -> Dict[str, Any]:
     payload = {
+        "jsonrpc": "2.0",
         "id": int(time.time() * 1000),
         "method": method,
         "params": params or {},

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1617,6 +1617,29 @@ def test_list_gpus_error_outputs_single_decoded_json_object(monkeypatch):
     assert payload["error"] == "telemetry service unavailable"
 
 
+def test_rpc_call_sends_explicit_jsonrpc_request_version(monkeypatch):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    captured = {}
+
+    def fake_http_json_request(method, url, payload, timeout=8.0):
+        captured["method"] = method
+        captured["url"] = url
+        captured["payload"] = payload
+        return {"jsonrpc": "2.0", "id": payload["id"], "result": {}}
+
+    monkeypatch.setattr(cli, "_http_json_request", fake_http_json_request)
+
+    assert cli._rpc_call("status", None, "127.0.0.1", 8765) == {}
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://127.0.0.1:8765/rpc"
+    assert captured["payload"] == {
+        "jsonrpc": "2.0",
+        "id": 1000,
+        "method": "status",
+        "params": {},
+    }
+
+
 def test_rpc_call_rejects_success_envelope_without_result(monkeypatch):
     monkeypatch.setattr(cli.time, "time", lambda: 1.0)
 


### PR DESCRIPTION
## Summary
- Add `jsonrpc: "2.0"` to CLI service JSON-RPC requests sent by `_rpc_call()`.
- Cover the outgoing request envelope with a regression test.
- Document that CLI service commands use explicit JSON-RPC 2.0 requests while omitted-version direct calls remain legacy compatibility for local scripts.

## Verification
- RED: `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_rpc_call_sends_explicit_jsonrpc_request_version -q` failed because the outgoing payload lacked `jsonrpc`.
- GREEN: `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_rpc_call_sends_explicit_jsonrpc_request_version -q` -> `1 passed`
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/mcp/test_server.py::test_jsonrpc_rejects_explicit_invalid_request_version tests/mcp/test_server.py::test_jsonrpc_accepts_explicit_valid_request_version tests/mcp/test_server.py::test_jsonrpc_omitted_version_legacy_direct_call_still_works -q` -> `234 passed`
- `PYTHONPATH=src pytest tests -q` -> `944 passed, 11 skipped`
- `mkdocs build --strict` -> passed with the known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- Local subagent review -> no functional issues; tracked plan file before PR
- `rg -n "zenodo.org/badge|doi.org/10.5281/zenodo" README.md tests/test_package_metadata.py` confirms the Zenodo badge is still present and tested
