### PR TITLE
[mcp] fix: reject null RPC params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,11 @@ This file defines how coding agents should work in this repository.
 - Keep platform detection and environment probing centralized in `src/keep_gpu/utilities/platform_manager.py`.
 - Keep GPU telemetry helpers in `src/keep_gpu/utilities/gpu_info.py` and related utility modules.
 - Keep public session input validation centralized in `src/keep_gpu/utilities/session_config.py`; CLI, Python, REST, and JSON-RPC entry points must share the same contract.
-- JSON-RPC user parameter validation errors and unknown direct-method params must return `-32602 Invalid params`; reserve `-32603 Internal error` for unexpected server failures.
+- JSON-RPC user parameter validation errors and unknown direct-method params
+  must return `-32602 Invalid params`; reserve `-32603 Internal error` for
+  unexpected server failures. Omitted `params` remain a legacy/internal empty
+  object, but explicit `params: null` or other non-object `params` are invalid
+  and must not trigger method side effects such as stop-all.
 - Expected controller startup unavailability, such as no usable visible GPUs,
   failed CUDA/ROCm visible-device enumeration, unavailable or unprobeable
   PyTorch MPS backends, or unsupported platforms, must surface as explicit

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -110,7 +110,10 @@ Successful direct-method responses are KeepGPU JSON-RPC envelopes with
 `jsonrpc: "2.0"`, the matching request `id`, and an object `result`.
 
 For direct JSON-RPC calls, public validation failures and unknown parameters
-return JSON-RPC `-32602 Invalid params`. Expected startup-unavailable
+return JSON-RPC `-32602 Invalid params`. Omitted `params` are treated as an
+empty object for legacy direct calls; explicit `params: null` or any other
+non-object `params` value is invalid and does not call the target method.
+Expected startup-unavailable
 conditions, such as an unsupported controller platform, no usable visible GPUs,
 failed CUDA/ROCm visible-device enumeration during `start_keep` or `list_gpus`,
 or an unavailable PyTorch MPS backend during `start_keep`, return `-32000` with

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,6 +199,9 @@ arbitrary runtime failures remain `-32603 Internal error`. CLI service commands
 send explicit JSON-RPC 2.0
 request envelopes to `/rpc`; omitted-version direct calls are retained only for
 legacy local scripts.
+Omitted direct-call `params` are treated as `{}` for compatibility, but explicit
+`params: null` or any other non-object `params` value returns `-32602 Invalid
+params` before method side effects.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -947,7 +947,7 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
         if "id" in payload and _is_valid_jsonrpc_id(raw_id):
             req_id = raw_id
         method = payload.get("method")
-        params = payload.get("params", {})
+        params = payload["params"] if "params" in payload else {}
         if not isinstance(method, str) or not method:
             raise JSONRPCError(JSONRPC_INVALID_REQUEST, "Request method is required.")
         if "jsonrpc" in payload and payload["jsonrpc"] != "2.0":
@@ -960,8 +960,6 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
             raise JSONRPCError(
                 JSONRPC_INVALID_REQUEST, "Notifications must not include an id."
             )
-        if params is None:
-            params = {}
         if not isinstance(params, dict):
             raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params must be an object")
         if method == "initialize":

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -998,6 +998,21 @@ def test_jsonrpc_stop_keep_rejects_empty_job_id_without_stopping_sessions():
     assert controller.released is False
 
 
+def test_jsonrpc_stop_keep_rejects_null_params_without_stopping_sessions():
+    server = make_server()
+    active_job_id = server.start_keep(job_id="active-job")["job_id"]
+    controller = server._sessions[active_job_id].controller
+    req = {"id": 1, "method": "stop_keep", "params": None}
+
+    resp = _handle_request(server, req)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == JSONRPC_INVALID_PARAMS
+    assert resp["error"]["message"] == "params must be an object"
+    assert server.status(active_job_id)["active"] is True
+    assert controller.released is False
+
+
 def test_stop_all():
     server = make_server()
     job_a = server.start_keep()["job_id"]


### PR DESCRIPTION
## Summary
- Reject explicit JSON-RPC params:null and other non-object params before method dispatch.
- Preserve omitted params as legacy empty-object direct calls.
- Add regression coverage proving stop_keep params:null does not stop existing sessions.
- Update AGENTS and MCP/CLI docs for the parameter contract.

## Test Plan
- RED: PYTHONPATH=src pytest 'tests/mcp/test_server.py::test_jsonrpc_stop_keep_rejects_null_params_without_stopping_sessions' -q failed before the fix because active-job was stopped.
- PYTHONPATH=src pytest 'tests/mcp/test_server.py::test_jsonrpc_stop_keep_rejects_null_params_without_stopping_sessions' -q
- PYTHONPATH=src pytest tests/mcp/test_server.py -q
- mkdocs build --strict
- pre-commit run --all-files --show-diff-on-failure
- PYTHONPATH=src pytest tests -q

## Local Review
- Local subagent code review: no Critical, Important, or Minor issues; ready to merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified JSON-RPC handling so omitted `params` are treated as an empty object for compatibility, while `params: null` or other non-object values are rejected with `Invalid params`.
  * Prevented invalid direct calls from triggering any method side effects before validation completes.
* **Documentation**
  * Updated user-facing JSON-RPC and CLI guidance to reflect the expected behavior for omitted and invalid `params` values.
* **Tests**
  * Added coverage to verify invalid `params` are rejected and the active session remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->