### PR TITLE
[cli] fix: reject mismatched targeted job results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,10 @@ This file defines how coding agents should work in this repository.
   the shared URL-path-safe job-id contract. Known nested `status.params` fields
   must match the public session contract while extra fields remain
   forward-compatible.
+- Targeted CLI service commands must reject success payloads for the wrong
+  session: `keep-gpu status --job-id X` requires response `job_id == X`, and
+  `keep-gpu stop --job-id X` requires every `stopped`, `timed_out`, `failed`,
+  and `errors` job id to be `X`.
 - CLI service endpoint inputs (`--host`, `--port`) must be validated locally
   before service RPC, daemon auto-start, stop-all fallback, or daemon ownership
   operations. JSON-output commands must return structured `{"error": "..."}`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,6 +79,8 @@ Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
 envelopes, including missing or non-string `error.message`, and malformed status
 job records are reported as JSON error objects instead of empty success results.
+When `--job-id` is supplied, the returned `job_id` must match the requested
+target or the response is rejected as malformed.
 The machine JSON stream is plain JSON without Rich color or highlighting, even
 when the command runs under a pseudo-TTY or forced-color terminal.
 Started sessions with terminal worker allocation/runtime failures remain listed
@@ -110,7 +112,8 @@ The output is a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
 envelopes, including missing or non-string `error.message`, and malformed stop
 result records are reported as JSON error objects instead of empty success
