### PR TITLE
[metadata,ci] chore: align python support range

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,5 @@
-# This workflow installs Python dependencies and runs tests on the supported floor
-# plus the default development version.
+# This workflow installs Python dependencies and runs tests on the supported
+# floor plus the latest Python version advertised in package classifiers.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -32,6 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install torch --index-url https://download.pytorch.org/whl/cpu
+        pip install "setuptools>=77,<82"
         pip install -e .
     - name: Test with pytest
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ This file defines how coding agents should work in this repository.
 - Keep Python test CI dependency installs explicit. Do not reintroduce a root
   `requirements.txt` fallback; runtime and test dependencies belong in
   `pyproject.toml`, while docs dependencies belong in `docs/requirements.txt`.
+- Keep Python support metadata explicit: `requires-python`, package classifiers,
+  docs, and CI must agree on the advertised supported Python range.
 - Source distributions should not ship the test suite by default; package data
   should enumerate required runtime assets such as the MCP dashboard files.
 - Keep license metadata as a plain SPDX string and keep the advertised Python

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,6 +78,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   Python standard library when packages such as `colorlog` are absent.
 - Keep package metadata such as `requires-python` aligned with the documented
   supported Python versions.
+- Keep `requires-python`, Python classifiers, docs, and runtime CI aligned on
+  the advertised supported Python range.
 - Keep project URLs in package metadata pointing to live repository pages.
 - Keep metadata tests self-contained for simple checks; avoid importing parser
   libraries that are only available through transitive test dependencies.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,8 @@ understand the minimum knobs you need to keep a GPU occupied.
 
 ## Requirements
 
