### PR TITLE
[cli] fix: reject malformed RPC error codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,9 +214,9 @@ This file defines how coding agents should work in this repository.
   (wrong `jsonrpc`, mismatched `id`, `id: null` responses to a request with a
   concrete id, response IDs that compare equal but use an invalid JSON-RPC id
   type such as float or boolean, missing `result`, non-object direct-method
-  `result`, non-object `error`, or missing/non-string `error.message`) instead
-  of treating them as successful empty responses, real service errors, or
-  leaking tracebacks.
+  `result`, non-object `error`, missing/non-integer `error.code`, or
+  missing/non-string `error.message`) instead of treating them as successful
+  empty responses, real service errors, or leaking tracebacks.
 - CLI service RPC clients must send explicit JSON-RPC 2.0 request envelopes
   (`jsonrpc: "2.0"`) instead of relying on the server's omitted-version legacy
   direct-call compatibility path.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -31,9 +31,9 @@ keep-gpu start --gpu-ids 0 --vram 1GiB --interval 60 --busy-threshold 25
 If this invocation auto-starts the service but session creation fails with an
 expected startup-unavailable error before a session is created, `start`
 best-effort stops the just-created daemon so it does not remain idle.
-Malformed JSON-RPC service envelopes, including missing or non-string
-`error.message`, are reported as response errors and do not trigger this
-startup-unavailable rollback.
+Malformed JSON-RPC service envelopes, including missing/non-integer
+`error.code` or missing/non-string `error.message`, are reported as response
+errors and do not trigger this startup-unavailable rollback.
 If auto-start times out before the service becomes healthy, the CLI applies the
 same best-effort cleanup to the daemon it just started.
 
@@ -110,9 +110,10 @@ including `{"error": "..."}` for service/runtime errors after CLI parsing
 succeeds, that can be parsed directly with `jq` or a single `json.loads()` call.
 The machine JSON stream is plain JSON without Rich color or highlighting, even
 when the command runs under a pseudo-TTY or forced-color terminal.
-Malformed JSON-RPC service envelopes, including missing or non-string
-`error.message`, and malformed method-specific result records are reported as
-JSON error objects instead of empty success results.
+Malformed JSON-RPC service envelopes, including missing/non-integer
+`error.code` or missing/non-string `error.message`, and malformed
+method-specific result records are reported as JSON error objects instead of
+empty success results.
 CLI service commands send explicit JSON-RPC 2.0 request envelopes to the local
 `/rpc` endpoint; omitted-version direct calls remain only a compatibility path
 for legacy local scripts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,8 +48,9 @@ GPUs; explicit empty or whitespace-only values are invalid.
 If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
-Malformed JSON-RPC service envelopes, including missing or non-string
-`error.message`, are response errors and do not trigger this rollback.
+Malformed JSON-RPC service envelopes, including missing/non-integer
+`error.code` or missing/non-string `error.message`, are response errors and do
+not trigger this rollback.
 When `--job-id` is supplied, the successful `start_keep` response must echo the
 requested `job_id` or the response is rejected as malformed.
 The same best-effort cleanup runs when auto-start times out before the service
@@ -79,8 +80,9 @@ the service log at
 
 Prints a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes, including missing or non-string `error.message`, and malformed status
-job records are reported as JSON error objects instead of empty success results.
+envelopes, including missing/non-integer `error.code` or missing/non-string
+`error.message`, and malformed status job records are reported as JSON error
+objects instead of empty success results.
 When `--job-id` is supplied, the returned `job_id` must match the requested
 target or the response is rejected as malformed.
 Status record `state` values are validated against the known lifecycle states:
@@ -118,10 +120,10 @@ reported as JSON errors and do not trigger daemon stop fallback based on message
 text.
 The output is a directly parseable JSON object, including `{"error": "..."}` for
 service/runtime errors after CLI parsing succeeds. Malformed JSON-RPC service
-envelopes, including missing or non-string `error.message`, and malformed stop
-result records are reported as JSON error objects instead of empty success
-results. When `--job-id` is supplied, all returned outcome and error job IDs
-must match the requested target.
+envelopes, including missing/non-integer `error.code` or missing/non-string
+`error.message`, and malformed stop result records are reported as JSON error
+objects instead of empty success results. When `--job-id` is supplied, all
+returned outcome and error job IDs must match the requested target.
 The machine JSON stream is plain JSON without Rich color or highlighting, even
 when the command runs under a pseudo-TTY or forced-color terminal.
 
@@ -138,9 +140,10 @@ Torch can select; nullable memory fields mean memory telemetry is unavailable
 after selection succeeds. Service/runtime errors after CLI parsing succeeds are
 reported as `{"error": "..."}`. CUDA/ROCm visible-device enumeration failures
 are reported as startup-unavailable errors instead of successful empty GPU
-lists. Malformed JSON-RPC service envelopes, including missing or non-string
-`error.message`, are reported as JSON error objects instead of empty success
-results; malformed GPU records are reported the same way. `utilization` is
+lists. Malformed JSON-RPC service envelopes, including missing/non-integer
+`error.code` or missing/non-string `error.message`, are reported as JSON error
+objects instead of empty success results; malformed GPU records are reported the
+same way. `utilization` is
 either `null` or a finite number from `0` to `100`;
 out-of-range telemetry is unavailable, not idle. Memory fields are
 non-negative integers or `null`; invalid counters and impossible

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -680,7 +680,9 @@ def _rpc_call(
             raise ServiceResponseError("Malformed JSON-RPC response: mismatched id")
         code = error.get("code")
         if isinstance(code, bool) or not isinstance(code, int):
-            code = None
+            raise ServiceResponseError(
+                "Malformed JSON-RPC response: error.code must be an integer"
+            )
         message = error.get("message")
         if not isinstance(message, str):
             raise ServiceResponseError(

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -2007,6 +2007,30 @@ def test_rpc_call_rejects_error_envelope_without_string_message(monkeypatch, err
         cli._rpc_call("status", {}, "127.0.0.1", 8765)
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        {"message": "missing code"},
+        {"code": None, "message": "null code"},
+        {"code": "bad", "message": "string code"},
+        {"code": True, "message": "bool code"},
+        {"code": 1.0, "message": "float code"},
+    ],
+)
+def test_rpc_call_rejects_error_envelope_without_integer_code(monkeypatch, error):
+    monkeypatch.setattr(cli.time, "time", lambda: 1.0)
+    monkeypatch.setattr(
+        cli,
+        "_http_json_request",
+        lambda *args, **kwargs: {"jsonrpc": "2.0", "id": 1000, "error": error},
+    )
+
+    with pytest.raises(
+        cli.ServiceResponseError, match=re.escape("error.code must be an integer")
+    ):
+        cli._rpc_call("status", {}, "127.0.0.1", 8765)
+
+
 def test_rpc_call_rejects_error_envelope_with_null_id(monkeypatch):
     monkeypatch.setattr(cli.time, "time", lambda: 1.0)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Reject JSON-RPC service error envelopes with missing or non-integer error.code as malformed responses.
- Add regression coverage for missing, null, string, bool, and float error.code values.
- Update AGENTS and CLI docs to keep the malformed-envelope contract explicit.

## Test Plan
- PYTHONPATH=src pytest 'tests/test_cli_service_commands.py::test_rpc_call_rejects_error_envelope_without_integer_code' -q
- PYTHONPATH=src pytest tests/test_cli_service_commands.py -q
- mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- PYTHONPATH=src pytest tests -q

## Local Review
- Local subagent code review: no Critical, Important, or Minor issues; ready to merge.