### PR TITLE
[cli,tests] fix: use monotonic deadlines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
+- Use monotonic clocks for timeout/deadline arithmetic. Reserve wall-clock
+  `time.time()` for epoch timestamps, persisted records, and protocol IDs.
 - Build metadata should list directly used third-party distributions; do not
   rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,6 +40,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep broad validation matrices with the utility or controller that owns the
   contract; interface tests should use representative smoke cases plus
   side-effect guards instead of repeating every edge case.
+- Use monotonic clocks for timeout/deadline helpers; reserve wall-clock time for
+  persisted timestamps and protocol identifiers.
 - When changing CUDA visibility telemetry, cover numeric and UUID
   `CUDA_VISIBLE_DEVICES` masks, including NVML UUID string/bytes lookup
   differences.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -604,8 +604,8 @@ def _stop_service_process(host: str, port: int, timeout: float = 3.0) -> bool:
     except OSError:
         _clear_service_pid(host, port)
         return False
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         if not _pid_alive(pid):
             _clear_service_pid(host, port)
             return True
@@ -620,8 +620,8 @@ def _stop_service_process(host: str, port: int, timeout: float = 3.0) -> bool:
     except OSError:
         _clear_service_pid(host, port)
         return False
-    deadline = time.time() + max(0.5, min(timeout, 3.0))
-    while time.time() < deadline:
+    deadline = time.monotonic() + max(0.5, min(timeout, 3.0))
+    while time.monotonic() < deadline:
         if not _pid_alive(pid):
             _clear_service_pid(host, port)
             return True

--- a/tests/polling.py
+++ b/tests/polling.py
@@ -8,8 +8,8 @@ def wait_until(
     interval_s: float = 0.05,
 ) -> bool:
     """Poll predicate until it returns True or timeout is reached."""
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
         if predicate():
             return True
         time.sleep(interval_s)

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2687,6 +2687,105 @@ def test_stop_service_process_uses_ps_start_identity_when_proc_is_unavailable(
     assert not cli._service_pid_path("127.0.0.1", 8765).exists()
 
 
+def test_stop_service_process_uses_monotonic_deadlines(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "argv": cli._service_command("127.0.0.1", 8765),
+        "uid": 1000,
+        "start_time": "12345",
+        "created_at": 1.0,
+    }
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+
+    alive = iter([True, False])
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: next(alive, False))
+    kills = []
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+    monotonic_calls = [10.0, 10.1]
+    monkeypatch.setattr(
+        cli.time,
+        "monotonic",
+        lambda: (
+            monotonic_calls.pop(0) if len(monotonic_calls) > 1 else monotonic_calls[0]
+        ),
+    )
+    monkeypatch.setattr(
+        cli.time,
+        "time",
+        lambda: (_ for _ in ()).throw(AssertionError("wall clock used")),
+    )
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0.5)
+
+    assert stopped is True
+    assert kills == [(4321, cli.signal.SIGTERM)]
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
+def test_stop_service_process_sigkill_wait_uses_monotonic_deadline(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cli, "_runtime_dir", lambda: tmp_path)
+    payload = {
+        "pid": 4321,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "argv": cli._service_command("127.0.0.1", 8765),
+        "uid": 1000,
+        "start_time": "12345",
+        "created_at": 1.0,
+    }
+    cli._service_pid_path("127.0.0.1", 8765).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli, "_process_cmdline", lambda pid: cli._service_command("127.0.0.1", 8765)
+    )
+    monkeypatch.setattr(cli, "_process_uid", lambda pid: 1000)
+    monkeypatch.setattr(cli, "_process_start_identity", lambda pid: "12345")
+
+    alive = {"value": True}
+    kills = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        if sig == cli.signal.SIGKILL:
+            alive["value"] = False
+
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: alive["value"])
+    monkeypatch.setattr(cli.os, "kill", fake_kill)
+    monotonic_calls = [10.0, 11.0, 11.0, 11.1]
+    monkeypatch.setattr(
+        cli.time,
+        "monotonic",
+        lambda: (
+            monotonic_calls.pop(0) if len(monotonic_calls) > 1 else monotonic_calls[0]
+        ),
+    )
+    monkeypatch.setattr(cli.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        cli.time,
+        "time",
+        lambda: (_ for _ in ()).throw(AssertionError("wall clock used")),
+    )
+
+    stopped = cli._stop_service_process("127.0.0.1", 8765, timeout=0.5)
+
+    assert stopped is True
+    assert kills == [(4321, cli.signal.SIGTERM), (4321, cli.signal.SIGKILL)]
+    assert not cli._service_pid_path("127.0.0.1", 8765).exists()
+
+
 def test_stop_service_process_requires_structured_ownership_record(
     monkeypatch, tmp_path
 ):

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,26 @@
+from tests import polling
+
+
+def test_wait_until_uses_monotonic_deadline(monkeypatch):
+    calls = {"predicate": 0}
+
+    def predicate():
+        calls["predicate"] += 1
+        return calls["predicate"] == 2
+
+    monotonic_calls = [1.0, 1.1, 1.2]
+    monkeypatch.setattr(
+        polling.time,
+        "monotonic",
+        lambda: (
+            monotonic_calls.pop(0) if len(monotonic_calls) > 1 else monotonic_calls[0]
+        ),
+    )
+    monkeypatch.setattr(polling.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        polling.time,
+        "time",
+        lambda: (_ for _ in ()).throw(AssertionError("wall clock used")),
+    )
+
+    assert polling.wait_until(predicate, timeout_s=1.0, interval_s=0.01) is True


### PR DESCRIPTION
## Summary
- Use monotonic clocks for CLI service-stop SIGTERM/SIGKILL deadline loops.
- Use monotonic clocks in the shared test polling helper.
- Add regressions for SIGTERM, SIGKILL, and polling helper deadline paths, plus concise AGENTS/contributing guidance.

## Test Plan
- RED: new SIGTERM/polling tests failed on current main with `AssertionError: wall clock used`.
- RED: SIGKILL-path test failed when only the SIGKILL wait loop was temporarily reverted to `time.time()`.
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/test_polling.py -q` -> 234 passed.
- `PYTHONPATH=src pytest tests/cuda_controller/test_context_manager.py tests/cuda_controller/test_keep_and_release.py -q` -> 5 passed, 3 skipped.
- `PYTHONPATH=src pytest tests -q` -> 951 passed, 11 skipped.
- `mkdocs build --strict` -> passed, with the known Material/MkDocs warning.
- `pre-commit run --all-files --show-diff-on-failure` -> passed.

## Local Review
- Local subagent review found a missing SIGKILL-loop regression; fixed before PR.
- Second local subagent review reported no Critical, Important, or Minor issues and marked the branch ready to open PR.

## Notes
- Wall-clock `time.time()` remains in place for epoch timestamps and JSON-RPC request IDs.
- README was not changed; the Zenodo DOI badge remains present.