### PR TITLE
[controllers] fix: clear state on thread start failure

### DIFF
--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -124,7 +124,12 @@ class CudaGPUController(BaseGPUController):
             name=f"gpu-keeper-{self.rank}",
             daemon=True,  # daemon so program can exit cleanly
         )
-        self._thread.start()
+        try:
+            self._thread.start()
+        except Exception:  # noqa: BLE001 - preserve original thread-start failure
+            self._thread = None
+            self._stop_evt = None
+            raise
         startup_timeout = 5.0
         if not startup_evt.wait(startup_timeout):
             stop_evt = self._stop_evt

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -81,7 +81,12 @@ class MacMGPUController(BaseGPUController):
             name=f"gpu-keeper-macm-{self.rank}",
             daemon=True,
         )
-        self._thread.start()
+        try:
+            self._thread.start()
+        except Exception:  # noqa: BLE001 - preserve original thread-start failure
+            self._thread = None
+            self._stop_evt = None
+            raise
         startup_timeout = 5.0
         if not startup_evt.wait(startup_timeout):
             stop_evt = self._stop_evt

--- a/tests/cuda_controller/test_keep_and_release.py
+++ b/tests/cuda_controller/test_keep_and_release.py
@@ -58,6 +58,34 @@ def test_cuda_keep_raises_when_startup_allocation_fails(monkeypatch):
     assert ctrl._stop_evt is None
 
 
+def test_cuda_keep_clears_state_when_thread_start_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module.torch.cuda, "device_count", lambda: 1)
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(cuda_module.threading, "Thread", FailingThread)
+
+    ctrl = CudaGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+    )
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
 def test_cuda_keep_returns_when_startup_defers_for_unknown_utilization(monkeypatch):
     import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
 

--- a/tests/macm_controller/test_macm_backoff.py
+++ b/tests/macm_controller/test_macm_backoff.py
@@ -184,6 +184,39 @@ def test_macm_keep_raises_when_startup_allocation_fails(monkeypatch):
     assert ctrl._stop_evt is None
 
 
+def test_macm_keep_clears_state_when_thread_start_fails(monkeypatch):
+    import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+
+    monkeypatch.setattr(
+        macm_module.torch.backends.mps,
+        "is_available",
+        lambda: True,
+    )
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(macm_module.threading, "Thread", FailingThread)
+
+    ctrl = MacMGPUController(
+        rank=0,
+        interval=0.01,
+        vram_to_keep=4,
+        busy_threshold=-1,
+        iterations=1,
+    )
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        ctrl.keep()
+
+    assert ctrl._thread is None
+    assert ctrl._stop_evt is None
+
+
 def test_macm_unknown_utilization_backs_off_when_threshold_enabled():
     assert MacMGPUController._should_run_batch(None, 10) is False
 


### PR DESCRIPTION
## Summary

- clear CUDA controller `_thread` and `_stop_evt` when `Thread.start()` raises
- clear MPS controller `_thread` and `_stop_evt` when `Thread.start()` raises
- add CUDA and MPS regressions mirroring the existing ROCm cleanup behavior

## Why

A thread/resource startup failure can happen before a keep worker ever runs. CUDA and MPS previously left a stale thread object and stop event behind on that path, while ROCm already cleaned them up. This aligns all single-GPU controllers with the startup lifecycle contract in `AGENTS.md`.

## Local verification

- RED before fix: the two new tests failed because `_thread` retained the fake `FailingThread` object.
- GREEN after fix:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests/cuda_controller/test_keep_and_release.py::test_cuda_keep_clears_state_when_thread_start_fails tests/macm_controller/test_macm_backoff.py::test_macm_keep_clears_state_when_thread_start_fails -q` (`2 passed`)
- Controller shard:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests/cuda_controller/test_keep_and_release.py tests/macm_controller/test_macm_backoff.py tests/rocm_controller/test_rocm_backoff.py -q` (`63 passed, 2 skipped`)
- Wider backend/controller shard:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests/cuda_controller tests/macm_controller tests/rocm_controller tests/single_gpu_controller tests/global_controller tests/utilities/test_platform_manager.py tests/utilities/test_gpu_info.py -q` (`259 passed, 11 skipped`)
- `pre-commit run --all-files --show-diff-on-failure`
- Full suite:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests -q` (`1022 passed, 11 skipped`)
- Final pre-commit gate:
  - `git diff --check`
  - focused regression tests again (`2 passed`)

## Local review

Local subagent review completed with no Critical, Important, or Minor findings. Reviewer confirmed the cleanup preserves the original exception, avoids unnecessary cache/vendor cleanup, matches ROCm behavior, and needs no docs update because the AGENTS lifecycle contract already covers this behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU keep/startup handling so a failed background thread launch no longer leaves the controller in a partially initialized state.
  * If startup fails, internal controller state is now cleared before the error is returned.
* **Tests**
  * Added coverage to verify controller state is reset when thread startup fails on both CUDA and macOS GPU paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->