### PR TITLE
[endpoint,cli,mcp] fix: require plain decimal ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,8 @@ This file defines how coding agents should work in this repository.
 - Shared public endpoint validation belongs in
   `src/keep_gpu/utilities/endpoint_validation.py`; CLI and MCP entry points
   should only translate those `ValueError`s into their interface-specific error
-  shape.
+  shape. Public string ports must be plain ASCII decimal digits before
+  conversion; reject signs, underscores, whitespace, and non-ASCII digits.
 - JSON-output service commands (`status`, `stop`, `list-gpus`) must parse
   `--port` through command-level validation so non-integer values return the
   shared structured `{"error": "port must be an integer between 1 and 65535"}`

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -41,7 +41,7 @@ Local `start` inputs are validated before auto-starting the service. Invalid
 `--vram`, `--job-id`, `--interval`, `--busy-threshold`, or `--gpu-ids` values
 fail without creating daemon runtime files or issuing RPC. Service endpoint
 flags are validated the same way: `--host` must be a DNS hostname or IPv4
-address, and `--port` must be an integer in `1..65535`.
+address, and `--port` must be a plain ASCII decimal integer in `1..65535`.
 Omit `--gpu-ids` to use all visible GPUs; an explicit empty or whitespace-only
 value is invalid.
 `--interval` must be finite, positive, and within the Python runtime wait

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -31,7 +31,8 @@ keep-gpu-mcp-server --mode http --host 127.0.0.1 --port 8765
 ```
 
 HTTP endpoint inputs are validated before socket bind. `--host` must be a DNS
-hostname or IPv4 address, and `--port` must be an integer in `1..65535`.
+hostname or IPv4 address, and `--port` must be a plain ASCII decimal integer
+in `1..65535`.
 
 ## MCP protocol over stdio
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,7 +35,7 @@ Starts local KeepGPU service (HTTP + JSON-RPC + dashboard).
 | Option | Default | Description |
 | --- | --- | --- |
 | `--host` | `127.0.0.1` | Service bind host. Must be a DNS hostname or IPv4 address. |
-| `--port` | `8765` | Service port as an integer in `1..65535`. |
+| `--port` | `8765` | Service port as a plain ASCII decimal integer in `1..65535`. |
 
 ### `keep-gpu start`
 
@@ -65,7 +65,7 @@ the service log at
 | `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact; invalid values are rejected before auto-start. |
-| `--port` | `8765` | Service port to contact; must be an integer in `1..65535`. |
+| `--port` | `8765` | Service port to contact; must be a plain ASCII decimal integer in `1..65535`. |
 | `--auto-start/--no-auto-start` | `--auto-start` | Auto-start local service if unavailable. |
 
 ### `keep-gpu status`
@@ -153,7 +153,7 @@ known and exactly matches the stored ownership record.
 
 | Option | Description |
 | --- | --- |
