### PR TITLE
[mcp] fix: reject bad-version notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,9 @@ This file defines how coding agents should work in this repository.
   (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
   preserving legacy direct JSON-RPC method calls for local scripts.
 - JSON-RPC handlers must reject explicit request versions other than `"2.0"`
-  with `-32600 Invalid Request` for request messages while preserving
-  omitted-version legacy/internal calls and silent id-less notifications.
+  with `-32600 Invalid Request` before applying notification silence, including
+  id-less notifications, while preserving omitted-version legacy/internal calls
+  and silent valid or omitted-version id-less notifications.
 - JSON-RPC error envelopes must use `id: null` when the request id is missing or
   has an invalid response-id type, and must echo only valid non-boolean string or
   integer ids.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -58,8 +58,9 @@ The stdio transport writes only JSON protocol messages to stdout. KeepGPU logs
 and diagnostics go to stderr so MCP clients can parse stdout safely.
 
 JSON-RPC request messages that include a `jsonrpc` version must use `"2.0"`;
-id-less `notifications/*` messages remain silent and do not produce response
-envelopes.
+valid id-less `notifications/*` messages remain silent and do not produce
+response envelopes. Id-less notifications with an explicit non-`"2.0"`
+`jsonrpc` version return `-32600 Invalid Request` with `id: null`.
 
 ## HTTP JSON-RPC quick example
 

--- a/docs/plans/jsonrpc-invalid-id-null.md
+++ b/docs/plans/jsonrpc-invalid-id-null.md
@@ -16,8 +16,9 @@ the existing behavior that valid string and integer ids are echoed in responses.
 
 - Add MCP server tests for invalid JSON-RPC id types.
 - Keep valid integer and string id behavior unchanged.
-- Preserve id-less notification handling: id-less `notifications/*` messages do
-  not receive responses, and missing-id requests receive `id: null` errors.
+- Preserve id-less notification handling: valid or omitted-version id-less
+  `notifications/*` messages do not receive responses, while explicit invalid
+  JSON-RPC versions and missing-id requests receive `id: null` errors.
 - Update `_handle_request` so the response id is assigned only after the raw id
   passes JSON-RPC id validation.
 

--- a/docs/plans/jsonrpc-request-version-validation.md
+++ b/docs/plans/jsonrpc-request-version-validation.md
@@ -16,14 +16,14 @@ The audit found that `_handle_request()` accepts requests such as `{"jsonrpc": "
 
 ## Solution
 
-Add explicit version validation in `_handle_request()` after confirming the payload is an object and before method dispatch. If a non-notification request message includes `jsonrpc` and its value is not `"2.0"`, return `JSONRPC_INVALID_REQUEST` (`-32600`). Do not require `jsonrpc` for legacy/internal direct calls, and keep id-less `notifications/*` messages silent even when they carry a malformed version.
+Add explicit version validation in `_handle_request()` after confirming the payload is an object and before method dispatch. If a request message includes `jsonrpc` and its value is not `"2.0"`, return `JSONRPC_INVALID_REQUEST` (`-32600`), including for id-less notifications. Do not require `jsonrpc` for legacy/internal direct calls, and keep valid or omitted-version id-less `notifications/*` messages silent.
 
 ## Tasks
 
 - [x] Add RED tests in `tests/mcp/test_server.py` for invalid explicit version, valid explicit `"2.0"`, and omitted legacy version.
 - [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q` and confirm the invalid-version test fails before implementation.
 - [x] Implement the minimal `_handle_request()` validation in `src/keep_gpu/mcp/server.py`.
-- [x] Preserve id-less notification silence before request-only version validation.
+- [x] Preserve valid or omitted-version id-less notification silence after explicit version validation.
 - [x] Update `AGENTS.md` with the JSON-RPC version compatibility note.
 - [x] Run `PYTHONPATH=$PWD/src pytest tests/mcp/test_server.py -q`.
 - [x] Run `git diff --check`.

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -946,10 +946,10 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
         params = payload.get("params", {})
         if not isinstance(method, str) or not method:
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Request method is required.")
-        if method.startswith("notifications/") and "id" not in payload:
-            return None
         if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "JSON-RPC version must be 2.0.")
+        if method.startswith("notifications/") and "id" not in payload:
+            return None
         if "id" not in payload or not _is_valid_jsonrpc_id(raw_id):
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Requests must include an id.")
         if method.startswith("notifications/"):

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -778,6 +778,26 @@ def test_http_jsonrpc_parse_error_returns_jsonrpc_envelope(rpc_path):
     assert payload["error"]["code"] == -32700
 
 
+def test_http_rpc_bad_version_notification_returns_invalid_request_envelope():
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+    request = {"jsonrpc": "1.0", "method": "notifications/initialized"}
+
+    try:
+        status, payload = _request_json("POST", f"{base}/rpc", request)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] is None
+    assert payload["error"]["code"] == -32600
+    assert payload["error"]["message"] == "JSON-RPC version must be 2.0."
+
+
 def test_http_post_sessions_rejects_negative_content_length_without_client_close():
     server = make_server()
     httpd, thread, _ = _start_threaded_http_server(server)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1308,13 +1308,16 @@ def test_mcp_initialized_notification_has_no_response():
     assert resp is None
 
 
-def test_mcp_initialized_notification_with_bad_version_has_no_response():
+def test_mcp_initialized_notification_with_bad_version_is_invalid_request():
     server = make_server()
     req = {"jsonrpc": "1.0", "method": "notifications/initialized"}
 
     resp = _handle_request(server, req)
 
-    assert resp is None
+    assert resp["jsonrpc"] == "2.0"
+    assert resp["id"] is None
+    assert resp["error"]["code"] == JSONRPC_INVALID_REQUEST
+    assert resp["error"]["message"] == "JSON-RPC version must be 2.0."
 
 
 def test_mcp_tools_list_exposes_keepgpu_actions():
@@ -1759,6 +1762,34 @@ def test_mcp_stdio_parse_errors_are_jsonrpc_errors():
     assert response["id"] is None
     assert response["error"]["code"] == -32700
     assert "Expecting property name" in response["error"]["message"]
+
+
+def test_mcp_stdio_bad_version_notification_is_invalid_request_error():
+    request = {"jsonrpc": "1.0", "method": "notifications/initialized"}
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "keep_gpu.mcp.server"],
+        input=json.dumps(request) + "\n",
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(stdout_lines) == 1
+    response = json.loads(stdout_lines[0])
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] is None
+    assert response["error"]["code"] == JSONRPC_INVALID_REQUEST
+    assert response["error"]["message"] == "JSON-RPC version must be 2.0."
 
 
 def test_mcp_stdio_non_object_messages_are_invalid_request_errors():


### PR DESCRIPTION
## Summary
- reject explicit non-2.0 JSON-RPC versions before id-less notification silence
- return `-32600 Invalid Request` with `id: null` for bad-version notifications across direct handling, stdio, and HTTP `/rpc`
- update MCP/agent contract docs while preserving valid/omitted-version notification silence and legacy omitted-version direct calls

## Verification
- RED: `PYTHONPATH=src pytest tests/mcp/test_server.py::test_mcp_initialized_notification_with_bad_version_is_invalid_request tests/mcp/test_http_api.py::test_http_rpc_bad_version_notification_returns_invalid_request_envelope -q` failed with direct `None` and HTTP `202`
- RED: `PYTHONPATH=src pytest tests/mcp/test_server.py::test_mcp_stdio_bad_version_notification_is_invalid_request_error -q` failed with zero stdout lines under the old handler order
- GREEN: `PYTHONPATH=src pytest tests/mcp/test_server.py::test_mcp_initialized_notification_with_bad_version_is_invalid_request tests/mcp/test_server.py::test_mcp_stdio_bad_version_notification_is_invalid_request_error tests/mcp/test_http_api.py::test_http_rpc_bad_version_notification_returns_invalid_request_envelope -q` -> 3 passed
- `PYTHONPATH=src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> 300 passed
- `PYTHONPATH=src pytest tests -q` -> 1016 passed, 11 skipped
- `mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> 13 passed

## Local Review
- local subagent review found no Critical, Important, or Minor issues
- reviewer also ran a focused compatibility set -> 5 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests that include a `jsonrpc` version other than `"2.0"` now return a clear `Invalid Request` error instead of being silently ignored.
  * Id-less notification-style messages with an explicit invalid version now produce a JSON-RPC error response with `id: null`.

* **Documentation**
  * Clarified JSON-RPC and MCP guidance to better describe when notifications remain silent and when errors are returned.

* **Tests**
  * Added coverage for invalid-version notification handling over both HTTP and stdio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->