### PR TITLE
[macm] fix: classify mps probe failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,10 +178,11 @@ This file defines how coding agents should work in this repository.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
 - JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
 - Expected controller startup unavailability, such as no usable visible GPUs,
-  failed CUDA/ROCm visible-device enumeration, unavailable PyTorch MPS backends,
-  or unsupported platforms, must surface as explicit startup-unavailable errors
-  (direct JSON-RPC `-32000`, REST `503`, MCP tool `isError=true`) while
-  arbitrary unexpected startup/runtime failures remain internal errors.
+  failed CUDA/ROCm visible-device enumeration, unavailable or unprobeable
+  PyTorch MPS backends, or unsupported platforms, must surface as explicit
+  startup-unavailable errors (direct JSON-RPC `-32000`, REST `503`, MCP tool
+  `isError=true`) while arbitrary unexpected startup/runtime failures remain
+  internal errors.
 - Direct JSON-RPC and MCP tool `list_gpus` calls must classify expected
   `DeviceEnumerationUnavailableError` failures as startup-unavailable, matching
   REST `/api/gpus` `503` behavior; malformed GPU listing payloads remain

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -135,8 +135,9 @@ Vendor detection probes initialize and then shut down their telemetry libraries
 immediately, so detection does not leave NVML or ROCm SMI handles open. A PyTorch
 build with a truthy `torch.version.hip` is treated as ROCm before any NVML-based
 CUDA fallback, even if NVML is available on the host.
-CUDA/ROCm enumeration failures and unavailable PyTorch MPS backends are expected
-startup-unavailable conditions rather than internal service errors.
+CUDA/ROCm enumeration failures and unavailable or unprobeable PyTorch MPS
+backends are expected startup-unavailable conditions rather than internal
+service errors.
 
 Runtime telemetry has its own recovery path because GPU listing can run while a
 keeper is active. If an independent listing probe shuts down NVML or ROCm SMI,

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -40,7 +40,7 @@ class MacMGPUController(BaseGPUController):
         rank = validate_visible_rank(rank, 1)
         try:
             mps_available = torch.backends.mps.is_available()
-        except RuntimeError as exc:
+        except Exception as exc:
             raise MPSBackendUnavailableError(
                 f"PyTorch MPS backend availability check failed: {exc}"
             ) from exc

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -155,6 +155,29 @@ def test_global_controller_reports_unavailable_mps_as_startup_unavailable(
         GlobalGPUController(gpu_ids=[0], vram_to_keep=4)
 
 
+def test_global_controller_reports_mps_probe_exception_as_startup_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    def raise_probe_error():
+        raise ValueError("MPS probe exploded")
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        raise_probe_error,
+    )
+
+    with pytest.raises(
+        NoGPUAvailableError,
+        match="PyTorch MPS backend availability check failed: MPS probe exploded",
+    ):
+        GlobalGPUController(gpu_ids=[0], vram_to_keep=4)
+
+
 def test_global_release_attempts_all_controllers_and_reports_failures():
     class DummyController:
         def __init__(self, rank, error=None):

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -2,7 +2,10 @@ import threading
 
 import pytest
 
-from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
+from keep_gpu.single_gpu_controller.macm_gpu_controller import (
+    MacMGPUController,
+    MPSBackendUnavailableError,
+)
 
 
 class _StopAfterOneWait:
@@ -113,6 +116,29 @@ def test_macm_constructor_preserves_unavailable_mps_runtime_error(monkeypatch):
 
     with pytest.raises(RuntimeError, match="PyTorch MPS backend is not available"):
         MacMGPUController(rank=0, busy_threshold=25, iterations=1)
+
+
+def test_macm_constructor_wraps_mps_probe_exception(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    probe_error = ValueError("mps probe corrupted")
+
+    def raise_probe_error():
+        raise probe_error
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        raise_probe_error,
+    )
+
+    with pytest.raises(
+        MPSBackendUnavailableError,
+        match="PyTorch MPS backend availability check failed: mps probe corrupted",
+    ) as exc_info:
+        MacMGPUController(rank=0, busy_threshold=25, iterations=1)
+
+    assert exc_info.value.__cause__ is probe_error
 
 
 def test_macm_keep_rejects_restart_while_previous_thread_is_stopping():

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -746,6 +746,41 @@ def test_jsonrpc_start_keep_unavailable_mps_returns_public_code(monkeypatch):
         server.shutdown()
 
 
+def test_jsonrpc_start_keep_mps_probe_exception_returns_public_code(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.MACM)
+
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    def raise_probe_error():
+        raise ValueError("MPS probe exploded")
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        raise_probe_error,
+    )
+
+    server = KeepGPUServer()
+    req = {
+        "id": 1,
+        "method": "start_keep",
+        "params": {"job_id": "mps-probe-error", "gpu_ids": [0]},
+    }
+
+    try:
+        resp = _handle_request(server, req)
+
+        assert "error" in resp
+        assert resp["error"]["code"] == JSONRPC_STARTUP_UNAVAILABLE
+        assert (
+            "PyTorch MPS backend availability check failed: MPS probe exploded"
+            in resp["error"]["message"]
+        )
+        assert server.status()["active_jobs"] == []
+    finally:
+        server.shutdown()
+
+
 def test_jsonrpc_start_keep_zero_visible_gpus_returns_public_code(monkeypatch):
     import torch
 


### PR DESCRIPTION
## Summary
- wrap failed `torch.backends.mps.is_available()` probes as `MPSBackendUnavailableError`
- preserve the startup-unavailable path through global controller and direct JSON-RPC `start_keep`
- document that unavailable or unprobeable MPS backends are startup-unavailable

## Verification
- RED: `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py::test_global_controller_reports_mps_probe_exception_as_startup_unavailable tests/mcp/test_server.py::test_jsonrpc_start_keep_mps_probe_exception_returns_public_code -q` failed with raw `ValueError` and JSON-RPC `-32603`
- RED: `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_constructor_wraps_mps_probe_exception -q` failed against the old `except RuntimeError` path
- GREEN: `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py::test_macm_constructor_wraps_mps_probe_exception tests/global_controller/global_keep_test.py::test_global_controller_reports_mps_probe_exception_as_startup_unavailable tests/mcp/test_server.py::test_jsonrpc_start_keep_mps_probe_exception_returns_public_code -q` -> 3 passed
- `PYTHONPATH=src pytest tests/macm_controller/test_macm_backoff.py tests/global_controller/global_keep_test.py tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> 336 passed, 1 skipped
- `PYTHONPATH=src pytest tests -q` -> 1019 passed, 11 skipped
- `mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> 13 passed

## Local Review
- local subagent review found no Critical, Important, or Minor issues
- reviewer agreed extra REST/MCP tool probe-exception tests would be redundant because the concrete wrapper, global mapping, direct JSON-RPC mapping, and existing startup-unavailable surfaces are already covered
