### PR TITLE
[docs] docs: pin getting-started sanity check gpu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ This file defines how coding agents should work in this repository.
   not in README. Keep `docs/citation.md` aligned with the current Zenodo
   concept DOI metadata. Avoid badge clutter; keep badges to PyPI, docs status,
   and the Zenodo DOI badge.
+- First-run CLI examples in `README.md` and `docs/getting-started.md` should
+  prefer explicit `--gpu-ids 0` unless the text is intentionally demonstrating
+  the all-visible-GPUs default.
 - Avoid placing new project-specific documentation in the root directory; keep only canonical top-level docs (for example, `AGENTS.md`, `README.md`) at root.
 
 ### Quality Bar

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,9 +86,11 @@ understand the minimum knobs you need to keep a GPU occupied.
 
 2. Run the CLI in dry form (press `Ctrl+C` after a few seconds):
    ```bash
-   keep-gpu --interval 30 --vram 512MB
+   keep-gpu --gpu-ids 0 --interval 30 --vram 512MB
    ```
-   On CUDA or ROCm, you should see Rich logs showing the GPUs being kept awake.
+   This keeps the sanity check on visible GPU `0`; omit `--gpu-ids` only when
+   you intentionally want all visible GPUs. On CUDA or ROCm, you should see Rich
+   logs showing the GPUs being kept awake.
    Mac M series utilization telemetry is unavailable, so the default
    non-negative `busy_threshold` backs off instead of allocating keep tensors or
    running MPS compute. Use `--busy-threshold -1` only when you intentionally


### PR DESCRIPTION
## Summary
- Pin the Getting Started sanity-check command to visible GPU `0` with `--gpu-ids 0`.
- Clarify that omitting `--gpu-ids` intentionally targets all visible GPUs.
- Add an AGENTS.md guard so first-run CLI examples stay explicit unless demonstrating all-visible behavior.

## Verification
- `rg -n "keep-gpu --interval 30 --vram 512MB|keep-gpu --gpu-ids 0 --interval 30 --vram 512MB|First-run CLI" AGENTS.md docs/getting-started.md README.md -S` -> old command absent; new command and AGENTS guard present
- `mkdocs build --strict` -> passed, existing Material warning only
- `git diff --check` -> passed
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- Local subagent code review (`Pascal the 4th`) -> no Critical, Important, or Minor issues

## Notes
- README was not modified; the Zenodo DOI badge remains present.
