### PR TITLE
[cli] fix: reject non-canonical numeric inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,8 @@ This file defines how coding agents should work in this repository.
   auto-starting the service daemon or making RPC calls. CLI numeric options that
   use shared validators must pass raw command-line values to those validators so
   parse failures use KeepGPU's clean project errors instead of Typer usage text;
-  reject non-ASCII digits and underscore-separated numeric spellings locally.
+  reject leading plus signs, non-ASCII digits, and underscore-separated numeric
+  spellings locally. Only documented negative sentinels such as `-1` are valid.
 - If `keep-gpu start` auto-starts a service daemon and the following
   `start_keep` RPC returns expected startup-unavailable JSON-RPC code
   `-32000` before creating a session, the CLI must best-effort stop that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,8 @@ This file defines how coding agents should work in this repository.
   `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, and `--port` before
   auto-starting the service daemon or making RPC calls. CLI numeric options that
   use shared validators must pass raw command-line values to those validators so
-  parse failures use KeepGPU's clean project errors instead of Typer usage text.
+  parse failures use KeepGPU's clean project errors instead of Typer usage text;
+  reject non-ASCII digits and underscore-separated numeric spellings locally.
 - If `keep-gpu start` auto-starts a service daemon and the following
   `start_keep` RPC returns expected startup-unavailable JSON-RPC code
   `-32000` before creating a session, the CLI must best-effort stop that

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -48,8 +48,10 @@ value is invalid.
 limit; fractional seconds such as `0.5` are accepted. `--vram` keeps integer
 and digit-only values as bytes, accepts human units, and rejects
 byte-equivalent requests above 1 PiB.
-CLI numeric tokens use plain ASCII spellings; typo-like forms such as
-`1_000` or full-width digits are rejected before daemon auto-start or RPC.
+CLI numeric tokens use plain ASCII spellings; typo-like forms such as leading
+plus signs, `1_000`, or full-width digits are rejected before daemon auto-start
+or RPC. Only documented negative sentinels such as `--busy-threshold -1` are
+accepted.
 
 ### Check status
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -48,6 +48,8 @@ value is invalid.
 limit; fractional seconds such as `0.5` are accepted. `--vram` keeps integer
 and digit-only values as bytes, accepts human units, and rejects
 byte-equivalent requests above 1 PiB.
+CLI numeric tokens use plain ASCII spellings; typo-like forms such as
+`1_000` or full-width digits are rejected before daemon auto-start or RPC.
 
 ### Check status
 
@@ -162,10 +164,10 @@ summary averages and do not draw an idle-looking utilization fill.
 
 | Option | Meaning | Default |
 | --- | --- | --- |
-| `--gpu-ids` | Comma-separated unique non-negative visible device ordinals. Omit to use all visible devices; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. | all |
+| `--gpu-ids` | Comma-separated unique non-negative visible device ordinals using plain ASCII digits. Omit to use all visible devices; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. | all |
 | `--vram` | Per-GPU memory target (`512MB`, `1GiB`, or bare bytes), capped at 1 PiB byte-equivalent. | `1GiB` |
 | `--interval` | Finite positive seconds between keep-alive cycles, including fractional values, capped by the Python runtime wait limit. | `300` |
-| `--busy-threshold` / `--util-threshold` | `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
+| `--busy-threshold` / `--util-threshold` | ASCII `0..100` backs off when utilization exceeds this value or telemetry is unavailable; `-1` disables utilization backoff. | `25` |
 | `--job-id` | Optional URL-path-safe session id. Invalid IDs are rejected before service auto-start. | auto |
 
 ## Remote sessions

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,9 +21,9 @@ These options apply when you run `keep-gpu` without subcommands.
 | Option | Type | Description |
 | --- | --- | --- |
 | `--interval NUMBER` | seconds | Finite positive sleep duration, including fractional values, between utilization checks and keep-alive batches; values above the Python runtime wait limit are rejected. |
-| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`). Omit to let the controller resolve all visible GPUs; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. |
+| `--gpu-ids TEXT` | comma-separated unique non-negative ints | Subset of visible device ordinals to guard (for example, `0,2`) using plain ASCII digits. Omit to let the controller resolve all visible GPUs; explicit empty or whitespace-only values are invalid. Startup fails if all-visible resolution finds no GPUs or if an explicit ordinal is out of range. |
 | `--vram TEXT` | human size or bare bytes | Amount of memory each GPU controller allocates (`512MB`, `1GiB`, `1073741824`); byte-equivalent values above 1 PiB are rejected. |
-| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | `0..100` backs off before allocation/compute when utilization is above this value or unavailable; `-1` disables utilization backoff. |
+| `--busy-threshold INTEGER` / `--util-threshold INTEGER` | percent | ASCII `0..100` backs off before allocation/compute when utilization is above this value or unavailable; `-1` disables utilization backoff. |
 | `--threshold TEXT` | deprecated | Legacy alias: numeric values map to busy-threshold, size strings map to vram. |
 
 ## Service mode
@@ -45,6 +45,8 @@ Local input validation runs before service auto-start. Invalid `--vram`,
 `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, or `--port`
 values fail before daemon startup or RPC. Omit `--gpu-ids` to use all visible
 GPUs; explicit empty or whitespace-only values are invalid.
+CLI numeric tokens use plain ASCII spellings; typo-like forms such as `1_000` or
+full-width digits are rejected locally.
 If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.
@@ -62,10 +64,10 @@ the service log at
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--gpu-ids` | all | Comma-separated unique visible device ordinals in the service process environment. Omit for all visible GPUs; empty or whitespace-only values are invalid. |
+| `--gpu-ids` | all | Comma-separated unique visible device ordinals using plain ASCII digits in the service process environment. Omit for all visible GPUs; empty or whitespace-only values are invalid. |
 | `--vram` | `1GiB` | Per-GPU keep memory target; byte-equivalent values above 1 PiB are rejected. |
 | `--interval` | `300` | Finite positive keep cycle interval in seconds, including fractional values, capped by the Python runtime wait limit. |
-| `--busy-threshold` / `--util-threshold` | `25` | `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
+| `--busy-threshold` / `--util-threshold` | `25` | ASCII `0..100` backs off when utilization is above this value or telemetry is unavailable; `-1` disables utilization backoff. |
 | `--job-id` | auto | Optional URL-path-safe custom id. Invalid IDs are rejected locally before service auto-start; valid IDs must be unique across active and starting sessions. |
 | `--host` | `127.0.0.1` | Service host to contact; invalid values are rejected before auto-start. |
 | `--port` | `8765` | Service port to contact; must be a plain ASCII decimal integer in `1..65535`. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,8 +45,9 @@ Local input validation runs before service auto-start. Invalid `--vram`,
 `--job-id`, `--interval`, `--busy-threshold`, `--gpu-ids`, `--host`, or `--port`
 values fail before daemon startup or RPC. Omit `--gpu-ids` to use all visible
 GPUs; explicit empty or whitespace-only values are invalid.
-CLI numeric tokens use plain ASCII spellings; typo-like forms such as `1_000` or
-full-width digits are rejected locally.
+CLI numeric tokens use plain ASCII spellings; typo-like forms such as leading
+plus signs, `1_000`, or full-width digits are rejected locally. Only documented
+negative sentinels such as `--busy-threshold -1` are accepted.
 If `start` auto-starts the service and the service then reports expected
 startup unavailability before creating a session, the CLI best-effort stops the
 just-created daemon instead of leaving it idle.

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -54,6 +55,10 @@ ROOT_BLOCKING_OPTION_LABELS = {
     "busy_threshold": "--busy-threshold/--util-threshold",
     "interval": "--interval",
 }
+_CLI_INTEGER_TOKEN_RE = re.compile(r"[+-]?[0-9]+")
+_CLI_NUMBER_TOKEN_RE = re.compile(
+    r"[+-]?(?:(?:[0-9]+(?:\.[0-9]*)?)|(?:\.[0-9]+))(?:[eE][+-]?[0-9]+)?"
+)
 
 app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -61,6 +66,21 @@ app = typer.Typer(
 )
 console = Console()
 logger = setup_logger(__name__)
