### PR TITLE
[ci] ci: align pre-commit action versions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ This file defines how coding agents should work in this repository.
 - Pre-commit CI should install only the `pre-commit` runner; hooks provision
   their own tool environments, so do not install KeepGPU runtime dependencies
   just to lint.
+- Keep shared GitHub Actions on the same current major versions across
+  workflows, and guard intentional core action major pins in CI tests.
 - Keep Python test CI dependency installs explicit. Do not reintroduce a root
   `requirements.txt` fallback; runtime and test dependencies belong in
   `pyproject.toml`, while docs dependencies belong in `docs/requirements.txt`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep pre-commit CI lean: install the `pre-commit` runner only, and let hooks
   provision their own tool environments instead of installing KeepGPU runtime
   dependencies.
+- Keep shared GitHub Actions on aligned current major versions across workflows;
+  CI metadata tests should guard intentional core action major pins.
 - Keep Python CI installs explicit: do not add a root `requirements.txt`
   fallback. Use `pyproject.toml` for runtime/test dependencies and
   `docs/requirements.txt` for documentation builds.

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,6 +1,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 ROOT_REQUIREMENTS_INSTALL_RE = re.compile(
     r"\b(?:python\s+-m\s+)?pip\s+install\s+-r\s+(?:\./)?requirements\.txt\b"
@@ -45,9 +47,16 @@ def _bounds_below_mkdocs_two(requirement: str) -> bool:
 
 
 def _workflow_action_ref(workflow: str, action: str) -> str:
-    match = re.search(rf"uses:\s*{re.escape(action)}@v[0-9]+\b", workflow)
-    assert match is not None, f"missing workflow action: {action}"
-    return match.group(0).removeprefix("uses:").strip()
+    action_pattern = re.escape(action)
+    for line in workflow.splitlines():
+        active_line = line.split("#", 1)[0].strip()
+        match = re.match(
+            rf"-?\s*uses\s*:\s*['\"]?({action_pattern}@[^\s'\"]+)['\"]?\s*$",
+            active_line,
+        )
+        if match is not None:
+            return match.group(1)
+    raise AssertionError(f"missing workflow action: {action}")
 
 
 def test_precommit_workflow_does_not_install_runtime_package():
@@ -84,8 +93,38 @@ def test_precommit_workflow_uses_current_core_action_majors():
         python_workflow, "actions/setup-python"
     )
 
-    assert f"uses: {expected_checkout}" in precommit_workflow
-    assert f"uses: {expected_setup_python}" in precommit_workflow
+    assert (
+        _workflow_action_ref(precommit_workflow, "actions/checkout")
+        == expected_checkout
+    )
+    assert (
+        _workflow_action_ref(precommit_workflow, "actions/setup-python")
+        == expected_setup_python
+    )
+
+
+def test_workflow_action_ref_ignores_comments_and_allows_spacing():
+    workflow = """
+    steps:
+      - name: stale note
+        # uses: actions/checkout@v99
+      - uses:    actions/checkout@v4
+    """
+
+    assert _workflow_action_ref(workflow, "actions/checkout") == "actions/checkout@v4"
+
+
+def test_workflow_action_ref_requires_active_uses_line():
+    workflow = """
+    steps:
+      - name: stale note
+        # uses: actions/setup-python@v5
+    """
+
+    with pytest.raises(
+        AssertionError, match="missing workflow action: actions/setup-python"
+    ):
+        _workflow_action_ref(workflow, "actions/setup-python")
 
 
 def test_python_workflow_does_not_install_root_requirements_file():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -44,6 +44,12 @@ def _bounds_below_mkdocs_two(requirement: str) -> bool:
     return bool(MKDOCS_MAJOR_TWO_BOUND_RE.search(requirement))
 
 
+def _workflow_action_ref(workflow: str, action: str) -> str:
+    match = re.search(rf"uses:\s*{re.escape(action)}@v[0-9]+\b", workflow)
+    assert match is not None, f"missing workflow action: {action}"
+    return match.group(0).removeprefix("uses:").strip()
+
+
 def test_precommit_workflow_does_not_install_runtime_package():
     workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
     if not workflow_path.exists():
@@ -60,6 +66,26 @@ def test_precommit_workflow_does_not_install_runtime_package():
         "python -m pip install --upgrade pip",
         "pip install pre-commit",
     ]
