### PR TITLE
[controllers] fix: use monotonic batch timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,9 @@ This file defines how coding agents should work in this repository.
 - Keep it "Linus" simple - concise, readable, and robust; avoid bloat/over-engineering.
 - Run the smallest relevant checks first (unit tests, targeted scripts), then broader checks when needed.
 - Add tests when there is an existing test pattern; do not introduce a brand-new testing framework unless requested.
-- Use monotonic clocks for timeout/deadline arithmetic. Reserve wall-clock
-  `time.time()` for epoch timestamps, persisted records, and protocol IDs.
+- Use monotonic clocks for timeout/deadline arithmetic and elapsed-duration
+  measurements. Reserve wall-clock `time.time()` for epoch timestamps,
+  persisted records, and protocol IDs.
 - Build metadata should list directly used third-party distributions; do not
   rely on transitive dependencies, and do not add Python stdlib modules such as
   `argparse` as build/runtime dependencies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,8 +40,9 @@ expectations so you can get productive quickly and avoid surprises in CI.
 - Keep broad validation matrices with the utility or controller that owns the
   contract; interface tests should use representative smoke cases plus
   side-effect guards instead of repeating every edge case.
-- Use monotonic clocks for timeout/deadline helpers; reserve wall-clock time for
-  persisted timestamps and protocol identifiers.
+- Use monotonic clocks for timeout/deadline helpers and elapsed-duration
+  measurements; reserve wall-clock time for persisted timestamps and protocol
+  identifiers.
 - When changing CUDA visibility telemetry, cover numeric and UUID
   `CUDA_VISIBLE_DEVICES` masks, including NVML UUID string/bytes lookup
   differences.

--- a/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/cuda_gpu_controller.py
@@ -358,13 +358,13 @@ class CudaGPUController(BaseGPUController):
         """Run a batch of in-place ReLU ops to keep GPU busy."""
         stop_evt = self._stop_evt
 
-        tic = time.time()
+        tic = time.monotonic()
         for _ in range(self.relu_iterations):
             torch.relu_(matrix)
             if stop_evt is not None and stop_evt.is_set():
                 break
         torch.cuda.synchronize()