+
+
+def _is_invalid_gpu_id_token(token: str) -> bool:
+    if token.startswith("+") or not _CLI_INTEGER_TOKEN_RE.fullmatch(token):
+        return True
+    return token.startswith("-") and int(token) == 0
+
+
+def _looks_like_numeric_cli_token(token: str) -> bool:
+    return bool(token) and (
+        token[0] in "+-"
+        or any(ch.isdigit() for ch in token)
+        or "_" in token
+        or "." in token
+    )
 
 
 class ServiceUnreachableError(RuntimeError):
@@ -311,11 +331,21 @@ def _apply_legacy_threshold(
     if legacy_threshold is None:
         return vram_value, busy_threshold, None
 
+    normalized = legacy_threshold.strip()
+    if _CLI_INTEGER_TOKEN_RE.fullmatch(normalized) and not (
+        normalized.startswith("-") and int(normalized) == 0
+    ):
+        return vram_value, int(normalized), "busy"
     try:
-        parsed_threshold = int(legacy_threshold)
-    except ValueError:
-        return legacy_threshold, busy_threshold, "vram"
-    return vram_value, parsed_threshold, "busy"
+        parse_vram_to_elements(normalized)
+    except (TypeError, ValueError) as exc:
+        if any(ch.isalpha() for ch in normalized):
+            raise typer.BadParameter(str(exc)) from exc
+        if _looks_like_numeric_cli_token(normalized):
+            raise typer.BadParameter(
+                "threshold must be an integer utilization value or a VRAM size"
+            ) from exc
+    return legacy_threshold, busy_threshold, "vram"
 
 
 def _parse_gpu_ids(gpu_ids: Optional[str]) -> Optional[List[int]]:
@@ -326,7 +356,10 @@ def _parse_gpu_ids(gpu_ids: Optional[str]) -> Optional[List[int]]:
             "gpu_ids must not be empty; omit --gpu-ids to use all visible GPUs"
         )
     try:
