### PR TITLE
[cli] fix: type stop-all fallback errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,10 @@ This file defines how coding agents should work in this repository.
   explicit custom IDs locally before service RPC, stop-all fallback, or daemon
   side effects. Only omitting the option means all-session status or no stop
   target was chosen.
+- `keep-gpu stop --all` daemon fallback may signal an ownership-verified daemon
+  only after typed service transport failures such as `ServiceUnreachableError`;
+  generic application/runtime errors must never be classified by message text
+  such as `timed out`.
 - For CLI `--gpu-ids`, only omission means all visible GPUs; explicit empty or
   whitespace-only values are invalid and must not silently expand to all GPUs.
 - Blocking CLI mode must defer omitted-GPU hardware enumeration to

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,6 +110,10 @@ boundary first, waits only for starting jobs in that boundary, and does not stop
 later starts.
 `--all` releases the sessions in its snapshot concurrently and prints results
 in deterministic snapshot order with the same additive response fields.
+If the stop RPC transport is unreachable, `--all` may force-stop an
+ownership-verified local daemon. Application/runtime errors from the service are
+reported as JSON errors and do not trigger daemon stop fallback based on message
+text.
 The output is a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
 envelopes, including missing or non-string `error.message`, and malformed stop

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -985,12 +985,7 @@ def _rollback_auto_started_service_on_startup_unavailable(
 
 
 def _is_service_unreachable_error(exc: RuntimeError) -> bool:
-    if isinstance(exc, ServiceUnreachableError):
-        return True
-    if isinstance(exc, (ServiceRPCError, ServiceResponseError)):
-        return False
-    message = str(exc).lower()
-    return "cannot reach keepgpu service" in message or "timed out" in message
+    return isinstance(exc, ServiceUnreachableError)
 
 
 def _stop_all_sessions_with_fallback(host: str, port: int) -> Dict[str, Any]:

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2761,7 +2761,7 @@ def test_service_stop_refuses_active_sessions_without_force(monkeypatch):
 
 def test_stop_handles_service_timeout_without_traceback(monkeypatch):
     def fake_rpc(method, params, host, port, timeout=8.0):
-        raise RuntimeError(
+        raise cli.ServiceUnreachableError(
             "Cannot reach KeepGPU service at http://127.0.0.1:8765/rpc: timed out"
         )
 
@@ -2784,7 +2784,9 @@ def test_cli_module_avoids_eager_gpu_imports():
 
 def test_stop_all_fallback_force_stops_managed_daemon(monkeypatch):
     def fake_rpc(method, params, host, port, timeout=8.0):
-        raise RuntimeError("timed out")
+        raise cli.ServiceUnreachableError(
+            "Cannot reach KeepGPU service at http://127.0.0.1:8765/rpc: timed out"
+        )
 
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
     monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
@@ -2802,11 +2804,11 @@ def test_stop_all_fallback_force_stops_managed_daemon(monkeypatch):
     assert payload["errors"] == {}
 
 
-def test_stop_all_does_not_fallback_for_rpc_application_error(monkeypatch):
+def test_stop_all_does_not_fallback_for_generic_timeout_error(monkeypatch):
     called = {"stop_process": False}
 
     def fake_rpc(method, params, host, port, timeout=8.0):
-        raise RuntimeError("validation failed")
+        raise RuntimeError("controller timed out while releasing session")
 
     def fake_stop_process(host, port):
         called["stop_process"] = True
@@ -2820,14 +2822,47 @@ def test_stop_all_does_not_fallback_for_rpc_application_error(monkeypatch):
     result = runner.invoke(cli.app, ["stop", "--all"])
 
     assert result.exit_code == 1
-    assert "validation failed" in result.output
+    assert "controller timed out while releasing session" in result.output
+    assert "force-stopped local daemon" not in result.output
+    assert called["stop_process"] is False
+
+
+@pytest.mark.parametrize(
+    ("exc", "message"),
+    [
+        (RuntimeError("validation failed"), "validation failed"),
+        (cli.ServiceRPCError("rpc failed"), "rpc failed"),
+        (cli.ServiceResponseError("malformed response"), "malformed response"),
+    ],
+)
+def test_stop_all_does_not_fallback_for_rpc_application_error(
+    monkeypatch, exc, message
+):
+    called = {"stop_process": False}
+
+    def fake_rpc(method, params, host, port, timeout=8.0):
+        raise exc
+
+    def fake_stop_process(host, port):
+        called["stop_process"] = True
+        return True
+
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+    monkeypatch.setattr(cli, "_read_service_pid", lambda host, port: 1234)
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_stop_service_process", fake_stop_process)
+
+    result = runner.invoke(cli.app, ["stop", "--all"])
+
+    assert result.exit_code == 1
+    assert message in result.output
     assert "force-stopped local daemon" not in result.output
     assert called["stop_process"] is False
 
 
 def test_stop_all_fallback_requires_stop_process_success(monkeypatch):
     def fake_rpc(method, params, host, port, timeout=8.0):
-        raise RuntimeError(
+        raise cli.ServiceUnreachableError(
             "Cannot reach KeepGPU service at http://127.0.0.1:8765/rpc: timed out"
         )
 


### PR DESCRIPTION
## Summary
- restrict `stop --all` daemon fallback to typed service transport failures
- prevent generic runtime/application timeout messages from force-stopping an ownership-verified daemon
- document the typed fallback contract in AGENTS.md and the CLI reference

## Verification
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -k "stop_all_fallback or generic_timeout" -q (RED before fix: generic timeout test exited 0)
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -k "stop_all_fallback or generic_timeout or service_timeout" -q
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q
- mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- PYTHONPATH=src pytest tests -q
