### PR TITLE
[http] fix: return 404 for normalized asset paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,10 @@ This file defines how coding agents should work in this repository.
   noncanonical spellings such as `//rpc`, `/%2Frpc`, `/rpc/`, `/rpc;...`,
   `/rpc?...`, `/rp%63`, and `/%72pc` return structured JSON `404 Unknown
   endpoint` without JSON-RPC dispatch or dashboard/static fallback.
-- Missing dashboard asset URLs, including `GET`/`HEAD` requests for `/assets/*`
-  and extension-bearing static paths, must return structured JSON `404` errors
-  instead of the dashboard HTML shell; `HEAD` responses must not include a body.
+- Missing dashboard asset URLs, including raw or decoded `GET`/`HEAD` requests
+  under `/assets/*` and extension-bearing static paths, must return structured
+  JSON `404` errors instead of the dashboard HTML shell; `HEAD` responses must
+  not include a body.
 - `HEAD` requests for GET-able dashboard/static paths such as `/` and concrete
   static assets must return the same success headers as `GET` with no body,
   while API/RPC `HEAD` requests keep the structured JSON 405/404 contract.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -13,8 +13,9 @@ instead of dashboard HTML. `/api/sessions/{job_id}` uses one raw path component;
 extra raw path segments are unknown endpoints. Noncanonical raw aliases such as
 `//api/sessions` and encoded leading-slash aliases such as `/%2Fapi/gpus` are
 also unknown endpoints and do not start or stop sessions.
-Missing packaged asset URLs also return JSON `404` responses instead of the
-dashboard shell.
+Missing packaged asset URLs, including raw `/assets/*` requests that normalize
+outside the packaged asset directory, also return JSON `404` responses instead
+of the dashboard shell.
 
 ## Start service
 

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1219,13 +1219,24 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             )
             return
 
-        is_asset_request = (
-            decoded_relative == "assets"
-            or decoded_relative.startswith("assets/")
-            or (
-                bool(Path(decoded_relative).suffix) and decoded_relative != "index.html"
-            )
+        is_asset_prefix_request = (
+            decoded_relative == "assets" or decoded_relative.startswith("assets/")
         )
+        is_asset_request = is_asset_prefix_request or (
+            bool(Path(decoded_relative).suffix) and decoded_relative != "index.html"
+        )
+        asset_root = static_root / "assets"
+        if (
+            is_asset_prefix_request
+            and requested != asset_root
+            and asset_root not in requested.parents
+        ):
+            self._json_response(
+                404,
+                {"error": {"message": "Static asset not found"}},
+                write_body=write_body,
+            )
+            return
         if not requested.exists() or requested.is_dir():
             if is_asset_request:
                 self._json_response(

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -144,6 +144,11 @@ def _allow_methods(headers):
 
 
 def _send_raw_http_json_request(httpd, request: bytes):
+    status_code, _headers, body = _send_raw_http_response(httpd, request)
+    return status_code, json.loads(body.decode("utf-8")) if body else {}
+
+
+def _send_raw_http_response(httpd, request: bytes):
     host, port = httpd.server_address
     with socket.create_connection((host, port), timeout=2.0) as sock:
         sock.settimeout(2.0)
@@ -164,9 +169,14 @@ def _send_raw_http_json_request(httpd, request: bytes):
     response = b"".join(chunks)
     assert response
     header_bytes, body = response.split(b"\r\n\r\n", 1)
-    status_line = header_bytes.splitlines()[0].decode("iso-8859-1")
+    header_lines = header_bytes.splitlines()
+    status_line = header_lines[0].decode("iso-8859-1")
     status_code = int(status_line.split()[1])
-    return status_code, json.loads(body.decode("utf-8")) if body else {}
+    headers = {}
+    for raw_line in header_lines[1:]:
+        name, value = raw_line.decode("iso-8859-1").split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    return status_code, headers, body
 
 
 def _raw_post_with_content_length(httpd, path: str, content_length: str):
@@ -218,6 +228,17 @@ def _raw_http_json_request(httpd, method: str, target: str, payload=None):
         "\r\n"
     ).encode("ascii") + body
     return _send_raw_http_json_request(httpd, request)
+
+
+def _raw_http_response(httpd, method: str, target: str):
+    host, port = httpd.server_address
+    request = (
+        f"{method} {target} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("ascii")
+    return _send_raw_http_response(httpd, request)
 
 
 @pytest.mark.parametrize(
@@ -1025,6 +1046,34 @@ def test_http_missing_static_asset_returns_404_not_dashboard_index(path):
     }
 
 
+@pytest.mark.parametrize(
+    "target",
+    [
+        "/assets/../index.html",
+        "/assets/%2e%2e/index.html",
+        "/assets%2F%2e%2e/index.html",
+    ],
+)
+def test_http_normalized_asset_escape_returns_404_not_dashboard_index(target):
+    server = make_server()
+    httpd, thread, _base = _start_http_server(server)
+
+    try:
+        status, headers, body = _raw_http_response(httpd, "GET", target)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers["content-type"] == "application/json"
+    assert b"<html" not in body.lower()
+    assert json.loads(body.decode("utf-8")) == {
+        "error": {"message": "Static asset not found"}
+    }
+
+
 @pytest.mark.parametrize("path", ["/assets/missing.js", "/missing.keepgpu-test.js"])
 def test_http_head_missing_static_asset_returns_json_404_without_body(path):
     server = make_server()
@@ -1040,6 +1089,31 @@ def test_http_head_missing_static_asset_returns_json_404_without_body(path):
 
     assert status == 404
     assert headers.get_content_type() == "application/json"
+    assert body == b""
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "/assets/../index.html",
+        "/assets/%2e%2e/index.html",
+        "/assets%2F%2e%2e/index.html",
+    ],
+)
+def test_http_head_normalized_asset_escape_returns_404_without_body(target):
+    server = make_server()
+    httpd, thread, _base = _start_http_server(server)
+
+    try:
+        status, headers, body = _raw_http_response(httpd, "HEAD", target)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert status == 404
+    assert headers["content-type"] == "application/json"
     assert body == b""
 
 


### PR DESCRIPTION
## Summary
- Keep raw/decoded `/assets/*` requests inside the static asset contract even when they normalize outside `static/assets/`.
- Return structured JSON 404 for those asset misses instead of serving the dashboard HTML shell.
- Add raw HTTP GET/HEAD regression tests for dot-dot and encoded slash asset paths.
- Update AGENTS and MCP guide wording for the normalized asset-path contract.

## Verification
- RED: `PYTHONPATH=src pytest tests/mcp/test_http_api.py::test_http_normalized_asset_escape_returns_404_not_dashboard_index tests/mcp/test_http_api.py::test_http_head_normalized_asset_escape_returns_404_without_body` failed with 200 responses before the fix.
- GREEN: same focused command -> 6 passed.
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py` -> 161 passed.
- `PYTHONPATH=src pytest tests/mcp` -> 308 passed.
- `mkdocs build --strict` -> passed.
- `pre-commit clean && pre-commit run --all-files --show-diff-on-failure` -> passed.
- `PYTHONPATH=src pytest tests` -> 1035 passed, 11 skipped.

## Local subagent review
- Reviewer: Godel the 4th
- Initial verdict: Ready to merge; no Critical or Important issues.
- Follow-up: addressed two Minor notes (renamed decoded asset-prefix variable and added encoded-slash case), then reviewer rechecked and reported no Critical, Important, or Minor findings.

## Notes
- README was not touched; the Zenodo DOI badge remains present.