-results.
+results. When `--job-id` is supplied, all returned outcome and error job IDs
+must match the requested target.
 The machine JSON stream is plain JSON without Rich color or highlighting, even
 when the command runs under a pseudo-TTY or forced-color terminal.
 

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -780,7 +780,10 @@ def _validate_status_session_record(
 
 
 def _validate_status_result(
-    result: Dict[str, Any], *, single_job: bool
+    result: Dict[str, Any],
+    *,
+    single_job: bool,
+    expected_job_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if single_job:
         if not isinstance(result.get("active"), bool):
@@ -791,6 +794,10 @@ def _validate_status_result(
             _validate_status_session_record(result, "status", "result")
         else:
             _validate_result_job_id(result["job_id"], "status", "job_id")
+        if expected_job_id is not None and result["job_id"] != expected_job_id:
+            raise _malformed_method_result(
+                "status", "result.job_id must match requested job_id"
+            )
     else:
         active_jobs = _require_list_field(result, "active_jobs", "status")
         for index, active_job in enumerate(active_jobs):
@@ -804,7 +811,9 @@ def _validate_status_result(
     return result
 
 
-def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_stop_keep_result(
+    result: Dict[str, Any], *, expected_job_id: Optional[str] = None
+) -> Dict[str, Any]:
     outcomes: Dict[str, List[str]] = {}
     seen_jobs: Dict[str, str] = {}
     for field in ("stopped", "timed_out", "failed"):
@@ -843,6 +852,12 @@ def _validate_stop_keep_result(result: Dict[str, Any]) -> Dict[str, Any]:
         raise _malformed_method_result(
             "stop_keep", "errors keys must match failed job ids"
         )
+    if expected_job_id is not None:
+        outcome_jobs = set(seen_jobs)
+        if any(job_id != expected_job_id for job_id in outcome_jobs | error_jobs):
+            raise _malformed_method_result(
+                "stop_keep", "outcome job ids must match requested job_id"
+            )
     message = result.get("message")
     if "message" in result and not isinstance(message, str):
         raise _malformed_method_result("stop_keep", "message must be a string")
@@ -1240,7 +1255,11 @@ def status(
             host,
             port,
         )
-        result = _validate_status_result(result, single_job=job_id is not None)
+        result = _validate_status_result(
+            result,
+            single_job=job_id is not None,
+            expected_job_id=job_id,
+        )
         _print_machine_json(result)
     except (RuntimeError, typer.BadParameter) as exc:
         _print_machine_json({"error": str(exc)})
@@ -1283,7 +1302,7 @@ def stop(
                 port,
                 timeout=45.0,
             )
-            result = _validate_stop_keep_result(result)
+            result = _validate_stop_keep_result(result, expected_job_id=job_id)
         _print_machine_json(result)
     except (RuntimeError, typer.BadParameter) as exc:
         _print_machine_json({"error": str(exc)})

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -1126,6 +1126,36 @@ def test_status_job_allows_inactive_payload_without_session_fields(monkeypatch):
     assert payload == {"active": False, "job_id": "missing-job"}
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"active": False, "job_id": "other-job"},
+        {
+            "active": True,
+            "job_id": "other-job",
+            "params": {},
+            "state": "active",
+            "last_error": None,
+        },
+    ],
+)
+def test_status_job_rejects_mismatched_job_id_result(monkeypatch, payload):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == {"job_id": "job-1"}
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["status", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert "result.job_id must match requested job_id" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
 def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
     def fake_rpc(method, params, host, port, timeout=8.0):
         assert method == "stop_keep"
@@ -1140,6 +1170,53 @@ def test_stop_job_outputs_single_decoded_json_object(monkeypatch):
     assert result.exit_code == 0
     payload = _single_decoded_json_object(result.output)
     assert payload["stopped"] == ["job-1"]
+
+
+def test_stop_job_allows_empty_not_found_result(monkeypatch):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "missing-job"}
+        assert timeout == 45.0
+        return {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "missing-job"])
+
+    assert result.exit_code == 0
+    payload = _single_decoded_json_object(result.output)
+    assert payload == {"stopped": [], "timed_out": [], "failed": [], "errors": {}}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"stopped": ["other-job"], "timed_out": [], "failed": [], "errors": {}},
+        {"stopped": [], "timed_out": ["other-job"], "failed": [], "errors": {}},
+        {
+            "stopped": [],
+            "timed_out": [],
+            "failed": ["other-job"],
+            "errors": {"other-job": "release failed"},
+        },
+    ],
+)
+def test_stop_job_rejects_mismatched_job_id_result(monkeypatch, payload):
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        assert method == "stop_keep"
+        assert params == {"job_id": "job-1"}
+        assert timeout == 45.0
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["stop", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed stop_keep response" in decoded["error"]
+    assert "outcome job ids must match requested job_id" in decoded["error"]
+    assert "Traceback" not in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Reject `keep-gpu status --job-id X` service payloads whose returned `job_id` is not `X`.
- Reject `keep-gpu stop --job-id X` payloads whose outcome or error job ids refer to a different session.
- Document the targeted machine-JSON contract in AGENTS and the CLI reference.

## Test Plan
- RED: `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_status_job_rejects_mismatched_job_id_result tests/test_cli_service_commands.py::test_stop_job_rejects_mismatched_job_id_result -q` failed with 5 failures because mismatched results exited successfully.
- GREEN: same mismatch tests passed after the fix: `5 passed`.
- Targeted CLI shard: `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q` -> `250 passed`.
- Broader affected shard: `PYTHONPATH=src pytest tests/test_cli_service_commands.py tests/test_cli_thresholds.py tests/utilities/test_session_config.py -q` -> `334 passed`.
- Reviewer-suggested shard after positive not-found test: `7 passed`.
- Full suite: `PYTHONPATH=src pytest tests -q` -> `1014 passed, 11 skipped`.
- Docs: `mkdocs build --strict` passed with the known Material for MkDocs warning.
- Quality gate: `pre-commit run --all-files --show-diff-on-failure` passed.
- Metadata badge guard: `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> `13 passed`.
- Badge check: `rg -n "zenodo.org/badge|doi.org/10.5281/zenodo" README.md tests/test_package_metadata.py` confirms README line 5 and test pin.

## Local Review
- Local subagent review found no Critical or Important issues.
- Minor suggestion to add an explicit targeted-stop not-found success regression was addressed before this PR.