+
+
+def test_precommit_workflow_uses_current_core_action_majors():
+    precommit_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
+    if not precommit_path.exists():
+        precommit_path = PROJECT_ROOT / ".github/workflows/pre-commit.yml"
+    precommit_workflow = precommit_path.read_text(encoding="utf-8")
+
+    python_workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yml"
+    if not python_workflow_path.exists():
+        python_workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yaml"
+    python_workflow = python_workflow_path.read_text(encoding="utf-8")
+
+    expected_checkout = _workflow_action_ref(python_workflow, "actions/checkout")
+    expected_setup_python = _workflow_action_ref(
+        python_workflow, "actions/setup-python"
+    )
+
+    assert f"uses: {expected_checkout}" in precommit_workflow
+    assert f"uses: {expected_setup_python}" in precommit_workflow
 
 
 def test_python_workflow_does_not_install_root_requirements_file():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -8,6 +8,7 @@ ROOT_REQUIREMENTS_INSTALL_RE = re.compile(
     r"\b(?:python\s+-m\s+)?pip\s+install\s+-r\s+(?:\./)?requirements\.txt\b"
 )
 MKDOCS_MAJOR_TWO_BOUND_RE = re.compile(r"<\s*2(?:\.0+)?(?:\s|,|$)")
+YAML_BLOCK_SCALAR_START_RE = re.compile(r":\s*[|>][-+0-9]*\s*$")
 
 
 def _installs_root_requirements_file(workflow: str) -> bool:
@@ -48,8 +49,23 @@ def _bounds_below_mkdocs_two(requirement: str) -> bool:
 
 def _workflow_action_ref(workflow: str, action: str) -> str:
     action_pattern = re.escape(action)
+    block_scalar_indent = None
     for line in workflow.splitlines():
-        active_line = line.split("#", 1)[0].strip()
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        if block_scalar_indent is not None:
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+
+        active_line = line.split("#", 1)[0]
+        if YAML_BLOCK_SCALAR_START_RE.search(active_line.rstrip()):
+            block_scalar_indent = indent
+            continue
+
+        active_line = active_line.strip()
         match = re.match(
             rf"-?\s*uses\s*:\s*['\"]?({action_pattern}@[^\s'\"]+)['\"]?\s*$",
             active_line,
@@ -77,7 +93,7 @@ def test_precommit_workflow_does_not_install_runtime_package():
     ]
 
 
-def test_precommit_workflow_uses_current_core_action_majors():
+def test_precommit_workflow_uses_current_core_action_refs():
     precommit_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
     if not precommit_path.exists():
         precommit_path = PROJECT_ROOT / ".github/workflows/pre-commit.yml"
@@ -125,6 +141,18 @@ def test_workflow_action_ref_requires_active_uses_line():
         AssertionError, match="missing workflow action: actions/setup-python"
     ):
         _workflow_action_ref(workflow, "actions/setup-python")
+
+
+def test_workflow_action_ref_ignores_run_block_content():
+    workflow = """
+    steps:
+      - name: show historical action
+        run: |
+          uses: actions/checkout@v99
+      - uses: actions/checkout@v4
+    """
+
+    assert _workflow_action_ref(workflow, "actions/checkout") == "actions/checkout@v4"
 
 
 def test_python_workflow_does_not_install_root_requirements_file():


### PR DESCRIPTION
## Summary
- Bump the pre-commit workflow from `actions/checkout@v3` / `actions/setup-python@v4` to `checkout@v4` / `setup-python@v5`.
- Add a CI metadata guard so the pre-commit workflow does not drift back to stale core action majors.
- Document action-major alignment in AGENTS and contributing guidance while keeping the pre-commit lane lean.

## Verification
- Baseline: `PYTHONPATH=src pytest tests/test_ci_workflows.py -q` -> `8 passed`
- RED: `PYTHONPATH=src pytest tests/test_ci_workflows.py::test_precommit_workflow_uses_current_core_action_majors -q` failed because `checkout@v4` was absent
- GREEN: `PYTHONPATH=src pytest tests/test_ci_workflows.py::test_precommit_workflow_uses_current_core_action_majors -q` -> `1 passed`
- `PYTHONPATH=src pytest tests/test_ci_workflows.py -q` -> `9 passed`
- `PYTHONPATH=src pytest tests -q` -> `945 passed, 11 skipped`
- `mkdocs build --strict` -> passed with the known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- Local subagent review -> no workflow/test issues; tracked plan file before PR
- `rg -n "zenodo.org/badge|doi.org/10.5281/zenodo" README.md tests/test_package_metadata.py` confirms the Zenodo badge is still present and tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pre-commit GitHub Actions workflow to use the latest supported major versions of key actions.

* **Tests**
  * Added CI coverage to catch future drift in workflow action versions.

* **Documentation**
  * Clarified contribution guidance around keeping shared workflow actions aligned.
  * Added a short planning note describing the version alignment approach.

* **Chores**
  * Added a maintenance guideline for consistent GitHub Actions versioning across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->