### PR TITLE
[api,cli,mcp] fix: reserve dot-segment job ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,10 +397,14 @@ This file defines how coding agents should work in this repository.
   no-active-session status check before signaling; use `--force` for
   unresponsive auto-started daemons.
 - Treat custom `job_id` values as reserved from the moment startup begins; duplicate starts must fail before another controller can begin keep-alive work.
-- Keep custom `job_id` validation centralized in `session_config.py`: only `None` means omitted/all-sessions, and custom IDs must be non-empty URL-path-safe strings before any session state changes.
+- Keep custom `job_id` validation centralized in `session_config.py`: only
+  `None` means omitted/all-sessions, and custom IDs must be non-empty
+  URL-path-safe strings before any session state changes. Standalone `.` and
+  `..` are reserved dot segments, not valid custom IDs.
 - MCP tool schemas that expose `job_id` must reuse the shared
   `JOB_ID_PATTERN_TEXT` contract from `session_config.py`, so generated clients
-  see the same non-empty URL-path-safe shape enforced at runtime.
+  see the same non-empty URL-path-safe shape, including dot-segment reservation,
+  enforced at runtime.
 - MCP `start_keep` schemas that expose `gpu_ids` must advertise the shared
   `MAX_GPU_IDS` limit from `session_config.py` as `maxItems`, so generated
   clients see the same list-size cap enforced at runtime.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -57,8 +57,8 @@ keep-gpu status --job-id <job_id>
 ```
 
 Explicit `--job-id` values use the shared session-id rules: non-empty strings
-containing only letters, digits, `.`, `_`, `-`, or `~`. Invalid IDs return a
-JSON error before contacting the service.
+containing only letters, digits, `.`, `_`, `-`, or `~`, except standalone `.`
+or `..`. Invalid IDs return a JSON error before contacting the service.
 
 ### Stop sessions
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -169,9 +169,10 @@ duplicate arrives while the original start is still creating controller work,
 the duplicate is rejected before another controller begins keep-alive work.
 Only `null`/omitted means "generate an ID" for `start_keep` or "all sessions"
 for `status` and `stop_keep`. Custom IDs must be non-empty strings containing
-only letters, digits, `.`, `_`, `-`, or `~`; invalid IDs return an error before
-session state changes. The MCP tool schemas advertise the same `job_id`
-pattern, so clients can reject invalid custom IDs before making a tool call.
+only letters, digits, `.`, `_`, `-`, or `~`, except standalone `.` or `..`;
+invalid IDs return an error before session state changes. The MCP tool schemas
+advertise the same `job_id` pattern, so clients can reject invalid custom IDs
+before making a tool call.
 For `start_keep`, the `gpu_ids` schema also advertises the runtime list limit
 of at most 64 unique visible ordinals.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -65,8 +65,8 @@ crash.
 
 For service session IDs, `job_id=None` is the only omitted/all-sessions
 sentinel. Custom IDs must be non-empty strings containing only letters, digits,
-`.`, `_`, `-`, or `~`; invalid values raise `ValueError` before session state
-changes.
+`.`, `_`, `-`, or `~`, and may not be standalone `.` or `..`; invalid values
+raise `ValueError` before session state changes.
 
 ::: keep_gpu.cli
     options:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -178,7 +178,8 @@ ownership record.
 
 Only omitted/`null` `job_id` values mean generated IDs or all-sessions, depending
 on the method. Custom IDs must be non-empty strings containing only letters,
-digits, `.`, `_`, `-`, or `~`; invalid REST path IDs return `400` before acting.
+digits, `.`, `_`, `-`, or `~`, and may not be standalone `.` or `..`; invalid
+REST path IDs return `400` before acting.
 Supported REST route/method errors are JSON objects: validation errors return
 `400`, unknown API routes return `404`, expected startup-unavailable session
 creation returns `503`, and unexpected service/runtime failures return `500`

--- a/src/keep_gpu/utilities/session_config.py
+++ b/src/keep_gpu/utilities/session_config.py
@@ -3,7 +3,7 @@ import re
 import threading
 from typing import Any, List, Optional, Tuple, Union
 
-JOB_ID_PATTERN_TEXT = r"^[A-Za-z0-9._~-]+$"
+JOB_ID_PATTERN_TEXT = r"^(?!\.{1,2}$)[A-Za-z0-9._~-]+$"
 _JOB_ID_PATTERN = re.compile(JOB_ID_PATTERN_TEXT)
 DEFAULT_BUSY_THRESHOLD = 25
 MAX_GPU_IDS = 64

--- a/tests/mcp/test_http_api.py
+++ b/tests/mcp/test_http_api.py
@@ -2525,13 +2525,16 @@ def test_http_post_rejects_invalid_job_id_without_creating_session():
         thread.join(timeout=2)
 
 
-def test_http_get_rejects_invalid_decoded_job_id_path():
+@pytest.mark.parametrize("job_id_path", ["bad%3Fjob", "%2E", "%2E%2E"])
+def test_http_get_rejects_invalid_decoded_job_id_path(job_id_path):
     server = make_server()
     active_job_id = server.start_keep(job_id="active-job")["job_id"]
     httpd, thread, base = _start_http_server(server)
 
     try:
-        status_code, payload = _request_json("GET", f"{base}/api/sessions/bad%3Fjob")
+        status_code, payload = _request_json(
+            "GET", f"{base}/api/sessions/{job_id_path}"
+        )
 
         assert status_code == 400
         assert "job_id" in payload["error"]["message"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -939,7 +939,9 @@ def test_jsonrpc_start_keep_defaults_to_eco_safe_busy_threshold():
     assert status["params"]["busy_threshold"] == 25
 
 
-@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+@pytest.mark.parametrize(
+    "job_id", ["", " ", 123, ".", "..", "job/123", "job?123", "job#123"]
+)
 def test_start_keep_rejects_invalid_job_id_before_starting_controller(job_id):
     controllers = []
 
@@ -959,7 +961,9 @@ def test_start_keep_rejects_invalid_job_id_before_starting_controller(job_id):
     assert server.status()["active_jobs"] == []
 
 
-@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+@pytest.mark.parametrize(
+    "job_id", ["", " ", 123, ".", "..", "job/123", "job?123", "job#123"]
+)
 def test_status_rejects_invalid_job_id_without_changing_sessions(job_id):
     server = make_server()
     active_job_id = server.start_keep(job_id="active-job")["job_id"]
@@ -970,7 +974,9 @@ def test_status_rejects_invalid_job_id_without_changing_sessions(job_id):
     assert server.status(active_job_id)["active"] is True
 
 
-@pytest.mark.parametrize("job_id", ["", " ", 123, "job/123", "job?123", "job#123"])
+@pytest.mark.parametrize(
+    "job_id", ["", " ", 123, ".", "..", "job/123", "job?123", "job#123"]
+)
 def test_stop_keep_rejects_invalid_job_id_without_stopping_sessions(job_id):
     server = make_server()
     active_job_id = server.start_keep(job_id="active-job")["job_id"]

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -390,6 +390,8 @@ def test_start_command_rejects_non_integer_busy_threshold_before_auto_start(
     ("args", "message"),
     [
         (["--job-id", "bad/id"], "job_id must be a URL-path-safe non-empty string"),
+        (["--job-id", "."], "job_id must be a URL-path-safe non-empty string"),
+        (["--job-id", ".."], "job_id must be a URL-path-safe non-empty string"),
         (["--vram", "not-a-size"], "invalid format"),
         (["--vram", ("9" * 500) + "GiB"], "vram must be no more than"),
         (["--interval", str(10**1000)], "interval must be no more than"),
@@ -571,7 +573,7 @@ def test_stop_rejects_job_id_with_all_before_rpc(monkeypatch):
     assert called["stop_all"] is False
 
 
-@pytest.mark.parametrize("job_id", ["", "   ", "bad/id"])
+@pytest.mark.parametrize("job_id", ["", "   ", ".", "..", "bad/id"])
 def test_status_rejects_invalid_job_id_before_rpc(monkeypatch, job_id):
     def fake_rpc(*args, **kwargs):
         raise AssertionError("RPC should not be called")
@@ -585,7 +587,7 @@ def test_status_rejects_invalid_job_id_before_rpc(monkeypatch, job_id):
     assert payload["error"] == "job_id must be a URL-path-safe non-empty string"
 
 
-@pytest.mark.parametrize("job_id", ["", "   ", "bad/id"])
+@pytest.mark.parametrize("job_id", ["", "   ", ".", "..", "bad/id"])
 def test_stop_rejects_invalid_job_id_before_rpc_or_fallback(monkeypatch, job_id):
     def fake_rpc(*args, **kwargs):
         raise AssertionError("RPC should not be called")

--- a/tests/utilities/test_session_config.py
+++ b/tests/utilities/test_session_config.py
@@ -192,6 +192,8 @@ def test_validate_job_id_accepts_omitted_and_url_path_safe_strings(value):
         123,
         True,
         ["job-123"],
+        ".",
+        "..",
         "job/123",
         "job?123",
         "job#123",


### PR DESCRIPTION
## Summary
- reject standalone URL dot-segment custom job IDs (`.` and `..`) in the centralized session ID contract
- keep dotted IDs such as `job.123`, `...`, and `a..b` valid
- update CLI/API/MCP docs and AGENTS.md without changing README

## Verification
- Red tests before fix: validator and MCP service cases failed for `.` and `..` because they did not raise
- `PYTHONPATH=src pytest tests/mcp/test_server.py::test_start_keep_rejects_invalid_job_id_before_starting_controller tests/mcp/test_server.py::test_status_rejects_invalid_job_id_without_changing_sessions tests/mcp/test_server.py::test_stop_keep_rejects_invalid_job_id_without_stopping_sessions -q`
- `PYTHONPATH=src pytest tests/test_cli_service_commands.py::test_start_command_rejects_local_inputs_before_auto_start tests/test_cli_service_commands.py::test_status_rejects_invalid_job_id_before_rpc tests/test_cli_service_commands.py::test_stop_rejects_invalid_job_id_before_rpc_or_fallback -q`
- `PYTHONPATH=src pytest tests/utilities/test_session_config.py tests/mcp/test_server.py::test_start_keep_rejects_invalid_job_id_before_starting_controller tests/mcp/test_server.py::test_status_rejects_invalid_job_id_without_changing_sessions tests/mcp/test_server.py::test_stop_keep_rejects_invalid_job_id_without_stopping_sessions tests/mcp/test_server.py::test_mcp_tools_list_exposes_keepgpu_actions tests/mcp/test_http_api.py::test_http_get_rejects_invalid_decoded_job_id_path tests/test_cli_service_commands.py::test_start_command_rejects_local_inputs_before_auto_start tests/test_cli_service_commands.py::test_status_rejects_invalid_job_id_before_rpc tests/test_cli_service_commands.py::test_stop_rejects_invalid_job_id_before_rpc_or_fallback -q`
- `mkdocs build --strict` (passes; known Material/MkDocs 2.0 warning)
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=src pytest tests -q`

## Local review
- Local subagent review found one minor test-symmetry suggestion; addressed by adding CLI and stop-path `.`/`..` cases.
- Final local subagent review on commit `207b77c6630297a7e589e1e45504f06498708c8b`: no critical or important issues; ready to merge.