### PR TITLE
[cli] fix: reject unknown status states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,8 @@ This file defines how coding agents should work in this repository.
   records with visible ordinal metadata. Service-returned job IDs must satisfy
   the shared URL-path-safe job-id contract. Known nested `status.params` fields
   must match the public session contract while extra fields remain
-  forward-compatible.
+  forward-compatible. Session `state` values in status records must be one of
+  `active`, `starting`, `stopping`, `runtime_failed`, or `stop_failed`.
 - Targeted CLI service commands must reject success payloads for the wrong
   session: `keep-gpu status --job-id X` requires response `job_id == X`, and
   `keep-gpu stop --job-id X` requires every `stopped`, `timed_out`, `failed`,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,6 +81,8 @@ envelopes, including missing or non-string `error.message`, and malformed status
 job records are reported as JSON error objects instead of empty success results.
 When `--job-id` is supplied, the returned `job_id` must match the requested
 target or the response is rejected as malformed.
+Status record `state` values are validated against the known lifecycle states:
+`active`, `starting`, `stopping`, `runtime_failed`, and `stop_failed`.
 The machine JSON stream is plain JSON without Rich color or highlighting, even
 when the command runs under a pseudo-TTY or forced-color terminal.
 Started sessions with terminal worker allocation/runtime failures remain listed

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -40,6 +40,13 @@ from keep_gpu.utilities.session_config import (
 DEFAULT_SERVICE_HOST = "127.0.0.1"
 DEFAULT_SERVICE_PORT = 8765
 JSONRPC_STARTUP_UNAVAILABLE = -32000
+STATUS_SESSION_STATES = (
+    "active",
+    "starting",
+    "stopping",
+    "runtime_failed",
+    "stop_failed",
+)
 ROOT_BLOCKING_OPTION_LABELS = {
     "gpu_ids": "--gpu-ids",
     "vram": "--vram",
@@ -765,19 +772,26 @@ def _validate_status_params(params: Dict[str, Any], method: str, prefix: str) ->
             raise _malformed_method_result(method, f"{prefix}.{field}: {exc}") from exc
 
 
+def _validate_status_state(state: str, method: str, field: str) -> None:
+    if state not in STATUS_SESSION_STATES:
+        allowed = ", ".join(STATUS_SESSION_STATES)
+        raise _malformed_method_result(method, f"{field} must be one of: {allowed}")
+
+
 def _validate_status_session_record(
     record: Dict[str, Any], method: str, prefix: str
 ) -> None:
     try:
         job_id = _require_string_field(record, "job_id", method)
         params = _require_dict_field(record, "params", method)
-        _require_string_field(record, "state", method)
+        state = _require_string_field(record, "state", method)
         _require_nullable_string_field(record, "last_error", method)
     except ServiceResponseError as exc:
         detail = str(exc).split(": ", 1)[-1]
         raise _malformed_method_result(method, f"{prefix}.{detail}") from exc
     _validate_result_job_id(job_id, method, f"{prefix}.job_id")
     _validate_status_params(params, method, f"{prefix}.params")
+    _validate_status_state(state, method, f"{prefix}.state")
 
 
 def _validate_status_result(

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -19,6 +19,20 @@ def _single_decoded_json_object(output):
     return payload
 
 
+def _status_session_record(state="active"):
+    return {
+        "job_id": "job-1",
+        "params": {
+            "gpu_ids": [0],
+            "vram": "1GiB",
+            "interval": 60,
+            "busy_threshold": 25,
+        },
+        "state": state,
+        "last_error": None,
+    }
+
+
 def _force_color_console(monkeypatch):
     output = StringIO()
     monkeypatch.setattr(
@@ -1024,6 +1038,42 @@ def test_status_rejects_malformed_active_job_entries(monkeypatch, payload):
     assert result.exit_code == 1
     decoded = _single_decoded_json_object(result.output)
     assert "Malformed status response" in decoded["error"]
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_params", "payload", "field"),
+    [
+        (
+            ["status"],
+            {},
+            {"active_jobs": [_status_session_record("weird")]},
+            "active_jobs[0].state",
+        ),
+        (
+            ["status", "--job-id", "job-1"],
+            {"job_id": "job-1"},
+            {"active": True, **_status_session_record("weird")},
+            "result.state",
+        ),
+    ],
+)
+def test_status_rejects_unknown_session_state(
+    monkeypatch, command, expected_params, payload, field
+):
+    def fake_rpc(method, params, host, port):
+        assert method == "status"
+        assert params == expected_params
+        return payload
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, command)
+
+    assert result.exit_code == 1
+    decoded = _single_decoded_json_object(result.output)
+    assert "Malformed status response" in decoded["error"]
+    assert f"{field} must be one of" in decoded["error"]
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Summary
- reject service status records with unknown session state values before rendering CLI JSON
- add all-session and --job-id regression coverage for malformed state payloads
- document the status state whitelist in AGENTS.md and the CLI reference

## Verification
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -k "unknown_active" -q (RED before fix: 2 failed)
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -k status -q
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q
- mkdocs build --strict
- PYTHONPATH=src pytest tests -q
- pre-commit run --all-files --show-diff-on-failure
