### PR TITLE
[mps,mcp] fix: classify unavailable backend as startup unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,10 +177,10 @@ This file defines how coding agents should work in this repository.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - Expected controller startup unavailability, such as no usable visible GPUs,
-  failed CUDA/ROCm visible-device enumeration, or unsupported platforms, must
-  surface as explicit startup-unavailable errors (direct JSON-RPC `-32000`,
-  REST `503`, MCP tool `isError=true`) while arbitrary unexpected
-  startup/runtime failures remain internal errors.
+  failed CUDA/ROCm visible-device enumeration, unavailable PyTorch MPS backends,
+  or unsupported platforms, must surface as explicit startup-unavailable errors
+  (direct JSON-RPC `-32000`, REST `503`, MCP tool `isError=true`) while
+  arbitrary unexpected startup/runtime failures remain internal errors.
 - Direct JSON-RPC and MCP tool `list_gpus` calls must classify expected
   `DeviceEnumerationUnavailableError` failures as startup-unavailable, matching
   REST `/api/gpus` `503` behavior; malformed GPU listing payloads remain

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -135,6 +135,8 @@ Vendor detection probes initialize and then shut down their telemetry libraries
 immediately, so detection does not leave NVML or ROCm SMI handles open. A PyTorch
 build with a truthy `torch.version.hip` is treated as ROCm before any NVML-based
 CUDA fallback, even if NVML is available on the host.
+CUDA/ROCm enumeration failures and unavailable PyTorch MPS backends are expected
+startup-unavailable conditions rather than internal service errors.
 
 Runtime telemetry has its own recovery path because GPU listing can run while a
 keeper is active. If an independent listing probe shuts down NVML or ROCm SMI,

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -102,8 +102,9 @@ Successful direct-method responses are KeepGPU JSON-RPC envelopes with
 For direct JSON-RPC calls, public validation failures and unknown parameters
 return JSON-RPC `-32602 Invalid params`. Expected startup-unavailable
 conditions, such as an unsupported controller platform, no usable visible GPUs,
-or failed CUDA/ROCm visible-device enumeration during `start_keep` or
-`list_gpus`, return `-32000` with the startup message. Unexpected server
+failed CUDA/ROCm visible-device enumeration during `start_keep` or `list_gpus`,
+or an unavailable PyTorch MPS backend during `start_keep`, return `-32000` with
+the startup message. Unexpected server
 failures use `-32603 Internal error`.
 
 Explicit `gpu_ids` that are validly shaped but outside the service process's
@@ -114,8 +115,9 @@ returns `-32602`, while MCP `tools/call` returns a tool result with
 MCP `tools/call` responses keep protocol envelopes successful for normal tool
 results, public tool-input validation failures, and expected hardware/platform
 startup-unavailable failures, including failed CUDA/ROCm device enumeration
-during `start_keep` or `list_gpus`. Those tool-level failures return
-`result.isError=true` with the message in tool content. Protocol shape errors,
+during `start_keep` or `list_gpus` and unavailable PyTorch MPS backends during
+`start_keep`. Those tool-level failures return `result.isError=true` with the
+message in tool content. Protocol shape errors,
 such as unknown tools, still return JSON-RPC errors such as `-32602`, and
 unexpected internal controller/runtime failures return JSON-RPC
 `-32603 Internal error`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -173,8 +173,9 @@ The dashboard consumes those JSON objects and displays `error.message` when it i
 present, falling back to the plain response body or HTTP status only when needed.
 Direct JSON-RPC service calls report the same expected hardware/platform
 startup-unavailable conditions, including failed CUDA/ROCm visible-device
-enumeration, with error code `-32000`; arbitrary runtime failures remain
-`-32603 Internal error`. CLI service commands send explicit JSON-RPC 2.0
+enumeration and unavailable PyTorch MPS backends, with error code `-32000`;
+arbitrary runtime failures remain `-32603 Internal error`. CLI service commands
+send explicit JSON-RPC 2.0
 request envelopes to `/rpc`; omitted-version direct calls are retained only for
 legacy local scripts.
 

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -68,6 +68,10 @@ class GlobalGPUController:
         self.vram_to_keep = vram_to_keep
         gpu_ids = validate_gpu_ids(gpu_ids)
         self.computing_platform = get_platform()
