### PR TITLE
[cli] fix: reject mismatched start job ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,9 +223,9 @@ This file defines how coding agents should work in this repository.
   method-specific payloads should become clean `ServiceResponseError` messages,
   not `KeyError`, tracebacks, or partial success text.
 - Keep `_rpc_call()` limited to generic JSON-RPC envelope validation; validate
-  method-specific `status`, `stop_keep`, and `list_gpus` result payloads at CLI
-  call sites before reading fields or triggering daemon stop side effects, while
-  allowing extra result fields for forward compatibility.
+  method-specific `start_keep`, `status`, `stop_keep`, and `list_gpus` result
+  payloads at CLI call sites before reading fields or triggering daemon stop
+  side effects, while allowing extra result fields for forward compatibility.
 - CLI method-specific result validation must include nested records consumed by
   downstream tools: `status.active_jobs` entries, disjoint `stop_keep` job-id
   outcome lists whose `errors` keys exactly match `failed`, and `list_gpus` GPU

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,6 +50,8 @@ startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
 Malformed JSON-RPC service envelopes, including missing or non-string
 `error.message`, are response errors and do not trigger this rollback.
+When `--job-id` is supplied, the successful `start_keep` response must echo the
+requested `job_id` or the response is rejected as malformed.
 The same best-effort cleanup runs when auto-start times out before the service
 passes its health check. Auto-start refuses to overwrite an ownership-verified
 live daemon PID record when that daemon's health endpoint is unavailable; inspect

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -879,6 +879,25 @@ def _validate_stop_keep_result(
     return result
 
 
+def _validate_start_keep_result(
+    result: Dict[str, Any], *, expected_job_id: Optional[str] = None
+) -> str:
+    result_job_id = result.get("job_id")
+    if result_job_id is None:
+        raise ServiceResponseError(
+            "Malformed JSON-RPC response: start_keep result must include job_id"
+        )
+    try:
+        result_job_id = validate_job_id(result_job_id)
+    except ValueError as exc:
+        raise ServiceResponseError(f"Malformed JSON-RPC response: {exc}") from exc
+    if expected_job_id is not None and result_job_id != expected_job_id:
+        raise _malformed_method_result(
+            "start_keep", "result.job_id must match requested job_id"
+        )
+    return result_job_id
+
+
 def _require_clean_stop_keep_for_service_stop(result: Dict[str, Any]) -> None:
     incomplete = []
     if result["stopped"]:
@@ -1215,15 +1234,7 @@ def start(
             host,
             port,
         )
-        result_job_id = result.get("job_id")
-        if result_job_id is None:
-            raise ServiceResponseError(
-                "Malformed JSON-RPC response: start_keep result must include job_id"
-            )
-        try:
-            result_job_id = validate_job_id(result_job_id)
-        except ValueError as exc:
-            raise ServiceResponseError(f"Malformed JSON-RPC response: {exc}") from exc
+        result_job_id = _validate_start_keep_result(result, expected_job_id=job_id)
         if auto_started:
             console.print(
                 f"[bold cyan]Auto-started KeepGPU service[/bold cyan] at http://{host}:{port}/"

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -69,7 +69,7 @@ def test_start_command_uses_rpc(monkeypatch):
 
     def fake_rpc(method, params, host, port):
         called["rpc"] = (method, params, host, port)
-        return {"job_id": "job-123"}
+        return {"job_id": "custom-job"}
 
     monkeypatch.setattr(cli, "_ensure_service_running", fake_ensure)
     monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
@@ -145,6 +145,24 @@ def test_start_command_rejects_malformed_job_id_result(
 
     assert result.exit_code == 1
     assert expected_message in " ".join(result.output.split())
+    assert "Traceback" not in result.output
+
+
+def test_start_command_rejects_mismatched_job_id_result(monkeypatch):
+    def fake_rpc(method, params, host, port):
+        assert method == "start_keep"
+        assert params["job_id"] == "job-1"
+        return {"job_id": "job-2"}
+
+    monkeypatch.setattr(cli, "_ensure_service_running", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_rpc_call", fake_rpc)
+
+    result = runner.invoke(cli.app, ["start", "--job-id", "job-1"])
+
+    assert result.exit_code == 1
+    normalized_output = " ".join(result.output.split())
+    assert "Malformed start_keep response" in normalized_output
+    assert "result.job_id must match requested job_id" in normalized_output
     assert "Traceback" not in result.output
 
 


### PR DESCRIPTION
## Summary
- validate successful `start_keep` payloads before rendering CLI success output
- reject `keep-gpu start --job-id X` responses that return a different `job_id`
- document the start response echo contract and update AGENTS.md result-validation guidance

## Verification
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -k "start_command_rejects_mismatched_job_id_result or start_command_rejects_malformed_job_id_result" -q`
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=src pytest tests -q`

Local subagent review: no must-fix issues found.

README note: Zenodo DOI badge remains present at `README.md:5`.
