### PR TITLE
[global] fix: preserve already-running children on rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,7 +379,9 @@ This file defines how coding agents should work in this repository.
   still alive and explicitly stopping.
 - `GlobalGPUController.keep()` must best-effort release a child controller that
   fails after leaving `_thread` or `_stop_evt` worker state, then roll back
-  previously-started children while preserving the original startup error.
+  children newly started by the current keep attempt while preserving the
+  original startup error. It must not release children that were already running
+  before that keep attempt began.
 - Internal single-GPU startup paths that receive a `startup_evt` must always
   signal it before returning, and paths without a `startup_errors` list must
   retain the failure detail in `allocation_status()`.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -130,6 +130,9 @@ Elementwise keep-alive batches:
 - If startup fails before a worker is running, controller state and any
   initialized vendor telemetry library are cleared before the original failure
   is re-raised.
+- During multi-device startup, rollback releases only controllers started by the
+  current `GlobalGPUController.keep()` call; already-running children are left
+  alone if a later child fails.
 
 ## Platform detection
 

--- a/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
+++ b/src/keep_gpu/global_gpu_controller/global_gpu_controller.py
@@ -27,6 +27,11 @@ def _controller_has_worker_state(ctrl) -> bool:
     )
 
 
+def _controller_worker_alive(ctrl) -> bool:
+    thread = getattr(ctrl, "_thread", None)
+    return thread is not None and thread.is_alive()
+
+
 class ControllerStartupUnavailable(Exception):
     """Expected hardware/platform unavailability during controller startup."""
 
@@ -143,6 +148,7 @@ class GlobalGPUController:
     def keep(self) -> None:
         started = []
         for ctrl in self.controllers:
+            already_running = _controller_worker_alive(ctrl)
             try:
                 ctrl.keep()
             except Exception:
@@ -166,7 +172,8 @@ class GlobalGPUController:
                             cleanup_exc,
                         )
                 raise
-            started.append(ctrl)
+            if not already_running:
+                started.append(ctrl)
 
     @staticmethod
     def parse_size(text: str) -> int:

--- a/tests/global_controller/global_keep_test.py
+++ b/tests/global_controller/global_keep_test.py
@@ -65,6 +65,48 @@ def test_global_keep_rolls_back_started_controllers(monkeypatch):
     assert instances[1].released is False
 
 
+def test_global_keep_does_not_roll_back_already_running_controller(monkeypatch):
+    monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+
+    instances = []
+
+    class RunningThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    class DummyController:
+        def __init__(self, *, rank, interval, vram_to_keep, busy_threshold):
+            self.rank = rank
+            self.keep_calls = 0
+            self.released = False
+            self._thread = RunningThread() if rank == 0 else None
+            self._stop_evt = object() if rank == 0 else None
+            instances.append(self)
+
+        def keep(self):
+            self.keep_calls += 1
+            if self.rank == 1:
+                raise RuntimeError("rank 1 failed to start")
+
+        def release(self):
+            self.released = True
+
+    import keep_gpu.single_gpu_controller.cuda_gpu_controller as cuda_module
+
+    monkeypatch.setattr(cuda_module, "CudaGPUController", DummyController)
+
+    controller = GlobalGPUController(gpu_ids=[0, 1], vram_to_keep="8MB")
+
+    with pytest.raises(RuntimeError, match="rank 1 failed to start"):
+        controller.keep()
+
+    assert instances[0].keep_calls == 1
+    assert instances[0].released is False
+    assert instances[1].released is False
+
+
 def test_global_keep_releases_failed_controller_with_worker_state(monkeypatch):
     monkeypatch.setattr(pm, "_cached_platform", pm.ComputingPlatform.CUDA)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)


### PR DESCRIPTION
## Summary
- avoid rolling back child controllers that were already running before a `GlobalGPUController.keep()` retry
- keep cleanup for a child that fails after leaving worker state and for children newly started by the current attempt
- document the lifecycle invariant in AGENTS and architecture docs

## Verification
- RED: `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py::test_global_keep_does_not_roll_back_already_running_controller -q` failed before the fix because rank 0 was released
- GREEN: `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py::test_global_keep_does_not_roll_back_already_running_controller -q`
- `PYTHONPATH=src pytest tests/global_controller/global_keep_test.py tests/global_controller/test_contract.py -q`
- `PYTHONPATH=src pytest tests/global_controller tests/single_gpu_controller/test_release_contract.py -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`
- `PYTHONPATH=src pytest tests -q`

## Local Review
- Local subagent review found no Critical, Important, or Minor issues; verdict: ready to merge.
