### PR TITLE
[docs] docs: use canonical PyPI badge URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ This file defines how coding agents should work in this repository.
   caveats, sentinel-value explanations, and long citation metadata in `docs/`,
   not in README. Keep `docs/citation.md` aligned with the current Zenodo
   concept DOI metadata. Avoid badge clutter; keep badges to PyPI, docs status,
-  and the Zenodo DOI badge.
+  and the Zenodo DOI badge. The PyPI badge should target the canonical
+  `https://pypi.org/project/keep-gpu/` project URL.
 - First-run CLI examples in `README.md` and `docs/getting-started.md` should
   prefer explicit `--gpu-ids 0` unless the text is intentionally demonstrating
   the all-visible-GPUs default.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KeepGPU
 
-[![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)
+[![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.org/project/keep-gpu/)
 [![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)
 [![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,7 +111,8 @@ expectations so you can get productive quickly and avoid surprises in CI.
   platform caveats, sentinel-value explanations, and contracts in the focused
   docs pages. Use `docs/index.md` for detailed navigation, keep full citation
   metadata in `docs/citation.md`, and avoid badge clutter beyond PyPI, docs
-  status, and Zenodo DOI.
+  status, and Zenodo DOI. Link the PyPI badge to the canonical
+  `https://pypi.org/project/keep-gpu/` project page.
 
 ## MCP server
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -123,7 +123,7 @@ def test_readme_stays_a_compact_front_door():
     assert readme.startswith("# KeepGPU\n")
     assert len(lines) <= 21
     assert badge_lines == [
-        "[![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.python.org/pypi/keep-gpu)",
+        "[![PyPI Version](https://img.shields.io/pypi/v/keep-gpu.svg)](https://pypi.org/project/keep-gpu/)",
         "[![Docs Status](https://readthedocs.org/projects/keepgpu/badge/?version=latest)](https://keepgpu.readthedocs.io/en/latest/?version=latest)",
         "[![DOI](https://zenodo.org/badge/987167271.svg)](https://doi.org/10.5281/zenodo.17129114)",
     ]


### PR DESCRIPTION
## Summary
- point the README PyPI badge at the canonical `pypi.org/project/keep-gpu/` URL
- keep the compact README metadata test aligned
- document the badge URL guardrail in AGENTS/contributing docs

## Verification
- RED: `PYTHONPATH=src pytest tests/test_package_metadata.py::test_readme_stays_a_compact_front_door -q` failed before updating README
- `PYTHONPATH=src pytest tests/test_package_metadata.py -q`
- `mkdocs build --strict`
- `pre-commit run --all-files --show-diff-on-failure`

## Local review
- Local subagent review found no must-fix issues.