-        parsed = [int(i.strip()) for i in gpu_ids.split(",")]
+        tokens = [i.strip() for i in gpu_ids.split(",")]
+        if any(_is_invalid_gpu_id_token(token) for token in tokens):
+            raise ValueError
+        parsed = [int(token) for token in tokens]
     except ValueError as exc:
         raise typer.BadParameter(
             f"Invalid characters in --gpu-ids '{gpu_ids}'. "
@@ -343,7 +376,7 @@ def _validate_cli_interval(interval: Any) -> Union[int, float]:
         raise typer.BadParameter("interval must be finite and positive")
     if isinstance(interval, str):
         normalized = interval.strip()
-        if not normalized:
+        if not normalized or not _CLI_NUMBER_TOKEN_RE.fullmatch(normalized):
             raise typer.BadParameter("interval must be finite and positive")
         try:
             try:
@@ -371,7 +404,7 @@ def _validate_cli_vram(vram: str) -> str:
 def _validate_cli_busy_threshold(busy_threshold: Any) -> int:
     if isinstance(busy_threshold, str):
         normalized = busy_threshold.strip()
-        if not normalized:
+        if not normalized or not _CLI_INTEGER_TOKEN_RE.fullmatch(normalized):
             raise typer.BadParameter(
                 "busy_threshold must be -1 or an integer between 0 and 100"
             )
@@ -1137,6 +1170,11 @@ def main(
         interval = _validate_cli_interval(interval)
         busy_threshold = _validate_cli_busy_threshold(busy_threshold)
         _parse_gpu_ids(gpu_ids)
+        legacy_vram, legacy_busy_threshold, _ = _apply_legacy_threshold(
+            vram, legacy_threshold, busy_threshold
+        )
+        _validate_cli_vram(legacy_vram)
+        _validate_cli_busy_threshold(legacy_busy_threshold)
         _run_blocking(interval, gpu_ids, vram, legacy_threshold, busy_threshold)
     except typer.BadParameter as exc:
         console.print(f"[bold red]Error: {exc}[/bold red]")

--- a/src/keep_gpu/cli.py
+++ b/src/keep_gpu/cli.py
@@ -55,9 +55,9 @@ ROOT_BLOCKING_OPTION_LABELS = {
     "busy_threshold": "--busy-threshold/--util-threshold",
     "interval": "--interval",
 }
-_CLI_INTEGER_TOKEN_RE = re.compile(r"[+-]?[0-9]+")
+_CLI_INTEGER_TOKEN_RE = re.compile(r"-?[0-9]+")
 _CLI_NUMBER_TOKEN_RE = re.compile(
-    r"[+-]?(?:(?:[0-9]+(?:\.[0-9]*)?)|(?:\.[0-9]+))(?:[eE][+-]?[0-9]+)?"
+    r"-?(?:(?:[0-9]+(?:\.[0-9]*)?)|(?:\.[0-9]+))(?:[eE][+-]?[0-9]+)?"
 )
 
 app = typer.Typer(
@@ -68,10 +68,18 @@ console = Console()
 logger = setup_logger(__name__)
 
 
+def _is_signed_zero_integer_token(token: str) -> bool:
+    return (
+        token.startswith("-")
+        and _CLI_INTEGER_TOKEN_RE.fullmatch(token) is not None
+        and int(token) == 0
+    )
+
+
 def _is_invalid_gpu_id_token(token: str) -> bool:
-    if token.startswith("+") or not _CLI_INTEGER_TOKEN_RE.fullmatch(token):
+    if not _CLI_INTEGER_TOKEN_RE.fullmatch(token):
         return True
-    return token.startswith("-") and int(token) == 0
+    return _is_signed_zero_integer_token(token)
 
 
 def _looks_like_numeric_cli_token(token: str) -> bool:
@@ -332,9 +340,9 @@ def _apply_legacy_threshold(
         return vram_value, busy_threshold, None
 
     normalized = legacy_threshold.strip()
-    if _CLI_INTEGER_TOKEN_RE.fullmatch(normalized) and not (
-        normalized.startswith("-") and int(normalized) == 0
-    ):
+    if _CLI_INTEGER_TOKEN_RE.fullmatch(
+        normalized
+    ) and not _is_signed_zero_integer_token(normalized):
         return vram_value, int(normalized), "busy"
     try:
         parse_vram_to_elements(normalized)
@@ -404,7 +412,11 @@ def _validate_cli_vram(vram: str) -> str:
 def _validate_cli_busy_threshold(busy_threshold: Any) -> int:
     if isinstance(busy_threshold, str):
         normalized = busy_threshold.strip()
-        if not normalized or not _CLI_INTEGER_TOKEN_RE.fullmatch(normalized):
+        if (
+            not normalized
+            or not _CLI_INTEGER_TOKEN_RE.fullmatch(normalized)
+            or _is_signed_zero_integer_token(normalized)
+        ):
             raise typer.BadParameter(
                 "busy_threshold must be -1 or an integer between 0 and 100"
             )

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -395,7 +395,7 @@ def test_start_command_rejects_non_integer_busy_threshold_before_auto_start(
         (["--vram", "not-a-size"], "invalid format"),
         (["--vram", ("9" * 500) + "GiB"], "vram must be no more than"),
         (["--interval", str(10**1000)], "interval must be no more than"),
-        (["--interval", f"+{10**1000}"], "interval must be no more than"),
+        (["--interval", f"+{10**1000}"], "interval must be finite and positive"),
         (["--interval", "NaN"], "interval must be finite and positive"),
         (["--interval", "Infinity"], "interval must be finite and positive"),
         (["--interval", "1_000"], "interval must be finite and positive"),
@@ -2251,13 +2251,23 @@ def test_blocking_mode_rejects_non_integer_busy_threshold_without_usage(monkeypa
     [
         (["--gpu-ids", "1_000"], "Invalid characters in --gpu-ids '1_000'"),
         (["--gpu-ids", "１２３"], "Invalid characters in --gpu-ids '１２３'"),
+        (["--gpu-ids", "+0"], "Invalid characters in --gpu-ids '+0'"),
         (["--interval", "1_000"], "interval must be finite and positive"),
+        (["--interval", "+1"], "interval must be finite and positive"),
         (
             ["--busy-threshold", "1_0"],
             "busy_threshold must be -1 or an integer between 0 and 100",
         ),
         (
+            ["--busy-threshold", "+25"],
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
             ["--threshold", "1_0"],
+            "threshold must be an integer utilization value or a VRAM size",
+        ),
+        (
+            ["--threshold", "+25"],
             "threshold must be an integer utilization value or a VRAM size",
         ),
         (

--- a/tests/test_cli_service_commands.py
+++ b/tests/test_cli_service_commands.py
@@ -398,6 +398,27 @@ def test_start_command_rejects_non_integer_busy_threshold_before_auto_start(
         (["--interval", f"+{10**1000}"], "interval must be no more than"),
         (["--interval", "NaN"], "interval must be finite and positive"),
         (["--interval", "Infinity"], "interval must be finite and positive"),
+        (["--interval", "1_000"], "interval must be finite and positive"),
+        (
+            ["--busy-threshold", "１２"],
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
+            ["--busy-threshold", "1_0"],
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
+            ["--gpu-ids", "１２３"],
+            "Invalid characters in --gpu-ids '１２３'",
+        ),
+        (
+            ["--gpu-ids", "1_000"],
+            "Invalid characters in --gpu-ids '1_000'",
+        ),
+        (
+            ["--gpu-ids", "-0"],
+            "Invalid characters in --gpu-ids '-0'",
+        ),
     ],
 )
 def test_start_command_rejects_local_inputs_before_auto_start(
@@ -2223,6 +2244,41 @@ def test_blocking_mode_rejects_non_integer_busy_threshold_without_usage(monkeypa
     assert result.exit_code == 1
     assert "busy_threshold must be -1 or an integer between 0 and 100" in result.output
     assert "Usage:" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--gpu-ids", "1_000"], "Invalid characters in --gpu-ids '1_000'"),
+        (["--gpu-ids", "１２３"], "Invalid characters in --gpu-ids '１２３'"),
+        (["--interval", "1_000"], "interval must be finite and positive"),
+        (
+            ["--busy-threshold", "1_0"],
+            "busy_threshold must be -1 or an integer between 0 and 100",
+        ),
+        (
+            ["--threshold", "1_0"],
+            "threshold must be an integer utilization value or a VRAM size",
+        ),
+        (
+            ["--threshold", "１２"],
+            "threshold must be an integer utilization value or a VRAM size",
+        ),
+    ],
+)
+def test_blocking_mode_rejects_non_canonical_numeric_tokens(monkeypatch, args, message):
+    monkeypatch.setattr(
+        cli,
+        "_run_blocking",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("blocking runner should not be called")
+        ),
+    )
+
+    result = runner.invoke(cli.app, args)
+
+    assert result.exit_code == 1
+    assert message in result.output
 
 
 def test_invalid_root_interval_before_subcommand_is_rejected(monkeypatch):

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -30,6 +30,31 @@ def test_parse_gpu_ids_rejects_duplicate_values():
         cli._parse_gpu_ids("0,1,0")
 
 
+@pytest.mark.parametrize("gpu_ids", ["1_000", "１２３", "+0", "-0", "-00"])
+def test_parse_gpu_ids_rejects_non_canonical_numeric_tokens(gpu_ids):
+    with pytest.raises(typer.BadParameter, match="Invalid characters in --gpu-ids"):
+        cli._parse_gpu_ids(gpu_ids)
+
+
+@pytest.mark.parametrize("interval", ["1_000", "１２３"])
+def test_validate_cli_interval_rejects_non_canonical_numeric_tokens(interval):
+    with pytest.raises(
+        typer.BadParameter, match="interval must be finite and positive"
+    ):
+        cli._validate_cli_interval(interval)
+
+
+@pytest.mark.parametrize("busy_threshold", ["1_0", "１２"])
+def test_validate_cli_busy_threshold_rejects_non_canonical_numeric_tokens(
+    busy_threshold,
+):
+    with pytest.raises(
+        typer.BadParameter,
+        match="busy_threshold must be -1 or an integer between 0 and 100",
+    ):
+        cli._validate_cli_busy_threshold(busy_threshold)
+
+
 def test_apply_legacy_threshold_none():
     vram, threshold, mode = cli._apply_legacy_threshold("1GiB", None, -1)
     assert vram == "1GiB"
@@ -42,6 +67,17 @@ def test_apply_legacy_threshold_numeric():
     assert vram == "1GiB"
     assert threshold == 25
     assert mode == "busy"
+
+
+@pytest.mark.parametrize("legacy_threshold", ["1_0", "１２", "-0"])
+def test_apply_legacy_threshold_rejects_non_canonical_numeric_tokens(
+    legacy_threshold,
+):
+    with pytest.raises(
+        typer.BadParameter,
+        match="threshold must be an integer utilization value or a VRAM size",
+    ):
+        cli._apply_legacy_threshold("1GiB", legacy_threshold, -1)
 
 
 def test_apply_legacy_threshold_memory_string():

--- a/tests/test_cli_thresholds.py
+++ b/tests/test_cli_thresholds.py
@@ -36,7 +36,7 @@ def test_parse_gpu_ids_rejects_non_canonical_numeric_tokens(gpu_ids):
         cli._parse_gpu_ids(gpu_ids)
 
 
-@pytest.mark.parametrize("interval", ["1_000", "１２３"])
+@pytest.mark.parametrize("interval", ["1_000", "１２３", "+1"])
 def test_validate_cli_interval_rejects_non_canonical_numeric_tokens(interval):
     with pytest.raises(
         typer.BadParameter, match="interval must be finite and positive"
@@ -44,7 +44,11 @@ def test_validate_cli_interval_rejects_non_canonical_numeric_tokens(interval):
         cli._validate_cli_interval(interval)
 
 
-@pytest.mark.parametrize("busy_threshold", ["1_0", "１２"])
+def test_validate_cli_interval_preserves_exponent_plus_sign():
+    assert cli._validate_cli_interval("1e+3") == 1000
+
+
+@pytest.mark.parametrize("busy_threshold", ["1_0", "１２", "+25", "-0"])
 def test_validate_cli_busy_threshold_rejects_non_canonical_numeric_tokens(
     busy_threshold,
 ):
@@ -69,7 +73,7 @@ def test_apply_legacy_threshold_numeric():
     assert mode == "busy"
 
 
-@pytest.mark.parametrize("legacy_threshold", ["1_0", "１２", "-0"])
+@pytest.mark.parametrize("legacy_threshold", ["1_0", "１２", "+25", "-0"])
 def test_apply_legacy_threshold_rejects_non_canonical_numeric_tokens(
     legacy_threshold,
 ):


### PR DESCRIPTION
## Summary
- reject non-canonical CLI numeric spellings before daemon auto-start, RPC, or blocking runner side effects
- tighten `--gpu-ids`, `--interval`, `--busy-threshold`, and legacy `--threshold` parsing while preserving valid legacy behavior
- document the plain-ASCII CLI numeric-token contract in AGENTS and CLI docs

## Verification
- Red tests failed before fixes for permissive `int()`/`float()` parsing, signed-zero GPU IDs, and legacy `--threshold` numeric-token bypasses
- `PYTHONPATH=src pytest tests/test_cli_thresholds.py tests/test_cli_service_commands.py tests/utilities/test_endpoint_validation.py -q` -> `357 passed`
- `pre-commit run --all-files --show-diff-on-failure` -> passed
- `mkdocs build --strict` -> exit 0, known Material/MkDocs 2.0 warning only
- `PYTHONPATH=src pytest tests -q` -> `1104 passed, 11 skipped`

## Local review
- Local reviewer found signed-zero GPU ID normalization; fixed and re-reviewed.
- Local reviewer found hidden `--threshold` bypass; fixed and re-reviewed.
- Final local subagent review: no Critical, Important, or Minor issues; ready to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CLI numeric input handling so only plain ASCII digit formats are accepted.
  * Rejected underscore-separated, full-width, and other non-canonical number spellings in startup and blocking commands.
  * Improved error messages for invalid numeric options, including GPU IDs, intervals, busy thresholds, and legacy threshold input.

* **Documentation**
  * Clarified CLI guidance to specify ASCII-only numeric formatting for supported options and thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->