-| `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be an integer in `1..65535`. |
+| `--host`, `--port` | Service host/port. `--host` must be a DNS hostname or IPv4 address, and `--port` must be a plain ASCII decimal integer in `1..65535`. |
 | `--force` | Skip session RPC checks and stop the daemon only if the auto-start ownership record verifies the process. |
 
 ## Service HTTP endpoints

--- a/src/keep_gpu/utilities/endpoint_validation.py
+++ b/src/keep_gpu/utilities/endpoint_validation.py
@@ -50,12 +50,14 @@ def validate_endpoint_port(port: Any) -> int:
     if isinstance(port, int):
         parsed_port = port
     elif isinstance(port, str):
-        if not port or port.strip() != port:
+        if (
+            not port
+            or port.strip() != port
+            or not port.isascii()
+            or not port.isdecimal()
+        ):
             raise ValueError(ENDPOINT_PORT_ERROR)
-        try:
-            parsed_port = int(port)
-        except ValueError:
-            raise ValueError(ENDPOINT_PORT_ERROR) from None
+        parsed_port = int(port)
     else:
         raise ValueError(ENDPOINT_PORT_ERROR)
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -64,6 +64,9 @@ def _wait_until(condition, timeout_s=1.0):
         (["--port", "0"], "port must be an integer between 1 and 65535"),
         (["--port", "70000"], "port must be an integer between 1 and 65535"),
         (["--port", "true"], "port must be an integer between 1 and 65535"),
+        (["--port", "+8765"], "port must be an integer between 1 and 65535"),
+        (["--port", "8_765"], "port must be an integer between 1 and 65535"),
+        (["--port", "１２３"], "port must be an integer between 1 and 65535"),
         (["--host", "bad host"], "host must be a DNS hostname or IPv4 address"),
     ],
 )

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -624,8 +624,11 @@ def test_service_json_command_rejects_invalid_port_before_rpc(monkeypatch):
     ("command", "called_key"),
     [
         (["status", "--port", "abc"], "rpc"),
+        (["status", "--port", "+8765"], "rpc"),
         (["stop", "--all", "--port", "abc"], "stop_all"),
+        (["stop", "--all", "--port", "8_765"], "stop_all"),
         (["list-gpus", "--port", "abc"], "rpc"),
+        (["list-gpus", "--port", "１２３"], "rpc"),
     ],
 )
 def test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback(

--- a/tests/utilities/test_endpoint_validation.py
+++ b/tests/utilities/test_endpoint_validation.py
@@ -59,7 +59,23 @@ def test_validate_endpoint_port_accepts_ints_and_clean_digit_strings(port):
 
 @pytest.mark.parametrize(
     "port",
-    [0, 65536, -1, True, False, "", " ", "abc", " 8765", "8765 ", 8765.0, None],
+    [
+        0,
+        65536,
+        -1,
+        True,
+        False,
+        "",
+        " ",
+        "abc",
+        " 8765",
+        "8765 ",
+        "+8765",
+        "8_765",
+        "１２３",
+        8765.0,
+        None,
+    ],
 )
 def test_validate_endpoint_port_rejects_invalid_values(port):
     with pytest.raises(ValueError, match=ENDPOINT_PORT_ERROR):


### PR DESCRIPTION
## Summary
- require public endpoint port strings to be plain ASCII decimal digits before conversion
- reject signed, underscored, and non-ASCII digit port strings consistently through CLI JSON commands and the MCP HTTP executable
- document the shared endpoint-port contract in AGENTS.md and user docs without expanding README

## Test Plan
- [x] RED before fix: `PYTHONPATH=src pytest tests/utilities/test_endpoint_validation.py::test_validate_endpoint_port_rejects_invalid_values tests/test_cli_service_commands.py::test_service_json_commands_reject_non_integer_port_as_json_before_rpc_or_fallback tests/mcp/test_server.py::test_http_main_rejects_invalid_endpoint_before_binding -q` failed 9 tests before validator change
- [x] GREEN after fix: same regression set passed, `28 passed in 1.51s`
- [x] `PYTHONPATH=src pytest tests/utilities/test_endpoint_validation.py tests/test_cli_service_commands.py tests/mcp/test_server.py -q` -> `422 passed in 7.48s`
- [x] `PYTHONPATH=src pytest tests -q` -> `960 passed, 11 skipped in 70.24s`
- [x] `mkdocs build --strict` -> exit 0 with known Material for MkDocs warning
- [x] `pre-commit run --all-files --show-diff-on-failure` -> passed
- [x] `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> `13 passed`; Zenodo DOI badge remains in README and compact README test

## Local Review
- [x] Endpoint/API reviewer: no must-fix findings; reran focused affected subset, `60 passed in 2.09s`
- [x] Docs/tests reviewer: no must-fix findings; confirmed README unchanged and Zenodo badge present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified port requirements across CLI and MCP docs: ports must be plain ASCII decimal integers in the valid range.
  * Updated architecture guidance to reflect stricter validation rules for port values.

* **Bug Fixes**
  * Tightened port input handling so malformed values like `+8765`, `8_765`, whitespace-padded strings, and non-ASCII digits are rejected consistently.
  * Expanded test coverage for invalid port formats.

[skip_review]

<!-- end of auto-generated comment: release notes by coderabbit.ai -->