### PR TITLE
[http] fix: reject session collection query routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,10 @@ This file defines how coding agents should work in this repository.
   responses instead of serving the dashboard/static fallback or
   `BaseHTTPRequestHandler` HTML errors. Exact API endpoints such as `/api/gpus`
   must not accept params, query strings, or fragments unless the handler
-  explicitly documents those components. Canonical API paths may still validate
-  encoded `job_id` path components normally.
+  explicitly documents those components; `/api/gpus?...` and
+  `/api/sessions?...` are unknown endpoints, not valid collection routes.
+  Canonical API paths may still validate encoded `job_id` path components
+  normally.
 - Implemented HTTP verb handlers (`do_POST`, `do_DELETE`, and future siblings)
   must call the shared unsupported-method helper before local unknown-endpoint
   404 branches, so known paths never regress to 404 or body-parse errors solely

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -13,6 +13,9 @@ instead of dashboard HTML. `/api/sessions/{job_id}` uses one raw path component;
 extra raw path segments are unknown endpoints. Noncanonical raw aliases such as
 `//api/sessions` and encoded leading-slash aliases such as `/%2Fapi/gpus` are
 also unknown endpoints and do not start or stop sessions.
+Exact API collection routes such as `/api/gpus` and `/api/sessions` do not
+accept query strings or path parameters unless documented; query-shaped
+collection URLs return JSON `404` responses.
 Missing packaged asset URLs, including raw `/assets/*` requests that normalize
 outside the packaged asset directory, also return JSON `404` responses instead
 of the dashboard shell.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -184,6 +184,9 @@ instead of dropping the connection. Encoded noncanonical spellings such as
 unknown API routes and return JSON `404` responses rather than the dashboard
 HTML shell. Raw leading-double-slash API aliases such as `//api/sessions` are
 also unknown routes and do not start or stop sessions.
+Exact API collection routes such as `/api/gpus` and `/api/sessions` do not
+accept query strings or path parameters unless documented; query-shaped
+collection URLs return JSON `404` responses.
 The dashboard consumes those JSON objects and displays `error.message` when it is
 present, falling back to the plain response body or HTTP status only when needed.
 Direct JSON-RPC service calls report the same expected hardware/platform

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -1073,7 +1073,7 @@ class _JSONRPCHandler(BaseHTTPRequestHandler):
             route_paths = cls._route_path_candidates(raw_parsed.path)
             if any(cls._is_api_path(path) for path in route_paths):
                 return True
-        if parsed.path == "/api/gpus" and bool(
+        if parsed.path in ("/api/gpus", "/api/sessions") and bool(
             parsed.params or parsed.query or parsed.fragment
         ):
             return True

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -2669,37 +2669,26 @@ def test_http_delete_rejects_extra_session_path_segment_without_stopping_session
         thread.join(timeout=2)
 
 
-def test_http_delete_rejects_query_shaped_collection_path_without_stopping_sessions():
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE", "OPTIONS"])
+@pytest.mark.parametrize("path", ["/api/sessions?bad=query", "/api/sessions;bad"])
+def test_http_api_sessions_noncanonical_collection_route_returns_json_404_without_side_effects(
+    method, path
+):
     server = make_server()
     active_job_id = server.start_keep(job_id="active-job")["job_id"]
     controller = server._sessions[active_job_id].controller
     httpd, thread, base = _start_http_server(server)
 
     try:
-        status_code, payload = _request_json("DELETE", f"{base}/api/sessions?bad=query")
+        data = b"{}" if method == "POST" else None
+        status_code, headers, body = _request_http_response(
+            method, f"{base}{path}", data
+        )
+        payload = json.loads(body.decode("utf-8"))
 
-        assert status_code == 400
-        assert "session path" in payload["error"]["message"]
-        assert server.status(active_job_id)["active"] is True
-        assert controller.released is False
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        server.shutdown()
-        thread.join(timeout=2)
-
-
-def test_http_delete_rejects_parameterized_collection_path_without_stopping_sessions():
-    server = make_server()
-    active_job_id = server.start_keep(job_id="active-job")["job_id"]
-    controller = server._sessions[active_job_id].controller
-    httpd, thread, base = _start_http_server(server)
-
-    try:
-        status_code, payload = _request_json("DELETE", f"{base}/api/sessions;bad")
-
-        assert status_code == 400
-        assert "session path" in payload["error"]["message"]
+        assert status_code == 404
+        assert payload == {"error": {"message": "Unknown endpoint"}}
+        assert _allow_methods(headers) == set()
         assert server.status(active_job_id)["active"] is True
         assert controller.released is False
     finally:


### PR DESCRIPTION
## Summary
- treat `/api/sessions` collection routes with query strings or path params as noncanonical JSON `404` routes
- cover GET, POST, DELETE, and OPTIONS so noncanonical collection URLs cannot list, start, stop, or return route `Allow` metadata
- document the collection-route query/path-param contract in AGENTS.md and API docs

## Verification
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -k noncanonical_collection_route -q`
- `PYTHONPATH=src pytest tests/mcp/test_http_api.py -k "noncanonical or unsupported_methods or api_sessions_noncanonical_collection_route or api_gpus_noncanonical" -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=src pytest tests -q`

Local subagent review: no must-fix issues found.

README note: Zenodo DOI badge remains present at `README.md:5`.
