### PR TITLE
[rocm] fix: clean up failed thread startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,9 @@ This file defines how coding agents should work in this repository.
   sessions. Eco-safe busy/unknown-telemetry deferral and recoverable OOM retries
   may still complete startup without allocating; recoverable OOM retries must
   clear the backend cache before sleeping and retrying.
+- Failed single-GPU startup paths must clear any vendor-library initialization
+  and stale `_thread`/`_stop_evt` state before re-raising unless a real worker is
+  still alive and explicitly stopping.
 - Internal single-GPU startup paths that receive a `startup_evt` must always
   signal it before returning, and paths without a `startup_errors` list must
   retain the failure detail in `allocation_status()`.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -126,6 +126,9 @@ Elementwise keep-alive batches:
   clearing the device cache. Internal startup waiters are always signaled before
   the worker returns, and no-error-list internal paths retain failure details in
   `allocation_status()`.
+- If startup fails before a worker is running, controller state and any
+  initialized vendor telemetry library are cleared before the original failure
+  is re-raised.
 
 ## Platform detection
 

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -90,7 +90,13 @@ class RocmGPUController(BaseGPUController):
             name=f"gpu-keeper-rocm-{self.rank}",
             daemon=True,
         )
-        self._thread.start()
+        try:
+            self._thread.start()
+        except Exception:  # noqa: BLE001 - preserve original thread-start failure
+            self._thread = None
+            self._stop_evt = None
+            self._shutdown_rocm_smi()
+            raise
         startup_timeout = 5.0
         if not startup_evt.wait(startup_timeout):
             stop_evt = self._stop_evt

--- a/tests/rocm_controller/test_rocm_backoff.py
+++ b/tests/rocm_controller/test_rocm_backoff.py
@@ -183,6 +183,45 @@ def test_rocm_keep_shuts_down_smi_when_worker_startup_fails(monkeypatch):
     assert calls == ["init", "shutdown"]
 
 
+def test_rocm_keep_shuts_down_smi_when_thread_start_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+
+    monkeypatch.setattr(rocm_module.torch.cuda, "device_count", lambda: 1)
+    calls = []
+
+    class DummyRocmSmi:
+        def rsmi_init(self):
+            calls.append("init")
+
+        def rsmi_shut_down(self):
+            calls.append("shutdown")
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(rocm_module.threading, "Thread", FailingThread)
+
+    ctrl = RocmGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+    )
+    ctrl._rocm_smi = DummyRocmSmi()
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        ctrl.keep()
+
+    assert calls == ["init", "shutdown"]
+    assert ctrl._rocm_smi_initialized is False
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
 def test_rocm_keep_rejects_retry_while_startup_thread_is_stopping(monkeypatch):
     import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
 


### PR DESCRIPTION
## Summary
- clear stale ROCm startup thread/stop-event state when `Thread.start()` itself fails
- shut down ROCm SMI after pre-worker startup failures while preserving the original exception
- document the single-GPU startup cleanup invariant

## Verification
- RED: `PYTHONPATH=src pytest tests/rocm_controller/test_rocm_backoff.py::test_rocm_keep_shuts_down_smi_when_thread_start_fails -q` failed with `calls == ["init"]`
- GREEN: `PYTHONPATH=src pytest tests/rocm_controller/test_rocm_backoff.py::test_rocm_keep_shuts_down_smi_when_thread_start_fails tests/rocm_controller/test_rocm_backoff.py::test_rocm_keep_shuts_down_smi_when_worker_startup_fails -q` -> 2 passed
- `PYTHONPATH=src pytest tests/rocm_controller/test_rocm_backoff.py tests/rocm_controller/test_rocm_utilization.py -q` -> 50 passed
- `PYTHONPATH=src pytest tests -q` -> 1020 passed, 11 skipped
- `mkdocs build --strict` -> passed with known Material for MkDocs warning
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=src pytest tests/test_package_metadata.py -q` -> 13 passed

## Local Review
- local subagent review found no Critical, Important, or Minor issues
- reviewer confirmed clearing `_thread`/`_stop_evt` is adequate because no worker is live if stdlib `Thread.start()` raises