-- Python 3.9+ (matching the version in your environment/cluster image).
+- Python 3.9 through 3.13 (matching the version in your environment/cluster
+  image).
 - A PyTorch build that matches your target platform: CUDA, ROCm/HIP, Mac M
   series MPS, or CPU-only for import and docs workflows.
 - CUDA utilization monitoring uses NVML by way of `nvidia-ml-py` (the `pynvml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "keep_gpu"
 dynamic = ["version"]  # Let setuptools read the version dynamically
 description = "KeepGPU is a polite GPU keeper with CLI, service, and MCP interfaces"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.14"
 
 authors = [
   {name = "Siyuan Wang", email = "sywang0227@gmail.com"},
@@ -22,7 +22,12 @@ maintainers = [
   {name= "Yiduck Liu", email = "geodesicseiran@gmail.com"}
 ]
 classifiers = [
-
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 license = "MIT"
 dependencies = [

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -9,6 +9,7 @@ ROOT_REQUIREMENTS_INSTALL_RE = re.compile(
 )
 MKDOCS_MAJOR_TWO_BOUND_RE = re.compile(r"<\s*2(?:\.0+)?(?:\s|,|$)")
 YAML_BLOCK_SCALAR_START_RE = re.compile(r":\s*[|>][-+0-9]*\s*$")
+PYTHON_VERSION_MATRIX_RE = re.compile(r"python-version:\s*\[([^\]]+)\]")
 
 
 def _installs_root_requirements_file(workflow: str) -> bool:
@@ -75,19 +76,31 @@ def _workflow_action_ref(workflow: str, action: str) -> str:
     raise AssertionError(f"missing workflow action: {action}")
 
 
+def _python_version_matrix(workflow: str) -> list[str]:
+    match = PYTHON_VERSION_MATRIX_RE.search(workflow)
+    if match is None:
+        raise AssertionError("missing python-version matrix")
+    return [
+        version.strip().strip("\"'")
+        for version in match.group(1).split(",")
+        if version.strip()
+    ]
+
+
+def _normalized_pip_install_commands(workflow: str) -> list[str]:
+    pip_install_commands = re.findall(
+        r"^\s*(?:python\s+-m\s+)?pip\s+install\b.*$", workflow, re.MULTILINE
+    )
+    return [re.sub(r"\s+", " ", command.strip()) for command in pip_install_commands]
+
+
 def test_precommit_workflow_does_not_install_runtime_package():
     workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yaml"
     if not workflow_path.exists():
         workflow_path = PROJECT_ROOT / ".github/workflows/pre-commit.yml"
     workflow = workflow_path.read_text(encoding="utf-8")
-    pip_install_commands = re.findall(
-        r"^\s*(?:python\s+-m\s+)?pip\s+install\b.*$", workflow, re.MULTILINE
-    )
-    normalized_commands = [
-        re.sub(r"\s+", " ", command.strip()) for command in pip_install_commands
-    ]
 
-    assert normalized_commands == [
+    assert _normalized_pip_install_commands(workflow) == [
         "python -m pip install --upgrade pip",
         "pip install pre-commit",
     ]
@@ -162,6 +175,30 @@ def test_python_workflow_does_not_install_root_requirements_file():
     workflow = workflow_path.read_text(encoding="utf-8")
 
     assert not _installs_root_requirements_file(workflow)
+
+
+def test_python_workflow_tests_supported_floor_and_latest_advertised_version():
+    workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yml"
+    if not workflow_path.exists():
+        workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yaml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    assert _python_version_matrix(workflow) == ["3.9", "3.13"]
+
+
+def test_python_workflow_restores_metadata_setuptools_after_torch_install():
+    workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yml"
+    if not workflow_path.exists():
+        workflow_path = PROJECT_ROOT / ".github/workflows/python-app.yaml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    assert _normalized_pip_install_commands(workflow) == [
+        "python -m pip install --upgrade pip",
+        "pip install pytest",
+        "pip install torch --index-url https://download.pytorch.org/whl/cpu",
+        'pip install "setuptools>=77,<82"',
+        "pip install -e .",
+    ]
 
 
 def test_root_requirements_guard_allows_harmless_references():

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -82,9 +82,20 @@ def test_colorlog_is_not_a_required_runtime_dependency():
 
 
 def test_license_metadata_uses_spdx_string_supported_by_python_floor():
-    assert _project_config()["requires-python"] == ">=3.9"
+    assert _project_config()["requires-python"] == ">=3.9,<3.14"
     assert _project_config()["license"] == "MIT"
     assert "setuptools>=77.0.1" in _build_system_requires()
+
+
+def test_python_version_classifiers_match_advertised_supported_range():
+    assert _project_config()["classifiers"] == [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+    ]
 
 
 def test_project_description_no_longer_describes_cli_only_app():


### PR DESCRIPTION
## Summary
- Bound advertised Python support to `>=3.9,<3.14` and add matching Python 3.9-3.13 classifiers.
- Update runtime CI to test the supported floor plus the latest advertised runtime (`3.9`, `3.13`).
- Align Getting Started, contributing guidance, and AGENTS.md with the package/CI support contract.
- Add metadata and workflow tests that guard the advertised support range.

## Verification
- RED: `PYTHONPATH=src pytest tests/test_package_metadata.py -q` failed when classifiers were empty
- RED: `PYTHONPATH=src pytest tests/test_ci_workflows.py::test_python_workflow_tests_supported_floor_and_current_stable -q` failed when the matrix was temporarily restored to `3.9`/`3.10`
- RED: `PYTHONPATH=src pytest tests/test_package_metadata.py::test_license_metadata_uses_spdx_string_supported_by_python_floor -q` failed while `requires-python` was still open-ended `>=3.9`
- `PYTHONPATH=src pytest tests/test_package_metadata.py tests/test_ci_workflows.py -q` -> 27 passed
- `mkdocs build --strict` -> passed, existing Material warning only
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=src pytest tests` -> 1037 passed, 11 skipped
- Local subagent code review (`Galileo the 4th`) -> no Critical, Important, or Minor issues

## Notes
- README was not modified; the Zenodo DOI badge remains present.
