### PR TITLE
[mcp] fix: support ping liveness checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,10 @@ This file defines how coding agents should work in this repository.
   when telemetry is unavailable unless users explicitly choose
   `busy_threshold=-1`.
 - Keep the MCP server compatible with standard MCP lifecycle/tool methods
-  (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) while
-  preserving legacy direct JSON-RPC method calls for local scripts.
+  (`initialize`, `notifications/initialized`, `ping`, `tools/list`,
+  `tools/call`) while preserving legacy direct JSON-RPC method calls for local
+  scripts. `ping` must stay a cheap liveness utility that does not touch GPU
+  telemetry or session runtime-health hooks.
 - MCP `tools/list` responses must be read-only snapshots from the caller's
   perspective; local embedding callers must not be able to mutate the server's
   shared tool registry through a returned response object.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -53,6 +53,9 @@ tool names:
 modify the returned tool metadata without mutating the server's shared MCP tool
 registry.
 
+Use MCP `ping` for cheap liveness checks instead of polling GPU or session
+endpoints when you only need to know whether the service is responsive.
+
 Minimal client config:
 
 ```yaml

--- a/src/keep_gpu/mcp/server.py
+++ b/src/keep_gpu/mcp/server.py
@@ -5,6 +5,7 @@ Supports MCP/JSON-RPC over stdio/HTTP and REST-style HTTP endpoints.
 MCP protocol methods:
   - initialize
   - notifications/initialized
+  - ping
   - tools/list
   - tools/call
 
@@ -962,7 +963,9 @@ def _handle_request(server: KeepGPUServer, payload: Any) -> Optional[Dict[str, A
             )
         if not isinstance(params, dict):
             raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params must be an object")
-        if method == "initialize":
+        if method == "ping":
+            result = {}
+        elif method == "initialize":
             result = _mcp_initialize_result(params)
         elif method == "tools/list":
             result = {"tools": copy.deepcopy(MCP_TOOLS)}

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1356,6 +1356,32 @@ def test_mcp_initialize_returns_server_capabilities():
     assert result["serverInfo"]["version"]
 
 
+def test_mcp_ping_returns_empty_result_without_touching_service_state(monkeypatch):
+    def fail_direct_dispatch(*args, **kwargs):
+        raise AssertionError("ping must not dispatch KeepGPU methods")
+
+    class RuntimeHookController(DummyController):
+        def runtime_error(self):
+            raise AssertionError("ping must not refresh session runtime health")
+
+    monkeypatch.setattr(server_module, "_call_keepgpu_method", fail_direct_dispatch)
+    monkeypatch.setattr(
+        server_module,
+        "get_gpu_info",
+        lambda: (_ for _ in ()).throw(AssertionError("ping must not enumerate GPUs")),
+    )
+    server = KeepGPUServer(
+        controller_factory=cast(Any, lambda **kwargs: RuntimeHookController(**kwargs))
+    )
+    job_id = server.start_keep(job_id="ping-existing-session", gpu_ids=[0])["job_id"]
+    req = {"jsonrpc": "2.0", "id": 99, "method": "ping"}
+
+    resp = _handle_request(server, req)
+
+    assert resp == {"jsonrpc": "2.0", "id": 99, "result": {}}
+    assert server._sessions[job_id].controller.released is False
+
+
 def test_mcp_initialized_notification_has_no_response():
     server = make_server()
     req = {"jsonrpc": "2.0", "method": "notifications/initialized"}


### PR DESCRIPTION
## Summary
- add MCP JSON-RPC `ping` as a cheap liveness method returning `{}`
- keep `ping` before direct KeepGPU dispatch so it avoids telemetry and session runtime-health work
- document the low-power liveness contract in AGENTS and MCP guide

## Verification
- `PYTHONPATH=src pytest tests/mcp/test_server.py::test_mcp_ping_returns_empty_result_without_touching_service_state -q` -> `1 passed`
- `PYTHONPATH=src pytest tests/mcp/test_server.py tests/mcp/test_http_api.py -q` -> `327 passed`
- `mkdocs build --strict` -> exit 0, known Material/MkDocs 2.0 warning only
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `PYTHONPATH=src pytest tests -q` -> `1080 passed, 11 skipped`

## Local review
- Initial local subagent review found one minor internal docstring drift; fixed by adding `ping` to the module MCP method list.
- Final local subagent re-review: no Critical, Important, or Minor issues; ready to merge.
