### PR TITLE
[cli] fix: require clean service-stop result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,8 +377,9 @@ This file defines how coding agents should work in this repository.
   message so the user can inspect logs or explicitly force-stop it.
 - Non-force `keep-gpu service-stop` must require a reachable service,
   successful status/RPC checks, a clean `stop_keep` result with no stopped,
-  timed-out, or failed sessions, and a final no-active-session status check
-  before signaling; use `--force` for unresponsive auto-started daemons.
+  timed-out, or failed sessions and no non-empty message, and a final
+  no-active-session status check before signaling; use `--force` for
+  unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
 - Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
 - MCP tool schemas that expose `job_id` must reuse the shared

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -150,14 +150,15 @@ reported as JSON errors before RPC.
 Stops the ownership-verified local daemon process created by auto-start logic.
 Invalid endpoint values are rejected locally before service checks or
 ownership-verified stop operations. Non-force shutdown requires the service to
-be reachable, `stop_keep` to report no stopped, timed-out, or failed sessions,
-and a final status check to show no active sessions before the daemon process is
-signaled. Malformed PID records with float or boolean numeric identity values
-are ignored rather than coerced before signaling. Auto-start cleans up and fails
-if it cannot create a trustworthy ownership record for the daemon it just
-spawned. On systems without `/proc`, KeepGPU may recover daemon identity from
-platform process metadata, but it still signals only when recovered identity is
-known and exactly matches the stored ownership record.
+be reachable, `stop_keep` to report no stopped, timed-out, or failed sessions
+and no non-empty message, and a final status check to show no active sessions
+before the daemon process is signaled. Malformed PID records with float or
+boolean numeric identity values are ignored rather than coerced before
+signaling. Auto-start cleans up and fails if it cannot create a trustworthy
+ownership record for the daemon it just spawned. On systems without `/proc`,
+KeepGPU may recover daemon identity from platform process metadata, but it still
+signals only when recovered identity is known and exactly matches the stored
+ownership record.
 
 | Option | Description |
 | --- | --- |

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -887,6 +887,10 @@ def _require_clean_stop_keep_for_service_stop(result: Dict[str, Any]) -> None:
         incomplete.append(f"timed out: {', '.join(result['timed_out'])}")
     if result["failed"]:
         incomplete.append(f"failed: {', '.join(result['failed'])}")
+    message = result.get("message")
+    if isinstance(message, str) and message:
+        message_detail = message.strip() or repr(message)
+        incomplete.append(f"message: {message_detail}")
     if incomplete:
         raise RuntimeError(
             "Stop sessions before stopping the service daemon. Incomplete stop_keep result "

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2553,6 +2553,50 @@ def test_service_stop_rejects_incomplete_stop_keep_before_stopping_daemon(
     assert "Traceback" not in result.output
 
 
+@pytest.mark.parametrize(
+    ("message", "expected_fragment"),
+    [
+        (
+            "Timed out while stopping some sessions.",
+            "Timed out while stopping some sessions.",
+        ),
+        (" ", "' '"),
+    ],
+)
+def test_service_stop_rejects_stop_keep_message_before_stopping_daemon(
+    monkeypatch, message, expected_fragment
+):
+    calls = {"stop_process": 0}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        if method == "status":
+            return {"active_jobs": []}
+        if method == "stop_keep":
+            return {
+                "stopped": [],
+                "timed_out": [],
+                "failed": [],
+                "errors": {},
+                "message": message,
+            }
+        raise AssertionError(f"unexpected method {method}")
+
+    def fake_stop_process(host, port):
+        calls["stop_process"] += 1
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["service-stop"])
+
+    assert result.exit_code == 1
+    assert expected_fragment in result.output
+    assert "service-stop --force" in result.output
+    assert calls["stop_process"] == 0
+    assert "Traceback" not in result.output
+
+
 def test_service_stop_rejects_newly_stopped_session_before_stopping_daemon(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- block non-force `service-stop` from signaling the daemon when `stop_keep` returns a non-empty message
- add regression coverage for a message-only stop result that previously allowed daemon shutdown
- document the clean `stop_keep` requirement in AGENTS.md and the CLI reference

## Verification
- PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_stop_rejects_stop_keep_message_before_stopping_daemon -q (RED before fix: failed because exit_code was 0)
- PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_service_stop_rejects_stop_keep_message_before_stopping_daemon -q
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -k service_stop -q
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q
- mkdocs build --strict
- PYTHONPATH=src pytest tests -q
- pre-commit run --all-files --show-diff-on-failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `keep-gpu service-stop` validation so malformed stop responses are treated as incomplete when they include a message, preventing shutdown from continuing with bad input.
  * The command now surfaces the returned message, exits with an error, and shows the `--force` hint when applicable.

* **Tests**
  * Added coverage for rejecting stop responses that contain a message before any daemon shutdown action occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->