-        toc = time.time()
+        toc = time.monotonic()
 
         logger.debug(
             "rank %s: relu ops batch done - avg %.2f ms",

--- a/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/macm_gpu_controller.py
@@ -314,13 +314,13 @@ class MacMGPUController(BaseGPUController):
     def _run_batch(self, tensor: torch.Tensor) -> None:
         stop_evt = self._stop_evt
 
-        tic = time.time()
+        tic = time.monotonic()
         for _ in range(self.iterations):
             torch.relu_(tensor)
             if stop_evt is not None and stop_evt.is_set():
                 break
         torch.mps.synchronize()
-        toc = time.time()
+        toc = time.monotonic()
 
         logger.debug(
             "rank %s: elementwise batch done - avg %.2f ms",

--- a/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
+++ b/src/keep_gpu/single_gpu_controller/rocm_gpu_controller.py
@@ -384,13 +384,13 @@ class RocmGPUController(BaseGPUController):
     @torch.no_grad()
     def _run_batch(self, tensor: torch.Tensor) -> None:
         stop_evt = self._stop_evt
-        tic = time.time()
+        tic = time.monotonic()
         for _ in range(self.iterations):
             torch.relu_(tensor)
             if stop_evt is not None and stop_evt.is_set():
                 break
         torch.cuda.synchronize()
-        toc = time.time()
+        toc = time.monotonic()
         logger.debug(
             "rank %s: elementwise batch done - avg %.2f ms",
             self.rank,

--- a/tests/single_gpu_controller/test_batch_timing.py
+++ b/tests/single_gpu_controller/test_batch_timing.py
@@ -1,0 +1,110 @@
+import pytest
+
+import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+import keep_gpu.single_gpu_controller.macm_gpu_controller as macm_module
+import keep_gpu.single_gpu_controller.rocm_gpu_controller as rocm_module
+from keep_gpu.single_gpu_controller.cuda_gpu_controller import CudaGPUController
+from keep_gpu.single_gpu_controller.macm_gpu_controller import MacMGPUController
+from keep_gpu.single_gpu_controller.rocm_gpu_controller import RocmGPUController
+
+
+def _forbid_wall_clock():
+    raise AssertionError("batch elapsed timing must not use wall-clock time")
+
+
+def _monotonic_sequence(*values):
+    values_iter = iter(values)
+    return lambda: next(values_iter)
+
+
+def test_cuda_relu_batch_uses_monotonic_elapsed_time(monkeypatch):
+    ctrl = CudaGPUController.__new__(CudaGPUController)
+    ctrl.rank = 0
+    ctrl.relu_iterations = 2
+    ctrl._stop_evt = None
+    relu_calls = []
+    logs = []
+
+    monkeypatch.setattr(cuda_module.time, "time", _forbid_wall_clock)
+    monkeypatch.setattr(
+        cuda_module.time, "monotonic", _monotonic_sequence(10.0, 10.006)
+    )
+    monkeypatch.setattr(
+        cuda_module.torch, "relu_", lambda tensor: relu_calls.append(tensor)
+    )
+    monkeypatch.setattr(cuda_module.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        cuda_module.logger, "debug", lambda message, *args: logs.append((message, args))
+    )
+
+    ctrl._run_relu_batch(object())
+
+    assert len(relu_calls) == 2
+    assert logs == [
+        (
+            "rank %s: relu ops batch done - avg %.2f ms",
+            (0, pytest.approx(3.0)),
+        )
+    ]
+
+
+def test_rocm_batch_uses_monotonic_elapsed_time(monkeypatch):
+    ctrl = RocmGPUController.__new__(RocmGPUController)
+    ctrl.rank = 1
+    ctrl.iterations = 3
+    ctrl._stop_evt = None
+    relu_calls = []
+    logs = []
+
+    monkeypatch.setattr(rocm_module.time, "time", _forbid_wall_clock)
+    monkeypatch.setattr(
+        rocm_module.time, "monotonic", _monotonic_sequence(20.0, 20.012)
+    )
+    monkeypatch.setattr(
+        rocm_module.torch, "relu_", lambda tensor: relu_calls.append(tensor)
+    )
+    monkeypatch.setattr(rocm_module.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        rocm_module.logger, "debug", lambda message, *args: logs.append((message, args))
+    )
+
+    ctrl._run_batch(object())
+
+    assert len(relu_calls) == 3
+    assert logs == [
+        (
+            "rank %s: elementwise batch done - avg %.2f ms",
+            (1, pytest.approx(4.0)),
+        )
+    ]
+
+
+def test_macm_batch_uses_monotonic_elapsed_time(monkeypatch):
+    ctrl = MacMGPUController.__new__(MacMGPUController)
+    ctrl.rank = 2
+    ctrl.iterations = 4
+    ctrl._stop_evt = None
+    relu_calls = []
+    logs = []
+
+    monkeypatch.setattr(macm_module.time, "time", _forbid_wall_clock)
+    monkeypatch.setattr(
+        macm_module.time, "monotonic", _monotonic_sequence(30.0, 30.020)
+    )
+    monkeypatch.setattr(
+        macm_module.torch, "relu_", lambda tensor: relu_calls.append(tensor)
+    )
+    monkeypatch.setattr(macm_module.torch.mps, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        macm_module.logger, "debug", lambda message, *args: logs.append((message, args))
+    )
+
+    ctrl._run_batch(object())
+
+    assert len(relu_calls) == 4
+    assert logs == [
+        (
+            "rank %s: elementwise batch done - avg %.2f ms",
+            (2, pytest.approx(5.0)),
+        )
+    ]


### PR DESCRIPTION
## Summary
- Switch CUDA, ROCm, and MPS batch elapsed debug timing from wall-clock `time.time()` to `time.monotonic()`.
- Add no-GPU regression coverage that forbids wall-clock timing in backend batch methods.
- Clarify AGENTS and contributing docs that elapsed-duration measurements use monotonic clocks.

## Verification
- RED: `PYTHONPATH=src pytest tests/single_gpu_controller/test_batch_timing.py` failed on all three backend methods while they called `time.time()`.
- GREEN: `PYTHONPATH=src pytest tests/single_gpu_controller/test_batch_timing.py` -> 3 passed.
- `PYTHONPATH=src pytest tests/single_gpu_controller/test_batch_timing.py tests/cuda_controller/test_throttle.py tests/rocm_controller/test_rocm_backoff.py tests/macm_controller/test_macm_backoff.py` -> 79 passed, 1 skipped.
- `mkdocs build --strict` -> passed.
- `pre-commit run --all-files --show-diff-on-failure` -> passed.
- `PYTHONPATH=src pytest tests` -> 1029 passed, 11 skipped.

## Local subagent review
- Reviewer: Dalton the 4th
- Verdict: Ready to merge. No Critical, Important, or Minor issues.

## Notes
- README was not touched; the Zenodo DOI badge remains present.
