### PR TITLE
[rpc] fix: reject nonstandard json constants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,10 @@ This file defines how coding agents should work in this repository.
 - HTTP JSON-RPC endpoints (`/` and `/rpc`) must return JSON-RPC envelopes for
   protocol parse errors, including `jsonrpc`, `id`, and numeric `error.code`;
   REST routes keep REST-shaped structured JSON errors.
+- Public protocol JSON decoders must reject non-standard JSON constants such as
+  `NaN`, `Infinity`, and `-Infinity` as parse errors. Do not use permissive
+  `json.loads` defaults at CLI service-response, HTTP request-body, or stdio
+  JSON-RPC boundaries.
 - HTTP body readers must validate parser-normalized `Content-Length` as exactly
   one plain ASCII decimal non-negative integer before reading. Duplicate values,
   signs, underscores, and other non-digit forms must fail quickly with REST JSON

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -71,8 +71,9 @@ slashes, query strings, leading double slashes such as `//rpc`, or encoded
 aliases such as `/rp%63` and `/%2Frpc`, return structured `404 Unknown endpoint`
 errors.
 
-Malformed HTTP JSON-RPC bodies return a JSON-RPC `-32700 Parse error` envelope
-with `id: null`; REST routes keep REST-shaped JSON errors.
+Malformed HTTP JSON-RPC bodies, including non-standard constants such as `NaN`
+or `Infinity`, return a JSON-RPC `-32700 Parse error` envelope with `id: null`;
+REST routes keep REST-shaped JSON errors.
 
 ```bash
 curl -X POST http://127.0.0.1:8765/rpc \

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -24,6 +24,7 @@ from keep_gpu.utilities.endpoint_validation import (
     validate_endpoint_port,
 )
 from keep_gpu.utilities.humanized_input import parse_vram_to_elements
+from keep_gpu.utilities.json_protocol import strict_json_loads
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.session_config import (
     DEFAULT_BUSY_THRESHOLD,
@@ -202,7 +203,7 @@ def _read_service_pid_record(host: str, port: int) -> Optional[Dict[str, Any]]:
         return None
     try:
         raw = pid_path.read_text(encoding="utf-8").strip()
-        payload = json.loads(raw)
+        payload = strict_json_loads(raw)
     except (OSError, json.JSONDecodeError, ValueError):
         return None
     if isinstance(payload, int) and not isinstance(payload, bool) and payload > 0:
@@ -451,7 +452,7 @@ def _http_json_request(
             if not body:
                 return {}
             try:
-                return json.loads(body)
+                return strict_json_loads(body)
             except (json.JSONDecodeError, ValueError) as exc:
                 raise ServiceResponseError(
                     f"Non-JSON response from service endpoint: {url}"

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -54,6 +54,7 @@ from keep_gpu.utilities.humanized_input import (
     PUBLIC_VRAM_MAX_BYTES,
     parse_vram_to_elements,
 )
+from keep_gpu.utilities.json_protocol import strict_json_loads
 from keep_gpu.utilities.logger import setup_logger
 from keep_gpu.utilities.platform_manager import DeviceEnumerationUnavailableError
 from keep_gpu.utilities.session_config import (
@@ -1199,7 +1200,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
                 f"Request body too large: {length} bytes (max {MAX_JSON_BODY_BYTES})"
             )
         body = self.rfile.read(length).decode("utf-8")
-        return json.loads(body)
+        return strict_json_loads(body)
 
     def _serve_static(self, request_path: str, write_body: bool = True) -> None:
         if request_path in ("/", ""):
@@ -1536,9 +1537,9 @@ def run_stdio(server: KeepGPUServer) -> None:
         if not line:
             continue
         try:
-            payload = json.loads(line)
+            payload = strict_json_loads(line)
             response = _handle_request(server, payload)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, ValueError) as exc:
             response = _jsonrpc_error(None, JSONRPC_PARSE_ERROR, str(exc))
         except Exception as exc:
             response = _jsonrpc_error(None, JSONRPC_INTERNAL_ERROR, str(exc))

--- a/src/keep_gpu/utilities/json_protocol.py
+++ b/src/keep_gpu/utilities/json_protocol.py
@@ -1,0 +1,13 @@
+"""Strict JSON helpers for public protocol boundaries."""
+
+import json
+from typing import Any
+
+
+def _reject_nonstandard_json_constant(constant: str) -> None:
+    raise ValueError(f"invalid JSON constant: {constant}")
+
+
+def strict_json_loads(data: Any) -> Any:
+    """Decode standard JSON while rejecting NaN and Infinity constants."""
+    return json.loads(data, parse_constant=_reject_nonstandard_json_constant)

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -778,6 +778,26 @@ def test_http_jsonrpc_parse_error_returns_jsonrpc_envelope(rpc_path):
     assert payload["error"]["code"] == -32700
 
 
+@pytest.mark.parametrize("rpc_path", ["/", "/rpc"])
+def test_http_jsonrpc_rejects_nonstandard_json_constants_as_parse_error(rpc_path):
+    server = make_server()
+    httpd, thread, base = _start_http_server(server)
+    body = b'{"jsonrpc":"2.0","id":1,"method":"tools/list","params":NaN}'
+
+    try:
+        status, payload = _request_raw("POST", f"{base}{rpc_path}", body)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] is None
+    assert payload["error"]["code"] == -32700
+
+
 def test_http_rpc_bad_version_notification_returns_invalid_request_envelope():
     server = make_server()
     httpd, thread, base = _start_http_server(server)
@@ -2271,7 +2291,7 @@ def test_http_post_rejects_non_positive_interval():
         thread.join(timeout=2)
 
 
-def test_http_post_rejects_nan_interval_without_creating_session():
+def test_http_post_rejects_nan_interval_as_bad_json_without_creating_session():
     server = make_server()
     httpd, thread, base = _start_http_server(server)
 
@@ -2288,7 +2308,7 @@ def test_http_post_rejects_nan_interval_without_creating_session():
         )
 
         assert status_code == 400
-        assert "interval must be finite and positive" in payload["error"]["message"]
+        assert "invalid JSON constant: NaN" in payload["error"]["message"]
         assert server.status()["active_jobs"] == []
     finally:
         httpd.shutdown()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1799,6 +1799,33 @@ def test_mcp_stdio_parse_errors_are_jsonrpc_errors():
     assert "Expecting property name" in response["error"]["message"]
 
 
+def test_mcp_stdio_rejects_nonstandard_json_constants_as_parse_errors():
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+    line = '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":NaN}\n'
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "keep_gpu.mcp.server"],
+        input=line,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(stdout_lines) == 1
+    response = json.loads(stdout_lines[0])
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] is None
+    assert response["error"]["code"] == -32700
+
+
 def test_mcp_stdio_bad_version_notification_is_invalid_request_error():
     request = {"jsonrpc": "1.0", "method": "notifications/initialized"}
     env = os.environ.copy()

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -720,6 +720,32 @@ def test_http_json_request_reports_invalid_utf8_as_service_response_error(monkey
         cli._http_json_request("GET", "http://127.0.0.1:8765/health")
 
 
+def test_status_outputs_json_error_for_nonstandard_json_constant_response(monkeypatch):
+    class NaNResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return (
+                b'{"jsonrpc":"2.0","id":1000,'
+                b'"result":{"active_jobs":[],"future_extra":NaN}}'
+            )
+
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(cli, "urlopen", lambda *args, **kwargs: NaNResponse())
+
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 1
+    payload = _single_decoded_json_object(result.output)
+    assert "Non-JSON response from service endpoint" in payload["error"]
+    assert result.exception is not None
+    assert not isinstance(result.exception, ValueError)
+
+
 def test_ensure_service_running_stops_auto_started_process_on_health_timeout(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Summary

- add a shared strict JSON decoder that rejects `NaN`, `Infinity`, and `-Infinity`
- use it at CLI service-response, HTTP request-body, and stdio JSON-RPC parse boundaries
- keep JSON-RPC parse failures as `-32700` envelopes with `id: null`, and REST failures as structured JSON 400 responses
- document the strict protocol boundary in `AGENTS.md` and the MCP guide

## Why

Python's default `json.loads` accepts non-standard constants. A malformed local service response containing `NaN` could reach CLI machine-output rendering and make commands like `keep-gpu status` crash without printing a parseable JSON error object. JSON-RPC request parsers also accepted `NaN` far enough to dispatch a request instead of returning a parse-error envelope.

## Local verification

- RED before fix: new tests failed because CLI printed no JSON, and HTTP/stdio accepted `NaN` far enough to echo request id `1`.
- Focused GREEN:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests/test_cli_service_commands.py::test_status_outputs_json_error_for_nonstandard_json_constant_response tests/mcp/test_http_api.py::test_http_jsonrpc_rejects_nonstandard_json_constants_as_parse_error tests/mcp/test_server.py::test_mcp_stdio_rejects_nonstandard_json_constants_as_parse_errors -q` (`4 passed`)
- CLI/MCP/API shard:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests/test_cli_service_commands.py tests/mcp/test_http_api.py tests/mcp/test_server.py tests/utilities/test_session_config.py -q` (`625 passed`)
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=$PWD/src mkdocs build --strict --site-dir "$tmp/site" --clean`
- Full suite:
  - `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src pytest -p no:cacheprovider tests -q` (`1026 passed, 11 skipped`)
- Staged final gate:
  - `git diff --cached --check`
  - focused regression tests again (`4 passed`)

## Local review

Local subagent review completed with no Critical, Important, or Minor findings. Reviewer confirmed the fix is at the right protocol boundary, maps errors correctly for CLI/HTTP JSON-RPC/REST/stdio, and the docs/AGENTS updates are concise.