+        controller_unavailable_errors = (
+            VisibleRankValidationError,
+            DeviceEnumerationUnavailableError,
+        )
         if self.computing_platform == ComputingPlatform.CUDA:
             from keep_gpu.single_gpu_controller.cuda_gpu_controller import (
                 CudaGPUController,
@@ -83,9 +87,14 @@ class GlobalGPUController:
         elif self.computing_platform == ComputingPlatform.MACM:
             from keep_gpu.single_gpu_controller.macm_gpu_controller import (
                 MacMGPUController,
+                MPSBackendUnavailableError,
             )
 
             controller_cls = MacMGPUController
+            controller_unavailable_errors = (
+                *controller_unavailable_errors,
+                MPSBackendUnavailableError,
+            )
         else:
             raise UnsupportedControllerPlatformError(
                 f"GlobalGPUController not implemented for platform {self.computing_platform}"
@@ -121,9 +130,7 @@ class GlobalGPUController:
                 )
                 for i in self.gpu_ids
             ]
-        except VisibleRankValidationError as exc:
-            raise NoGPUAvailableError(str(exc)) from exc
-        except DeviceEnumerationUnavailableError as exc:
+        except controller_unavailable_errors as exc:
             raise NoGPUAvailableError(str(exc)) from exc
 
     def keep(self) -> None:

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -20,6 +20,10 @@ from keep_gpu.utilities.session_config import (
 logger = setup_logger(__name__)
 
 
+class MPSBackendUnavailableError(RuntimeError):
+    """PyTorch MPS cannot be used for a Mac M keep session."""
+
+
 class MacMGPUController(BaseGPUController):
     def __init__(
         self,
@@ -34,8 +38,14 @@ class MacMGPUController(BaseGPUController):
         busy_threshold = validate_busy_threshold(busy_threshold)
         iterations = validate_positive_integer(iterations, "iterations")
         rank = validate_visible_rank(rank, 1)
-        if not torch.backends.mps.is_available():
-            raise RuntimeError("PyTorch MPS backend is not available")
+        try:
+            mps_available = torch.backends.mps.is_available()
+        except RuntimeError as exc:
+            raise MPSBackendUnavailableError(
+                f"PyTorch MPS backend availability check failed: {exc}"
+            ) from exc
+        if not mps_available:
+            raise MPSBackendUnavailableError("PyTorch MPS backend is not available")
 
         self.rank = rank
         self.device = torch.device("mps")

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -3,7 +3,10 @@ import time
 import pytest
 import torch
 
-from keep_gpu.global_gpu_controller.global_gpu_controller import GlobalGPUController
+from keep_gpu.global_gpu_controller.global_gpu_controller import (
+    GlobalGPUController,
+    NoGPUAvailableError,
+)
 from keep_gpu.utilities import platform_manager as pm
 
 
@@ -130,6 +133,26 @@ def test_global_controller_rejects_explicit_rocm_id_outside_visible_count(
         GlobalGPUController(gpu_ids=[2], vram_to_keep="8MB")
 
     assert instances == []
+
+
+def test_global_controller_reports_unavailable_mps_as_startup_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: False,
+    )
+
+    with pytest.raises(
+        NoGPUAvailableError,
+        match="PyTorch MPS backend is not available",
+    ):
+        GlobalGPUController(gpu_ids=[0], vram_to_keep=4)
 
 
 def test_global_release_attempts_all_controllers_and_reports_failures():

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -15,6 +15,7 @@ from keep_gpu.mcp.server import (
     SessionStartupUnavailable,
     _JSONRPCHandler,
 )
+from keep_gpu.utilities import platform_manager as pm
 from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 
 
@@ -2047,6 +2048,37 @@ def test_http_post_sessions_startup_unavailable_returns_json_503(monkeypatch):
 
     assert status_code == 503
     assert payload["error"]["message"] == "No usable GPUs are available"
+    assert payload["error"]["type"] == "SessionStartupUnavailable"
+
+
+def test_http_post_sessions_unavailable_mps_returns_json_503(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: False,
+    )
+
+    server = KeepGPUServer()
+    httpd, thread, base = _start_http_server(server)
+
+    try:
+        status_code, payload = _request_json(
+            "POST",
+            f"{base}/api/sessions",
+            {"job_id": "mps-unavailable"},
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status_code == 503
+    assert payload["error"]["message"] == "PyTorch MPS backend is not available"
     assert payload["error"]["type"] == "SessionStartupUnavailable"
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -717,6 +717,35 @@ def test_jsonrpc_start_keep_unsupported_platform_returns_public_code(monkeypatch
         server.shutdown()
 
 
+def test_jsonrpc_start_keep_unavailable_mps_returns_public_code(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: False,
+    )
+
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "mps-unavailable", "gpu_ids": [0]},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+        assert "PyTorch MPS backend is not available" in resp["error"]["message"]
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
 def test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code(monkeypatch):
     import torch
 
@@ -1381,6 +1410,42 @@ def test_mcp_tools_call_startup_unavailable_returns_tool_error():
     assert result["isError"] is True
     assert "No usable GPUs are available" in result["content"][0]["text"]
     assert server.status()["active_jobs"] == []
+
+
+def test_mcp_tools_call_unavailable_mps_returns_tool_error(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: False,
+    )
+
+    server = KeepGPUServer()
+    req = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "start_keep",
+            "arguments": {"job_id": "tool-mps-unavailable", "gpu_ids": [0]},
+        },
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert resp["jsonrpc"] == "2.0"
+        assert resp["id"] == 4
+        assert "result" in resp
+        result = resp["result"]
+        assert result["isError"] is True
+        assert "PyTorch MPS backend is not available" in result["content"][0]["text"]
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
 
 
 def test_mcp_tools_call_out_of_range_gpu_ids_returns_tool_error(monkeypatch):


### PR DESCRIPTION
## Summary
- add a narrow `MPSBackendUnavailableError` for unavailable PyTorch MPS backend checks
- map that expected Mac M startup condition through `GlobalGPUController` to startup-unavailable responses
- cover JSON-RPC, MCP `tools/call`, REST `/api/sessions`, and the Python global controller path while preserving direct `MacMGPUController` `RuntimeError` compatibility
- document the startup-unavailable contract for unavailable MPS backends without changing README

## Test Plan
- [x] RED before fix: `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py::test_global_controller_reports_unavailable_mps_as_startup_unavailable tests/mcp/test_server.py::test_jsonrpc_start_keep_unavailable_mps_returns_public_code -q` failed with raw `RuntimeError` and JSON-RPC `-32603`
- [x] `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py::test_global_controller_reports_unavailable_mps_as_startup_unavailable tests/mcp/test_server.py::test_jsonrpc_start_keep_unavailable_mps_returns_public_code tests/mcp/test_server.py::test_mcp_tools_call_unavailable_mps_returns_tool_error tests/mcp/test_http_api.py::test_http_post_sessions_unavailable_mps_returns_json_503 tests/macm_controller/test_macm_backoff.py::test_macm_constructor_preserves_unavailable_mps_runtime_error -q` -> `5 passed in 2.05s`
- [x] `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py tests/macm_controller/test_macm_backoff.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> `325 passed, 1 skipped in 69.26s`
- [x] `PYTHONPATH=src pytest tests -q` -> `964 passed, 11 skipped in 71.36s`
- [x] `mkdocs build --strict` -> exit 0 with known Material for MkDocs warning
- [x] `pre-commit run --all-files --show-diff-on-failure` -> passed
- [x] `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> `13 passed`; Zenodo DOI badge remains in README

## Local Review
- [x] Behavior/API reviewer: no must-fix findings; confirmed the exception boundary is narrow and direct Mac callers still receive a `RuntimeError` subclass
- [x] Docs/tests reviewer: no must-fix findings; confirmed docs are compact and README/Zenodo badge are unchanged
